### PR TITLE
Simplify `TradeProcessorTest` by Removing TestParameterInjector

### DIFF
--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -89,7 +89,6 @@ java_test(
     deps = [
         "@maven//:com_google_truth_truth",
         "@maven//:junit_junit",
-        "@maven//:com_google_testparameterinjector_test_parameter_injector",
         "//protos:marketdata_java_proto",
         "//src/main/java/com/verlumen/tradestream/ingestion:trade_processor",
     ],

--- a/src/test/java/com/verlumen/tradestream/ingestion/TradeProcessorTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/TradeProcessorTest.java
@@ -5,9 +5,9 @@ import static com.google.common.truth.Truth.assertThat;
 import marketdata.Marketdata.Trade;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import com.google.testing.junit.testparameterinjector.TestParameterInjector;
+import org.junit.runners.JUnit4;
 
-@RunWith(TestParameterInjector.class)
+@RunWith(JUnit4.class)
 public class TradeProcessorTest {
     private static final long CANDLE_INTERVAL = 60000L;
 


### PR DESCRIPTION
Replaced `TestParameterInjector` with `JUnit4` in `TradeProcessorTest`. Removed unnecessary `TestParameterInjector` dependency from the `BUILD` file. Simplified the test configuration.