### PR TITLE
Add Namespace to Kafka Templates in Helm Chart

### DIFF
--- a/charts/tradestream/templates/kafka-service.yaml
+++ b/charts/tradestream/templates/kafka-service.yaml
@@ -21,6 +21,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kafka
+  namespace: {{ .Release.Namespace }}
   labels:
     app: kafka
 spec:

--- a/charts/tradestream/templates/kafka-service.yaml
+++ b/charts/tradestream/templates/kafka-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kafka-headless
+  namespace: {{ .Release.Namespace }}
   labels:
     app: kafka
 spec:

--- a/charts/tradestream/templates/kafka-statefulset.yaml
+++ b/charts/tradestream/templates/kafka-statefulset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: kafka
+  namespace: {{ .Release.Namespace }}
   labels:
     app: kafka
 spec:


### PR DESCRIPTION
This pull request updates the Helm chart templates for the **TradeStream** project by explicitly adding the `namespace` field to ensure proper deployment and compatibility with Argo CD. 

### Changes Made:
- **`kafka-service.yaml`**: Added `namespace: {{ .Release.Namespace }}` to both `kafka-headless` and `kafka` service metadata.
- **`kafka-statefulset.yaml`**: Added `namespace: {{ .Release.Namespace }}` to the StatefulSet metadata.

### Purpose:
- Ensures that all resources are deployed in the specified namespace when managed by Argo CD or other Kubernetes deployment tools.
- Prevents `InvalidSpecError` issues related to missing namespaces, improving compatibility with GitOps workflows and automated deployment systems.

### Impact:
- This change enforces the deployment of Kafka services and StatefulSets into the namespace provided at deployment time (`.Release.Namespace`), allowing for consistent and isolated resource management.

### Next Steps:
- Verify the deployment in Argo CD to ensure all resources are synced and deployed without errors.
- Monitor the application for correct namespace usage and resource health.