### PR TITLE
chore:  Show all Bazel test output in CI

### DIFF
--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -16,4 +16,4 @@ jobs:
       with:
         path: "~/.cache/bazel"
         key: bazel
-    - run: bazel test //... --verbose_failures
+    - run: bazel test //... --test_output=all


### PR DESCRIPTION
This commit changes the Bazel test command in the CI workflow to show all test output, including standard output and standard error streams, for all tests. This change improves debugging by making it easier to see the output of failing tests, even if they don't explicitly print to stderr.