### PR TITLE
Refactor `CandlePublisherTest` to Use `MockitoRule` for Mock Initialization

### DIFF
--- a/src/test/java/com/verlumen/tradestream/ingestion/CandlePublisherTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/CandlePublisherTest.java
@@ -11,8 +11,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.MockitoJUnit;
-import org.mockito.MockitoRule;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import com.google.testing.junit.testparameterinjector.TestParameterInjector;
 import java.time.Duration; 
 

--- a/src/test/java/com/verlumen/tradestream/ingestion/CandlePublisherTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/CandlePublisherTest.java
@@ -7,15 +7,19 @@ import marketdata.Marketdata.Candle;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.MockitoJUnit;
+import org.mockito.MockitoRule;
 import com.google.testing.junit.testparameterinjector.TestParameterInjector;
 import java.time.Duration; 
 
 @RunWith(TestParameterInjector.class)
 public class CandlePublisherTest {
+    @Rule public MockitoRule mocks = MockitoJUnit.rule();
+
     private static final String TEST_TOPIC = "test-topic";
     
     @Mock
@@ -24,7 +28,6 @@ public class CandlePublisherTest {
 
     @Before
     public void setUp() {
-        MockitoAnnotations.openMocks(this);
         publisher = new CandlePublisher(mockProducer, TEST_TOPIC);
     }
 


### PR DESCRIPTION
This update replaces manual mock initialization in `CandlePublisherTest` with `MockitoRule`. This simplifies the setup process and ensures consistency across test cases.

**Changes:**
- **Added:**
  - `@Rule` field with `MockitoRule` for automatic mock initialization.
- **Removed:**
  - Manual call to `MockitoAnnotations.openMocks(this)` in the `setUp` method.

**Rationale:**
- **Simplified Setup:** Eliminates boilerplate code for mock initialization.
- **Consistency:** Ensures all mocks are initialized uniformly before each test.
- **Readability:** Makes the test setup cleaner and more maintainable.
