### PR TITLE
Add Suffix for `develop` Branch to Release Workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - develop
 
 jobs:
   version:
@@ -13,6 +14,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Determine Suffix
+        id: suffix
+        run: |
+          if [[ "${{ github.ref_name }}" == "develop" ]]; then
+            echo "suffix=-develop" >> $GITHUB_ENV
+          else
+            echo "suffix=" >> $GITHUB_ENV
+          fi
+
       - name: Semantic Version
         id: version
         uses: paulhatch/semantic-version@v5.3.0
@@ -20,7 +30,7 @@ jobs:
           tag_prefix: "v"
           major_pattern: "(MAJOR)"
           minor_pattern: "(MINOR)"
-          version_format: "${major}.${minor}.${patch}-prerelease${increment}"
+          version_format: "${major}.${minor}.${patch}${{ env.suffix }}-prerelease${increment}"
           enable_prerelease_mode: true
 
       - name: Set up Git


### PR DESCRIPTION
Modified `release.yaml` to handle version suffixes based on branch. Adds `-develop` suffix for tags generated from `develop` branch, distinguishing prerelease artifacts. This enables separate versioning for `main` and `develop` branches, streamlining prerelease management.