### PR TITLE
Add `CandlePublisher` Interface with Factory

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -49,6 +49,14 @@ java_library(
 )
 
 java_library(
+    name = "candle_publisher",
+    srcs = ["CandlePublisher.java"],
+    deps = [
+        "//protos:marketdata_java_proto",
+    ],
+)
+
+java_library(
     name = "candle_publisher_impl",
     srcs = ["CandlePublisherImpl.java"],
     deps = [

--- a/src/main/java/com/verlumen/tradestream/ingestion/CandlePublisher.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CandlePublisher.java
@@ -6,9 +6,9 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import java.time.Duration;
 
 interface CandlePublisher {
-    void publishCandle(Candle candle) {}
+    void publishCandle(Candle candle);
 
-    void close() {}
+    void close();
 
     interface Factory {
         CandlePublisher create(String topic);

--- a/src/main/java/com/verlumen/tradestream/ingestion/CandlePublisher.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CandlePublisher.java
@@ -1,8 +1,7 @@
 package com.verlumen.tradestream.ingestion;
 
 import marketdata.Marketdata.Candle;
-import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.ProducerRecord;
+
 import java.time.Duration;
 
 interface CandlePublisher {

--- a/src/main/java/com/verlumen/tradestream/ingestion/CandlePublisher.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CandlePublisher.java
@@ -8,5 +8,5 @@ import java.time.Duration;
 interface CandlePublisher {
     void publishCandle(Candle candle) {}
 
-    public void close() {}
+    void close() {}
 }

--- a/src/main/java/com/verlumen/tradestream/ingestion/CandlePublisher.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CandlePublisher.java
@@ -9,4 +9,8 @@ interface CandlePublisher {
     void publishCandle(Candle candle) {}
 
     void close() {}
+
+    interface Factory {
+        CandlePublisher create(String topic);
+    }
 }


### PR DESCRIPTION
Introduced `CandlePublisher` as an interface with a nested `Factory` for creating instances. Updated `BUILD` to include the new interface.