### PR TITLE
Replace `CandlePublisherImpl` with `CandlePublisher` in Dependencies

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -55,8 +55,9 @@ java_library(
     name = "candle_publisher_impl",
     srcs = ["CandlePublisherImpl.java"],
     deps = [
-        "//protos:marketdata_java_proto",
         "@maven//:org_apache_kafka_kafka_clients",
+        "//protos:marketdata_java_proto",
+        ":candle_publisher",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -37,7 +37,7 @@ java_library(
     srcs = ["CandleManager.java"],
     deps = [
         ":candle-builder",
-        ":candle_publisher_impl",
+        ":candle_publisher",
         ":price-tracker",
         "//protos:marketdata_java_proto",
     ],

--- a/src/main/java/com/verlumen/tradestream/ingestion/CandleManager.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CandleManager.java
@@ -9,10 +9,10 @@ import java.util.concurrent.ConcurrentHashMap;
 class CandleManager {
     private final Map<String, CandleBuilder> candleBuilders = new ConcurrentHashMap<>();
     private final long candleIntervalMillis;
-    private final CandlePublisherImpl publisher;
+    private final CandlePublisher publisher;
     private final PriceTracker priceTracker;
 
-    CandleManager(long candleIntervalMillis, CandlePublisherImpl publisher, PriceTracker priceTracker) {
+    CandleManager(long candleIntervalMillis, CandlePublisher publisher, PriceTracker priceTracker) {
         this.candleIntervalMillis = candleIntervalMillis;
         this.publisher = publisher;
         this.priceTracker = priceTracker;

--- a/src/main/java/com/verlumen/tradestream/ingestion/CandlePublisherImpl.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CandlePublisherImpl.java
@@ -5,7 +5,7 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import java.time.Duration;
 
-class CandlePublisherImpl {
+class CandlePublisherImpl implements CandlePublisher {
     private final KafkaProducer<String, byte[]> kafkaProducer;
     private final String topic;
 


### PR DESCRIPTION
Updated `CandleManager` to depend on the `CandlePublisher` interface instead of `CandlePublisherImpl`. Adjusted `BUILD` files to reflect this change, ensuring proper dependency linkage. Made `CandlePublisherImpl` implement `CandlePublisher` for consistency.