### PR TITLE
Rename `trade-processor` to `trade_processor` for Consistency

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -152,7 +152,7 @@ java_library(
 )
 
 java_library(
-    name = "trade-processor",
+    name = "trade_processor",
     srcs = ["TradeProcessor.java"],
     deps = [
         ":candle-key",

--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -91,6 +91,6 @@ java_test(
         "@maven//:junit_junit",
         "@maven//:com_google_testparameterinjector_test_parameter_injector",
         "//protos:marketdata_java_proto",
-        "//src/main/java/com/verlumen/tradestream/ingestion:trade-processor",
+        "//src/main/java/com/verlumen/tradestream/ingestion:trade_processor",
     ],
 )


### PR DESCRIPTION
Renamed `trade-processor` to `trade_processor` in `BUILD` files to align with naming conventions. Updated dependencies in test configurations accordingly.