### PR TITLE
Add Guice and Mockito Unit Test for `App.run` Method

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,8 +21,9 @@ maven.install(
         "com.google.protobuf:protobuf-java:3.21.12",
         "org.apache.kafka:kafka-clients:3.6.1",
         "org.slf4j:slf4j-api:2.0.12",
-        "junit:junit:4.13.2",  # For unit testing
-        "org.mockito:mockito-core:4.8.1",  # For mocking in tests
+        "junit:junit:4.13.2",
+        "org.mockito:mockito-core:4.8.1",
+        "com.google.inject.extensions:guice-testlib:7.0.0",
         "com.google.truth:truth:1.4.4",
         "com.google.testparameterinjector:test-parameter-injector:1.9",
     ],

--- a/src/main/java/com/verlumen/tradestream/ingestion/App.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/App.java
@@ -13,6 +13,7 @@ final class App {
 
   void run() {
     System.out.println("Starting real-time data ingestion...");
+    marketDataIngestion.start();
   }
 
   public static void main(String... args) throws Exception {

--- a/src/test/java/com/verlumen/tradestream/ingestion/AppTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/AppTest.java
@@ -14,9 +14,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AppTest {
-  
-  @Rule public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
-  
+
   @Bind @Mock
   private MarketDataIngestion mockMarketDataIngestion;
 

--- a/src/test/java/com/verlumen/tradestream/ingestion/AppTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/AppTest.java
@@ -28,11 +28,11 @@ public class AppTest {
   
   @Test
   public void run_callsMarketDataIngestionStart() {
-      // Act
-      app.run();
+    // Act
+    app.run();
   
-      // Assert
-      verify(mockMarketDataIngestion).start();
+    // Assert
+    verify(mockMarketDataIngestion).start();
   }
 
 }

--- a/src/test/java/com/verlumen/tradestream/ingestion/AppTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/AppTest.java
@@ -1,0 +1,40 @@
+package com.verlumen.tradestream.ingestion;
+
+import static org.mockito.Mockito.verify;
+
+import com.google.inject.testing.fieldbinder.Bind;
+import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AppTest {
+  
+  @Rule public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
+  
+  @Bind @Mock
+  private MarketDataIngestion mockMarketDataIngestion;
+
+  @Inject
+  private App app;
+  
+  @Before
+  public void setUp() {
+      Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+  }
+  
+  @Test
+  public void run_callsMarketDataIngestionStart() {
+      // Act
+      app.run();
+  
+      // Assert
+      verify(mockMarketDataIngestion).start();
+  }
+
+}

--- a/src/test/java/com/verlumen/tradestream/ingestion/AppTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/AppTest.java
@@ -23,7 +23,7 @@ public class AppTest {
   
   @Before
   public void setUp() {
-      Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+    Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
   }
   
   @Test

--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -10,6 +10,7 @@ java_test(
         "@maven//:com_google_inject_guice",
         "@maven//:com_google_truth_truth",
         "@maven//:junit_junit",
+        "@maven//:org.mockito:mockito-core",
         "//src/main/java/com/verlumen/tradestream/ingestion:app-lib",
     ],
 )

--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -6,7 +6,7 @@ java_test(
       "AppTest.java"
     ],
     deps = [
-        "@maven//:com_google_inject_extensions_guice-testlib",
+        "@maven//:com_google_inject_extensions_guice_testlib",
         "@maven//:com_google_inject_guice",
         "@maven//:com_google_truth_truth",
         "@maven//:junit_junit",

--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -1,6 +1,20 @@
 load("@rules_java//java:defs.bzl", "java_test")
 
 java_test(
+    name = "AppTest",
+    srcs = [
+      "AppTest.java"
+    ],
+    deps = [
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_testparameterinjector_test_parameter_injector",
+        "@maven//:com_google_truth_truth",
+        "@maven//:junit_junit",
+        "//src/main/java/com/verlumen/tradestream/ingestion:app-lib",
+    ],
+)
+
+java_test(
     name = "CandleKeyTest",
     srcs = [
       "CandleKeyTest.java"

--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -6,6 +6,7 @@ java_test(
       "AppTest.java"
     ],
     deps = [
+        "@maven//:com_google_inject_extensions_guice-testlib",
         "@maven//:com_google_inject_guice",
         "@maven//:com_google_truth_truth",
         "@maven//:junit_junit",

--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -7,7 +7,6 @@ java_test(
     ],
     deps = [
         "@maven//:com_google_guava_guava",
-        "@maven//:com_google_testparameterinjector_test_parameter_injector",
         "@maven//:com_google_truth_truth",
         "@maven//:junit_junit",
         "//src/main/java/com/verlumen/tradestream/ingestion:app-lib",

--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -10,7 +10,7 @@ java_test(
         "@maven//:com_google_inject_guice",
         "@maven//:com_google_truth_truth",
         "@maven//:junit_junit",
-        "@maven//:org.mockito:mockito-core",
+        "@maven//:org_mockito_mockito_core",
         "//src/main/java/com/verlumen/tradestream/ingestion:app-lib",
     ],
 )

--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -6,7 +6,7 @@ java_test(
       "AppTest.java"
     ],
     deps = [
-        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_inject_guice",
         "@maven//:com_google_truth_truth",
         "@maven//:junit_junit",
         "//src/main/java/com/verlumen/tradestream/ingestion:app-lib",

--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -12,6 +12,7 @@ java_test(
         "@maven//:junit_junit",
         "@maven//:org_mockito_mockito_core",
         "//src/main/java/com/verlumen/tradestream/ingestion:app-lib",
+        "//src/main/java/com/verlumen/tradestream/ingestion:market-data-ingestion",
     ],
 )
 


### PR DESCRIPTION
Enhanced `App.run` test coverage by introducing `AppTest`, which uses Guice for dependency injection and Mockito for mocking. Added `guice-testlib` dependency to facilitate injection of `MarketDataIngestion` mock, ensuring `App.run` correctly initiates `marketDataIngestion.start()`. Updated `BUILD` file to include necessary dependencies for the new test.