### PR TITLE
Combine `app-lib` and `app` into a single `java_binary`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -6,7 +6,7 @@ load("//platforms:transition.bzl", "multi_arch")
 
 package(default_visibility = ["//visibility:public"])
 
-java_library(
+java_binary(
     name = "app",
     srcs = ["App.java"],
     deps = [
@@ -16,12 +16,6 @@ java_library(
         ":market-data-ingestion",
         ":real-time-data-ingestion",
     ],
-)
-
-java_binary(
-    name = "app",
-    main_class = "com.verlumen.tradestream.ingestion.App",
-    runtime_deps = [":app"],
 )
 
 java_library(

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -7,7 +7,7 @@ load("//platforms:transition.bzl", "multi_arch")
 package(default_visibility = ["//visibility:public"])
 
 java_library(
-    name = "app-lib",
+    name = "app",
     srcs = ["App.java"],
     deps = [
         "@maven//:com_google_guava_guava",
@@ -21,7 +21,7 @@ java_library(
 java_binary(
     name = "app",
     main_class = "com.verlumen.tradestream.ingestion.App",
-    runtime_deps = [":app-lib"],
+    runtime_deps = [":app"],
 )
 
 java_library(

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -7,7 +7,7 @@ load("//platforms:transition.bzl", "multi_arch")
 package(default_visibility = ["//visibility:public"])
 
 java_binary(
-    name = "app",
+    name = "App",
     srcs = ["App.java"],
     deps = [
         "@maven//:com_google_guava_guava",

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -7,8 +7,9 @@ load("//platforms:transition.bzl", "multi_arch")
 package(default_visibility = ["//visibility:public"])
 
 java_binary(
-    name = "App",
+    name = "app",
     srcs = ["App.java"],
+    main_class = "com.verlumen.tradestream.ingestion.App",
     deps = [
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_inject_guice",

--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -11,7 +11,7 @@ java_test(
         "@maven//:com_google_truth_truth",
         "@maven//:junit_junit",
         "@maven//:org_mockito_mockito_core",
-        "//src/main/java/com/verlumen/tradestream/ingestion:app-lib",
+        "//src/main/java/com/verlumen/tradestream/ingestion:app",
         "//src/main/java/com/verlumen/tradestream/ingestion:market-data-ingestion",
     ],
 )

--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -11,7 +11,7 @@ java_test(
         "@maven//:com_google_truth_truth",
         "@maven//:junit_junit",
         "@maven//:org_mockito_mockito_core",
-        "//src/main/java/com/verlumen/tradestream/ingestion:App",
+        "//src/main/java/com/verlumen/tradestream/ingestion:app",
         "//src/main/java/com/verlumen/tradestream/ingestion:market-data-ingestion",
     ],
 )

--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -11,7 +11,7 @@ java_test(
         "@maven//:com_google_truth_truth",
         "@maven//:junit_junit",
         "@maven//:org_mockito_mockito_core",
-        "//src/main/java/com/verlumen/tradestream/ingestion:app",
+        "//src/main/java/com/verlumen/tradestream/ingestion:App",
         "//src/main/java/com/verlumen/tradestream/ingestion:market-data-ingestion",
     ],
 )


### PR DESCRIPTION
Merged the `app-lib` library into the `app` binary to simplify the build structure. Updated the `app` target to directly reference `App.java` as its source and set the `main_class` accordingly. Adjusted the `BUILD` files to remove the now-redundant `app-lib` target and updated dependencies in test targets to point to `app`.