### PR TITLE
Add Google Truth Library Dependency for Enhanced Assertions in Tests

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,6 +22,7 @@ maven.install(
         "org.slf4j:slf4j-api:2.0.12",
         "junit:junit:4.13.2",  # For unit testing
         "org.mockito:mockito-core:4.8.1",  # For mocking in tests
+        "com.google.truth:truth:1.4.4",
     ],
     fetch_sources = True,
     repositories = [


### PR DESCRIPTION
This PR updates the `MODULE.bazel` file to include the `com.google.truth:truth:1.4.4` dependency. The Truth library enhances the readability and reliability of assertions in Java unit tests, allowing for expressive, fluent assertions. This addition supports the testing framework for the `CandleKey` class introduced in previous changes.

- **Updated Dependencies:** Adds `"com.google.truth:truth:1.4.4"` to `maven.install` for improved assertion support in unit tests.
- **Purpose:** Truth provides fluent assertion methods that increase test clarity and ease of maintenance, which is valuable for testing components like `CandleKey`.

This improvement is part of ongoing efforts to build a robust testing framework for the TradeStream project.