### PR TITLE
Make `TradeProcessor` Package-Private and Finalize Methods

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/TradeProcessor.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/TradeProcessor.java
@@ -1,23 +1,24 @@
 package com.verlumen.tradestream.ingestion;
 
 import marketdata.Marketdata.Trade;
+
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-class TradeProcessor {
+final class TradeProcessor {
     private final Set<CandleKey> processedTrades = ConcurrentHashMap.newKeySet();
     private final long candleIntervalMillis;
 
-    public TradeProcessor(long candleIntervalMillis) {
+    TradeProcessor(long candleIntervalMillis) {
         this.candleIntervalMillis = candleIntervalMillis;
     }
 
-    public boolean isProcessed(Trade trade) {
+    boolean isProcessed(Trade trade) {
         CandleKey key = new CandleKey(trade.getTradeId(), getMinuteTimestamp(trade.getTimestamp()));
         return !processedTrades.add(key);
     }
 
-    public long getMinuteTimestamp(long timestamp) {
+    long getMinuteTimestamp(long timestamp) {
         return (timestamp / candleIntervalMillis) * candleIntervalMillis;
     }
 }


### PR DESCRIPTION
This refactor improves the encapsulation of the `TradeProcessor` class by making it package-private and marking its methods as package-private instead of public. The class is also declared `final` to prevent subclassing, ensuring its behavior remains consistent.

**Changes:**
- **Class:**
  - Made `TradeProcessor` package-private.
  - Declared the class `final` to prevent subclassing.
- **Methods:**
  - Updated `isProcessed` and `getMinuteTimestamp` to package-private.
  - Removed unnecessary `public` access modifiers.

**Rationale:**
- **Encapsulation:** Restricting access to the `TradeProcessor` class and its methods ensures better control over its usage within the package.
- **Consistency:** Declaring the class `final` aligns with its intended use as a utility without extensibility.
- **Clarity:** Simplifies the code by limiting the visibility to where it is actually needed.

---