### PR TITLE
Update `CandleManagerTest` to Use `MockitoRule` for Mock Initialization

### DIFF
--- a/src/test/java/com/verlumen/tradestream/ingestion/CandleManagerTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/CandleManagerTest.java
@@ -8,14 +8,18 @@ import com.google.common.collect.ImmutableList;
 import marketdata.Marketdata.Trade;
 import marketdata.Marketdata.Candle;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import com.google.testing.junit.testparameterinjector.TestParameterInjector;
 
 @RunWith(TestParameterInjector.class)
 public class CandleManagerTest {
+    @Rule public MockitoRule rule = MockitoJUnit.rule();
+    
     private static final long CANDLE_INTERVAL = 60000L;
     private static final String TEST_PAIR = "BTC/USD";
     
@@ -25,7 +29,6 @@ public class CandleManagerTest {
 
     @Before
     public void setUp() {
-        MockitoAnnotations.openMocks(this);
         manager = new CandleManager(CANDLE_INTERVAL, mockPublisher, mockPriceTracker);
     }
 


### PR DESCRIPTION
This pull request refactors the `CandleManagerTest` by replacing manual mock initialization with `MockitoRule`. Utilizing `MockitoRule` simplifies the setup process, enhances readability, and ensures consistent mock behavior across tests.

**Changes:**
- **Modified:**
  - `CandleManagerTest.java`:
    - Added `@Rule` annotation with `MockitoRule` for automatic mock initialization.
    - Removed manual invocation of `MockitoAnnotations.openMocks(this)` in the `setUp` method.
    - Updated import statements to include `org.junit.Rule`, `org.mockito.junit.MockitoJUnit`, and `org.mockito.junit.MockitoRule`.

**Rationale:**
- **Simplified Setup:** Leveraging `MockitoRule` eliminates the need for explicit mock initialization, reducing boilerplate code.
- **Enhanced Readability:** The test setup becomes cleaner and more maintainable.
- **Consistent Mock Behavior:** Ensures that all mocks are properly initialized before each test, preventing potential issues related to uninitialized mocks.

---