### PR TITLE
Add Platform Configurations for Linux and macOS Architectures

### DIFF
--- a/platforms/BUILD
+++ b/platforms/BUILD
@@ -2,16 +2,6 @@ load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
 
 package(default_visibility = ["//:__subpackages__"])
 
-native_binary(
-    name = "docker_cli",
-    src = select({
-        "@bazel_tools//src/conditions:linux_x86_64": "@docker_cli_linux_amd64//:docker",
-        "@bazel_tools//src/conditions:darwin_arm64": "@docker_cli_darwin_arm64//:docker",
-        "@bazel_tools//src/conditions:darwin_x86_64": "@docker_cli_darwin_amd64//:docker",
-    }),
-    out = "docker",
-)
-
 platform(
     name = "linux_arm64",
     constraint_values = [

--- a/platforms/BUILD
+++ b/platforms/BUILD
@@ -1,0 +1,53 @@
+load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+
+package(default_visibility = ["//:__subpackages__"])
+
+native_binary(
+    name = "docker_cli",
+    src = select({
+        "@bazel_tools//src/conditions:linux_x86_64": "@docker_cli_linux_amd64//:docker",
+        "@bazel_tools//src/conditions:darwin_arm64": "@docker_cli_darwin_arm64//:docker",
+        "@bazel_tools//src/conditions:darwin_x86_64": "@docker_cli_darwin_amd64//:docker",
+    }),
+    out = "docker",
+)
+
+platform(
+    name = "linux_arm64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:arm64",
+    ],
+)
+
+platform(
+    name = "linux_amd64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+config_setting(
+    name = "platform_darwin_arm64",
+    constraint_values = [
+        "@platforms//os:macos",
+        "@platforms//cpu:arm64",
+    ],
+)
+
+config_setting(
+    name = "platform_darwin_amd64",
+    constraint_values = [
+        "@platforms//os:macos",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+config_setting(
+    name = "platform_linux_amd64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+)


### PR DESCRIPTION
Introduces platform definitions for Linux and macOS with ARM64 and AMD64 architecture support in the `BUILD` file. Enables Bazel builds to target specific OS and CPU configurations for native binaries.