### PR TITLE
Add Guice Dependency to `app-lib` in TradeStream Ingestion Module

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -27,7 +27,10 @@ java_binary(
 java_library(
     name = "java-maven-lib",
     srcs = ["App.java"],
-    deps = ["@maven//:com_google_guava_guava"],
+    deps = [
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_inject_guice",
+    ],
 )
 
 java_binary(


### PR DESCRIPTION
- **Dependency Addition:** Added `@maven//:com_google_inject_guice` to `app-lib` to support dependency injection.

This update introduces Guice for better dependency management within the `app-lib` library.