### PR TITLE
Remove Redundant `test_class` Comment in `CandleKeyTest` BUILD Configuration

### DIFF
--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -5,7 +5,6 @@ java_test(
     srcs = [
       "CandleKeyTest.java"
     ],
-    # test_class = "com.verlumen.tradestream.ingestion.CandleKeyTest",
     deps = [
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_testparameterinjector_test_parameter_injector",


### PR DESCRIPTION
This PR cleans up the `BUILD` file for `CandleKeyTest` by removing an outdated or redundant comment specifying `test_class`.

### Changes:
- Deleted the commented line `# test_class = "com.verlumen.tradestream.ingestion.CandleKeyTest",` from the `java_test` target in the `BUILD` file.
  
Removing this line improves readability and avoids potential confusion, as the `test_class` attribute is unnecessary in this context.