### PR TITLE
Add Multiarch Transition Rule for OCI Images

### DIFF
--- a/platforms/transition.bzl
+++ b/platforms/transition.bzl
@@ -1,0 +1,27 @@
+"a rule transitioning an oci_image to multiple platforms"
+
+def _multiarch_transition(settings, attr):
+    return [
+        {"//command_line_option:platforms": str(platform)}
+        for platform in attr.platforms
+    ]
+
+multiarch_transition = transition(
+    implementation = _multiarch_transition,
+    inputs = [],
+    outputs = ["//command_line_option:platforms"],
+)
+
+def _impl(ctx):
+    return DefaultInfo(files = depset(ctx.files.image))
+
+multi_arch = rule(
+    implementation = _impl,
+    attrs = {
+        "image": attr.label(cfg = multiarch_transition),
+        "platforms": attr.label_list(),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+)


### PR DESCRIPTION
Adds a multi-platform transition rule for `oci_image` to support builds across multiple architectures. This rule allows setting target platforms dynamically via Bazel transitions. Copied from [rules_oci](https://github.com/bazel-contrib/rules_oci/blob/fdfbe2498feb17571db4ec0d5726d6c3ce13d21f/examples/multi_arch/transition.bzl).