### PR TITLE
Integrate Guice DI into `PriceTracker` and Tests

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -123,7 +123,9 @@ java_library(
 java_library(
     name = "price-tracker",
     srcs = ["PriceTracker.java"],
-    visibility = ["//visibility:public"],
+    deps = [
+        "@maven//:com_google_inject_guice",        
+    ],
 )
 
 oci_push(

--- a/src/main/java/com/verlumen/tradestream/ingestion/PriceTracker.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/PriceTracker.java
@@ -1,16 +1,15 @@
 package com.verlumen.tradestream.ingestion;
 
+import com.google.inject.Inject;
+
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 class PriceTracker {
-    static PriceTracker create() {
-        return new PriceTracker();        
-    }
-
     private final Map<String, Double> lastPrices = new ConcurrentHashMap<>();
 
-    private PriceTracker() {}
+    @Inject
+    PriceTracker() {}
 
     void updateLastPrice(String currencyPair, double price) {
         lastPrices.put(currencyPair, price);

--- a/src/main/java/com/verlumen/tradestream/ingestion/PriceTracker.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/PriceTracker.java
@@ -4,21 +4,27 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 class PriceTracker {
+    static PriceTracker create() {
+        return new PriceTracker();        
+    }
+
     private final Map<String, Double> lastPrices = new ConcurrentHashMap<>();
 
-    public void updateLastPrice(String currencyPair, double price) {
+    private PriceTracker() {}
+
+    void updateLastPrice(String currencyPair, double price) {
         lastPrices.put(currencyPair, price);
     }
 
-    public double getLastPrice(String currencyPair) {
+    double getLastPrice(String currencyPair) {
         return lastPrices.getOrDefault(currencyPair, Double.NaN);
     }
 
-    public boolean hasPrice(String currencyPair) {
+    boolean hasPrice(String currencyPair) {
         return lastPrices.containsKey(currencyPair);
     }
 
-    public void clear() {
+    void clear() {
         lastPrices.clear();
     }
 }

--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -75,6 +75,7 @@ java_test(
     name = "PriceTrackerTest",
     srcs = ["PriceTrackerTest.java"],
     deps = [
+        "@maven//:com_google_inject_guice",
         "@maven//:com_google_truth_truth",
         "@maven//:junit_junit",
         "@maven//:com_google_testparameterinjector_test_parameter_injector",

--- a/src/test/java/com/verlumen/tradestream/ingestion/PriceTrackerTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/PriceTrackerTest.java
@@ -2,6 +2,8 @@ package com.verlumen.tradestream.ingestion;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.inject.Guice;
+import com.google.inject.Inject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -10,11 +12,11 @@ import com.google.testing.junit.testparameterinjector.TestParameterInjector;
 @RunWith(TestParameterInjector.class)
 public class PriceTrackerTest {
     private static final String TEST_PAIR = "BTC/USD";
-    private PriceTracker tracker;
+    @Inject private PriceTracker tracker;
 
     @Before
     public void setUp() {
-        tracker = new PriceTracker();
+        Guice.createInjector().injectMembers(this);
     }
 
     @Test


### PR DESCRIPTION
Refactored the `PriceTracker` class to use Guice for dependency injection by adding the `@Inject` annotation to its constructor. Updated `PriceTrackerTest` to utilize Guice's injector for initializing dependencies. Added Guice as a dependency in the `BUILD` files to support the injection framework.

**Changes:**
- **Modified:**
  - `PriceTracker.java`:
    - Added `@Inject` to the constructor.
    - Changed method visibility from `public` to package-private.
  - `PriceTrackerTest.java`:
    - Updated to use Guice's `Injector` for injecting `PriceTracker`.
- **Updated:**
  - `BUILD`:
    - Added `@maven//:com_google_inject_guice` to `price-tracker` and its test dependencies.
