### PR TITLE
Refactor `real-time-data-ingestion` Target to Separate Library and Binary Components

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -7,10 +7,16 @@ java_library(
     srcs = ["CandleKey.java"]
 )
 
-java_binary(
-    name = "real-time-data-ingestion",
+java_library(
+    name = "real-time-data-ingestion-lib",
     srcs = ["RealTimeDataIngestion.java"],
     deps = [
         "@maven//:com_google_inject_guice",
     ]
+)
+
+java_binary(
+    name = "real-time-data-ingestion",
+    main_class = "com.verlumen.tradestream.RealTimeDataIngestion",
+    runtime_deps = [":real-time-data-ingestion-lib"],
 )


### PR DESCRIPTION
This PR refactors the `real-time-data-ingestion` target in the `BUILD` file by creating a separate `java_library` target, `real-time-data-ingestion-lib`, for the source files. The original `java_binary` target is updated to depend on this library target and now only defines the main class and runtime dependencies.

### Changes:
- Created `real-time-data-ingestion-lib` as a `java_library` target, containing `RealTimeDataIngestion.java`.
- Updated `real-time-data-ingestion` to a `java_binary` target with `main_class` specified as `com.verlumen.tradestream.RealTimeDataIngestion`.
- Added `real-time-data-ingestion-lib` as a `runtime_dep` for the `real-time-data-ingestion` binary target.

This refactor improves modularity by separating the library logic from the binary entry point, facilitating better reuse and testing of `RealTimeDataIngestion`.