### PR TITLE
Rename Library and Binary Targets in TradeStream Ingestion Module

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -25,20 +25,22 @@ java_binary(
 )
 
 java_library(
-    name = "java-maven-lib",
+    name = "app-lib",
     srcs = ["App.java"],
-    deps = ["@maven//:com_google_guava_guava"],
+    deps = [
+        "@maven//:com_google_guava_guava",
+    ],
 )
 
 java_binary(
-    name = "java-maven",
+    name = "app",
     main_class = "com.example.myproject.App",
-    runtime_deps = [":java-maven-lib"],
+    runtime_deps = [":app-lib"],
 )
 
 tar(
     name = "layer",
-    srcs = [":java-maven_deploy.jar"],
+    srcs = [":app_deploy.jar"],
 )
 
 oci_image(
@@ -47,7 +49,7 @@ oci_image(
     entrypoint = [
         "java",
         "-jar",
-        "/src/main/java/com/verlumen/tradestream/ingestion/java-maven_deploy.jar",
+        "/src/main/java/com/verlumen/tradestream/ingestion/app_deploy.jar",
     ],
     tars = [":layer"],
 )

--- a/src/main/java/com/verlumen/tradestream/ingestion/container-structure-test.yaml
+++ b/src/main/java/com/verlumen/tradestream/ingestion/container-structure-test.yaml
@@ -3,5 +3,5 @@ schemaVersion: 2.0.0
 commandTests:
   - name: test
     command: java
-    args: ['-jar', '/src/main/java/com/verlumen/tradestream/ingestion/java-maven_deploy.jar']
+    args: ['-jar', '/src/main/java/com/verlumen/tradestream/ingestion/app_deploy.jar']
     expectedOutput: ['Starting real-time data ingestion...']


### PR DESCRIPTION
- **Renamed Targets:** `java-maven-lib` to `app-lib` and `java-maven` to `app`.
- **Entrypoint Update:** Adjusted `oci_image` and `container-structure-test.yaml` to use `/src/main/java/com/verlumen/tradestream/ingestion/app_deploy.jar`.

These changes improve naming consistency and keep the configuration aligned with updated target names.