### PR TITLE
Remove Unused `java_test` Load Statement in TradeStream Ingestion Build File

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -1,6 +1,6 @@
 load("@aspect_bazel_lib//lib:tar.bzl", "tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
-load("@rules_java//java:defs.bzl", "java_binary", "java_library", "java_test")
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
 load("@rules_oci//oci:defs.bzl", "oci_image")
 
 package(default_visibility = ["//visibility:public"])


### PR DESCRIPTION
This minor update removes the unused `java_test` load statement from the `BUILD` file for the `TradeStream` ingestion module. Key changes include:

- **Removed `java_test` Load:** The `java_test` rule was removed from `@rules_java//java:defs.bzl` as it is not utilized in this specific `BUILD` file.
- **Improved Clarity:** Streamlines the `BUILD` configuration by removing unnecessary dependencies.

This cleanup simplifies the Bazel configuration, improving readability and maintainability.