### PR TITLE
Add Data Ingestion Deployment Template and Service Configuration to Helm Chart

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DATA_INGESTION_REPO: tradestreamhq/tradestream-data-ingestion
-      DATA_INGESTION_SECTION_KEY: data-ingestion
+      DATA_INGESTION_SECTION_KEY: dataIngestion
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/charts/tradestream/templates/data-ingestion-deployment.yaml
+++ b/charts/tradestream/templates/data-ingestion-deployment.yaml
@@ -1,13 +1,25 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  {{- define "tradestream.fullname" -}}
+  {{- $name := default .Chart.Name .Values.nameOverride -}}
+  {{- if contains $name .Release.Name -}}
+  {{- .Release.Name -}}
+  {{- else -}}
+  {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+  {{- end -}}
+  {{- end -}}
+  {{- define "tradestream.name" -}}
+  {{- $name := default .Chart.Name .Values.nameOverride -}}
+  {{- $name -}}
+  {{- end -}}
   name: {{ include "tradestream.fullname" . }}-data-ingestion
   labels:
     app: {{ include "tradestream.name" . }}
     component: data-ingestion
     release: {{ .Release.Name }}
 spec:
-  replicas: {{ index .Values "data-ingestion" "replicaCount" }}
+  replicas: {{ .Values.dataIngestion.replicaCount }}
   selector:
     matchLabels:
       app: {{ include "tradestream.name" . }}
@@ -20,7 +32,7 @@ spec:
     spec:
       containers:
         - name: data-ingestion
-          image: "{{ index .Values "data-ingestion" "image" "repository" }}:{{ index .Values "data-ingestion" "image" "tag" }}"
+          image: "{{ .Values.dataIngestion.image.repository }}:{{ .Values.dataIngestion.image.tag }}"
           imagePullPolicy: IfNotPresent
           ports:
-            - containerPort: {{ index .Values "data-ingestion" "service" "port" }}
+            - containerPort: {{ .Values.dataIngestion.service.port }}

--- a/charts/tradestream/templates/data-ingestion-deployment.yaml
+++ b/charts/tradestream/templates/data-ingestion-deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "tradestream.fullname" . }}-data-ingestion
+  labels:
+    app: {{ include "tradestream.name" . }}
+    component: data-ingestion
+    release: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.data-ingestion.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "tradestream.name" . }}
+      component: data-ingestion
+  template:
+    metadata:
+      labels:
+        app: {{ include "tradestream.name" . }}
+        component: data-ingestion
+    spec:
+      containers:
+        - name: data-ingestion
+          image: "{{ .Values.data-ingestion.image.repository }}:{{ .Values.data-ingestion.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: {{ .Values.data-ingestion.service.port }}

--- a/charts/tradestream/templates/data-ingestion-deployment.yaml
+++ b/charts/tradestream/templates/data-ingestion-deployment.yaml
@@ -1,18 +1,20 @@
+{{- define "tradestream.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "tradestream.name" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- $name -}}
+{{- end -}}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  {{- define "tradestream.fullname" -}}
-  {{- $name := default .Chart.Name .Values.nameOverride -}}
-  {{- if contains $name .Release.Name -}}
-  {{- .Release.Name -}}
-  {{- else -}}
-  {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-  {{- end -}}
-  {{- end -}}
-  {{- define "tradestream.name" -}}
-  {{- $name := default .Chart.Name .Values.nameOverride -}}
-  {{- $name -}}
-  {{- end -}}
   name: {{ include "tradestream.fullname" . }}-data-ingestion
   labels:
     app: {{ include "tradestream.name" . }}

--- a/charts/tradestream/templates/data-ingestion-deployment.yaml
+++ b/charts/tradestream/templates/data-ingestion-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     component: data-ingestion
     release: {{ .Release.Name }}
 spec:
-  replicas: {{ .Values.data-ingestion.replicaCount }}
+  replicas: {{ index .Values "data-ingestion" "replicaCount" }}
   selector:
     matchLabels:
       app: {{ include "tradestream.name" . }}
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: data-ingestion
-          image: "{{ .Values.data-ingestion.image.repository }}:{{ .Values.data-ingestion.image.tag }}"
+          image: "{{ index .Values "data-ingestion" "image" "repository" }}:{{ index .Values "data-ingestion" "image" "tag" }}"
           imagePullPolicy: IfNotPresent
           ports:
-            - containerPort: {{ .Values.data-ingestion.service.port }}
+            - containerPort: {{ index .Values "data-ingestion" "service" "port" }}

--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -22,7 +22,7 @@ kafka:
     offset.storage=raft
     transaction.state.log.replication.factor=3
     transaction.state.log.min.isr=2
-data-ingestion:
+dataIngestion:
   replicaCount: 1
   image:
     repository: "tradestreamhq/tradestream-data-ingestion"

--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -23,6 +23,9 @@ kafka:
     transaction.state.log.replication.factor=3
     transaction.state.log.min.isr=2
 data-ingestion:
+  replicaCount: 1
   image:
     repository: "tradestreamhq/tradestream-data-ingestion"
     tag: v0.0.22-develop
+  service:
+    port: 8080


### PR DESCRIPTION
Introduced `data-ingestion-deployment.yaml` template for deploying the data ingestion component, configured to pull the Docker image with dynamically updated repository and tag from `values.yaml`. Added replica count and service port configuration under `data-ingestion` in `values.yaml`, enabling flexible scaling and port management. This setup ensures the data ingestion component is independently configurable within the Helm chart.