### PR TITLE
Update OCI Image Entrypoint Path in TradeStream Ingestion Module

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -47,7 +47,7 @@ oci_image(
     entrypoint = [
         "java",
         "-jar",
-        "/java-maven_deploy.jar",
+        "/src/main/java/com/verlumen/tradestream/ingestion/java-maven_deploy.jar",
     ],
     tars = [":layer"],
 )


### PR DESCRIPTION
This update corrects the path for the entrypoint in the `oci_image` configuration within the `TradeStream` ingestion module's `BUILD` file. Key changes include:

- **Entrypoint Path Update:** Modified the entrypoint path from `/java-maven_deploy.jar` to `/src/main/java/com/verlumen/tradestream/ingestion/java-maven_deploy.jar` to reflect the accurate file location within the container.
- **Improved Build Accuracy:** Ensures the OCI image runs the correct JAR file, aligning with the updated directory structure.

This fix aligns the image entrypoint with the directory structure, ensuring accurate execution of the `java-maven_deploy.jar` file during runtime.