### PR TITLE
Remove Version Commit Step from Release Workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,12 +28,6 @@ jobs:
           git config user.name "GitHub Action"
           git config user.email "action@github.com"
 
-      - name: Commit Changes
-        run: |
-          git add hubitat_lock_manager/version.py
-          git commit -m "chore: update version to ${{ steps.version.outputs.version_tag }}"
-          git push origin main
-
       - name: Push Tag
         env:
           GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}


### PR DESCRIPTION
Simplified `release.yaml` by removing the step that commits version changes to `hubitat_lock_manager/version.py`. Now, the workflow only tags the release, reducing unnecessary commits to the `main` branch.