### PR TITLE
Remove Unused `real-time-data-ingestion` Binary Target

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -11,17 +11,11 @@ java_library(
 )
 
 java_library(
-    name = "real-time-data-ingestion-lib",
+    name = "real-time-data-ingestion",
     srcs = ["RealTimeDataIngestion.java"],
     deps = [
         "@maven//:com_google_inject_guice",
     ]
-)
-
-java_binary(
-    name = "real-time-data-ingestion",
-    main_class = "com.verlumen.tradestream.RealTimeDataIngestion",
-    runtime_deps = [":real-time-data-ingestion-lib"],
 )
 
 java_library(


### PR DESCRIPTION
- **Removed Binary Target:** Deleted the unused `real-time-data-ingestion` binary target, leaving only the library version.
- **Streamlined Dependencies:** Consolidates `real-time-data-ingestion` as a library for dependency injection.

This cleanup reduces redundancy and focuses on the modular library approach for `real-time-data-ingestion`.