### PR TITLE
chore: Update protobuf syntax to proto3

### DIFF
--- a/protos/marketdata.proto
+++ b/protos/marketdata.proto
@@ -1,4 +1,4 @@
-syntax = "proto3";
+edition = "2023";
 
 package marketdata;
 


### PR DESCRIPTION
This commit updates the protobuf syntax from `syntax = "proto3";` to `edition = "2023";`.  This leverages the latest Protobuf features and best practices, including performance improvements.  While functionally equivalent to `proto3` in most cases, the newer syntax allows for future enhancements and compatibility with newer Protobuf tools.