### PR TITLE
Restrict `CandleBuilder` Access and Scope for Better Encapsulation

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/CandleBuilder.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CandleBuilder.java
@@ -3,7 +3,7 @@ package com.verlumen.tradestream.ingestion;
 import marketdata.Marketdata.Candle;
 import marketdata.Marketdata.Trade;
 
-public class CandleBuilder {
+class CandleBuilder {
     private final String currencyPair;
     private final long timestamp;
     private double open = Double.NaN;
@@ -13,12 +13,12 @@ public class CandleBuilder {
     private double volume = 0.0;
     private boolean hasTrades = false;
 
-    public CandleBuilder(String currencyPair, long timestamp) {
+    CandleBuilder(String currencyPair, long timestamp) {
         this.currencyPair = currencyPair;
         this.timestamp = timestamp;
     }
 
-    public void addTrade(Trade trade) {
+    void addTrade(Trade trade) {
         double price = trade.getPrice();
         double tradeVolume = trade.getVolume();
 
@@ -36,11 +36,11 @@ public class CandleBuilder {
         hasTrades = true;
     }
 
-    public boolean hasTrades() {
+    boolean hasTrades() {
         return hasTrades;
     }
 
-    public Candle build() {
+    Candle build() {
         return Candle.newBuilder()
                 .setTimestamp(timestamp)
                 .setCurrencyPair(currencyPair)

--- a/src/main/java/com/verlumen/tradestream/ingestion/CandleBuilder.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CandleBuilder.java
@@ -3,7 +3,7 @@ package com.verlumen.tradestream.ingestion;
 import marketdata.Marketdata.Candle;
 import marketdata.Marketdata.Trade;
 
-class CandleBuilder {
+final class CandleBuilder {
     private final String currencyPair;
     private final long timestamp;
     private double open = Double.NaN;


### PR DESCRIPTION
This refactor limits the visibility of the `CandleBuilder` class and its methods by making it package-private. This improves encapsulation and ensures the class is used only within its intended scope.

**Changes:**
- **Class:**
  - Changed `CandleBuilder` from `public` to package-private.
- **Methods:**
  - Updated `addTrade`, `hasTrades`, and `build` methods to package-private.
  - Removed unnecessary `public` access modifiers.

**Rationale:**
- **Encapsulation:** Reduces unnecessary exposure of `CandleBuilder`, keeping it scoped to the package.
- **Simplicity:** Aligns visibility with usage, improving code maintainability.
- **Consistency:** Ensures access is restricted to where it is actually needed.
