### PR TITLE
Add Guice Dependency for Dependency Injection

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,6 +17,7 @@ maven.install(
         # Make sure we use RxJava 3.x as that's what xchange-stream uses
         "io.reactivex.rxjava3:rxjava:3.1.6",
         "com.google.guava:guava:31.1-jre",
+        "com.google.inject:guice:7.0.0",
         "com.google.protobuf:protobuf-java:3.21.12",
         "org.apache.kafka:kafka-clients:3.6.1",
         "org.slf4j:slf4j-api:2.0.12",


### PR DESCRIPTION
This pull request adds the `com.google.inject:guice:7.0.0` dependency to the Bazel module to enable dependency injection support across the project. Guice provides a lightweight and flexible approach to managing dependencies, which will enhance the modularity and testability of components within the application. This addition is compatible with existing dependencies and aligns with the current module configuration. 

### Changes:
- Added `com.google.inject:guice:7.0.0` to `maven.install` in `MODULE.bazel`. 

### Motivation:
The inclusion of Guice allows for improved code structure and cleaner dependency management, which is particularly beneficial for large-scale applications or services that require flexible injection and configuration of components.