### PR TITLE
Remove Unnecessary `main` Method from RealTimeDataIngestion

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestion.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestion.java
@@ -11,8 +11,4 @@ final class RealTimeDataIngestion implements MarketDataIngestion {
 
       @Override
       public void shutdown() {}
-      
-      public static void main(String[] args) throws Exception {
-        System.out.println("Starting real-time data ingestion...");
-    }
 }


### PR DESCRIPTION
This pull request deletes the unused `main` method from the `RealTimeDataIngestion.java` class. Removing this method streamlines the class by eliminating redundant code, as the real-time data ingestion is now managed through other mechanisms within the application.

**Changes:**
- Removed the `main` method that printed "Starting real-time data ingestion..."
- Cleaned up the class by deleting unnecessary lines.