### PR TITLE
Add Bazel Skylib Dependency, Update Docker Dependencies, and Version Bump for TradeStream Chart

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,7 @@
 "Bazel dependencies"
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.8.1")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "container_structure_test", version = "1.16.0")
 bazel_dep(name = "protobuf", version = "28.3")
 bazel_dep(name = "rules_jvm_external", version = "5.3")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,1 +1,4 @@
 workspace(name = "tradestream")
+
+load("//platforms:docker.bzl", "setup_docker_deps")
+setup_docker_deps()

--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -26,6 +26,6 @@ dataIngestion:
   replicaCount: 1
   image:
     repository: "tradestreamhq/tradestream-data-ingestion"
-    tag: v0.0.27-develop
+    tag: v0.0.28-develop
   service:
     port: 8080

--- a/platforms/BUILD
+++ b/platforms/BUILD
@@ -1,4 +1,16 @@
+load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+
 package(default_visibility = ["//examples:__subpackages__"])
+
+native_binary(
+    name = "docker_cli",
+    src = select({
+        "@bazel_tools//src/conditions:linux_x86_64": "@docker_cli_linux_amd64//:docker",
+        "@bazel_tools//src/conditions:darwin_arm64": "@docker_cli_darwin_arm64//:docker",
+        "@bazel_tools//src/conditions:darwin_x86_64": "@docker_cli_darwin_amd64//:docker",
+    }),
+    out = "docker",
+)
 
 platform(
     name = "linux_arm64",
@@ -10,6 +22,30 @@ platform(
 
 platform(
     name = "linux_amd64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+config_setting(
+    name = "platform_darwin_arm64",
+    constraint_values = [
+        "@platforms//os:macos",
+        "@platforms//cpu:arm64",
+    ],
+)
+
+config_setting(
+    name = "platform_darwin_amd64",
+    constraint_values = [
+        "@platforms//os:macos",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+config_setting(
+    name = "platform_linux_amd64",
     constraint_values = [
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",

--- a/platforms/docker.bzl
+++ b/platforms/docker.bzl
@@ -1,0 +1,47 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file", "http_archive")
+
+def setup_docker_deps():
+    http_file(
+        name = "jd_darwin_arm64",
+        urls = ["https://github.com/josephburnett/jd/releases/download/v1.8.1/jd-arm64-darwin"],
+        sha256 = "8b0e51b902650287b7dedc2beee476b96c5d589309d3a7f556334c1baedbec61",
+        executable = True,
+    )
+
+    http_file(
+        name = "jd_darwin_amd64",
+        urls = ["https://github.com/josephburnett/jd/releases/download/v1.8.1/jd-amd64-darwin"],
+        sha256 = "c5fb5503d2804b1bf631bf12616d56b89711fd451ab233b688ca922402ff3444",
+        executable = True,
+    )
+
+    http_file(
+        name = "jd_linux_amd64",
+        urls = ["https://github.com/josephburnett/jd/releases/download/v1.8.1/jd-amd64-linux"],
+        sha256 = "ab918f52130561abd4f88d9c2d3ae95d4d56f1a2dff9762665890349d61c763e",
+        executable = True,
+    )
+
+    http_archive(
+        name = "docker_cli_darwin_arm64",
+        urls = ["https://download.docker.com/mac/static/stable/aarch64/docker-23.0.0.tgz"],
+        integrity = "sha256-naXFF3G/D3a8XieHkd2cm29/SHdheslS3VyI77ep/xA=",
+        strip_prefix = "docker",
+        build_file_content = 'exports_files(["docker"])',
+    )
+
+    http_archive(
+        name = "docker_cli_darwin_amd64",
+        urls = ["https://download.docker.com/mac/static/stable/x86_64/docker-23.0.0.tgz"],
+        integrity = "sha256-55P6RTHVIWEHuEuH8ZHFgu6TeCVPF7WqvPD6MBApOuc=",
+        strip_prefix = "docker",
+        build_file_content = 'exports_files(["docker"])',
+    )
+
+    http_archive(
+        name = "docker_cli_linux_amd64",
+        urls = ["https://download.docker.com/linux/static/stable/x86_64/docker-23.0.0.tgz"],
+        integrity = "sha256-agO72paEW3RRvi9qumnDgWxgqX3jGOg/0bOdG+Ji2K8=",
+        strip_prefix = "docker",
+        build_file_content = 'exports_files(["docker"])',
+    )


### PR DESCRIPTION
This pull request introduces several updates and enhancements to improve compatibility, dependency management, and configurability within the TradeStream project:

- **Bazel Dependencies**: 
  - Added the `bazel_skylib` dependency in `MODULE.bazel` to utilize additional native Bazel rules required for dependency configuration.
  
- **Docker Dependency Management**: 
  - Updated the `WORKSPACE` file to load Docker dependencies using `setup_docker_deps()`.
  - Introduced `docker.bzl` with the `setup_docker_deps` function to download and configure Docker CLI binaries and `jd` tools for multiple platforms, enhancing cross-platform support (macOS arm64, macOS amd64, and Linux amd64).
  - Modified `platforms/BUILD` to define `native_binary` targets and `config_setting` conditions for platform-specific Docker CLI binaries.

- **Helm Chart Version Update**:
  - Updated `charts/tradestream/values.yaml` to bump the data ingestion service image tag from `v0.0.27-develop` to `v0.0.28-develop`, ensuring the latest version is deployed.

These changes collectively improve the setup, compatibility, and deployment configuration for TradeStream, facilitating smoother cross-platform development and consistent Docker CLI usage across environments.