### PR TITLE
Configure Java Toolchain, Enable Multi-Arch Image Index, and Add Platform-Based Toolchains

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,10 @@
 common --enable_bzlmod
+
+# Add Java toolchain platform configuration
+build --java_runtime_version=remotejdk_17
+build --java_language_version=17
+build --tool_java_runtime_version=remotejdk_17
+build --tool_java_language_version=17
+
+# Enable platform-based toolchain resolution
+build --incompatible_enable_cc_toolchain_resolution

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,5 +1,3 @@
-"Bazel dependencies"
-
 bazel_dep(name = "aspect_bazel_lib", version = "2.8.1")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "container_structure_test", version = "1.16.0")
@@ -7,6 +5,23 @@ bazel_dep(name = "protobuf", version = "28.3")
 bazel_dep(name = "rules_jvm_external", version = "5.3")
 bazel_dep(name = "rules_oci", version = "1.4.0")
 bazel_dep(name = "rules_java", version = "7.11.1")
+
+# Add Java toolchain configuration
+JAVA_LANGUAGE_LEVEL = "17"
+
+java = use_extension("@rules_java//java:extensions.bzl", "java")
+java.toolchain(
+    name = "java",
+    java_runtime = "@rules_java//toolchains:remotejdk_17",
+    source_version = JAVA_LANGUAGE_LEVEL,
+    target_version = JAVA_LANGUAGE_LEVEL,
+)
+use_repo(java, "java_tools")
+
+# Register the toolchain
+register_toolchains(
+    "@rules_java//toolchains:all",
+)
 
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -43,3 +43,8 @@ oci.pull(
     image = "gcr.io/distroless/java17",
 )
 use_repo(oci, "distroless_java")
+
+bazel_lib = use_extension("@aspect_bazel_lib//lib:extensions.bzl", "toolchains")
+bazel_lib.jq()
+bazel_lib.tar()
+use_repo(bazel_lib, "bsd_tar_toolchains", "jq_toolchains")

--- a/platforms/BUILD
+++ b/platforms/BUILD
@@ -1,6 +1,6 @@
 load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
 
-package(default_visibility = ["//examples:__subpackages__"])
+package(default_visibility = ["//:__subpackages__"])
 
 native_binary(
     name = "docker_cli",

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -2,7 +2,7 @@ load("@aspect_bazel_lib//lib:tar.bzl", "tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("@rules_java//java:defs.bzl", "java_binary", "java_library")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index", "oci_push")
-load(":transition.bzl", "multi_arch")
+load("//platforms:transition.bzl", "multi_arch")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -46,6 +46,30 @@ oci_image(
     tars = [":layer"],
 )
 
+multi_arch(
+    name = "images",
+    image = ":image",
+    platforms = [
+        "//examples:linux_arm64",
+        "//examples:linux_amd64",
+    ],
+)
+
+oci_image_index(
+    name = "index",
+    images = [
+        ":images",
+    ],
+)
+
+genrule(
+    name = "hash",
+    srcs = [":index"],
+    outs = ["sha256.sum"],
+    cmd = "$(JQ_BIN) -r '.manifests[0].digest' $(location :index)/index.json > $@",
+    toolchains = ["@jq_toolchains//:resolved_toolchain"],
+)
+
 java_library(
     name = "ingestion_module",
     srcs = ["IngestionModule.java"],

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -92,7 +92,7 @@ java_library(
 
 oci_push(
     name = "push_image",
-    image = ":image",
+    image = ":index",
     remote_tags = ["latest"],
     repository = "tradestreamhq/tradestream-data-ingestion",
 )

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -1,7 +1,7 @@
 load("@aspect_bazel_lib//lib:tar.bzl", "tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("@rules_java//java:defs.bzl", "java_binary", "java_library")
-load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index", "oci_push")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -2,6 +2,7 @@ load("@aspect_bazel_lib//lib:tar.bzl", "tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("@rules_java//java:defs.bzl", "java_binary", "java_library")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index", "oci_push")
+load(":transition.bzl", "multi_arch")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -50,8 +50,8 @@ multi_arch(
     name = "images",
     image = ":image",
     platforms = [
-        "//examples:linux_arm64",
-        "//examples:linux_amd64",
+        "//platforms:linux_arm64",
+        "//platforms:linux_amd64",
     ],
 )
 


### PR DESCRIPTION
- **Java Toolchain Configuration**: Set up Java 17 toolchain in `.bazelrc` and `MODULE.bazel` to standardize the Java runtime and language version across builds.
- **Platform-Based Toolchains**: Enabled platform-based toolchain resolution in `.bazelrc` for more efficient builds.
- **Multi-Arch OCI Image Index**: Updated `BUILD` file to add multi-architecture support using `multi_arch` and `oci_image_index` for `linux_arm64` and `linux_amd64`, allowing platform-specific Docker images.
- **Toolchain Extensions**: Integrated `jq` and `tar` toolchains using `aspect_bazel_lib` in `MODULE.bazel` to support multi-arch builds and image indexing.