### PR TITLE
Rename `real-time-data-ingestion` to `real_time_data_ingestion`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -14,7 +14,7 @@ java_library(
         "@maven//:com_google_inject_guice",
         ":ingestion_module",
         ":market-data-ingestion",
-        ":real-time-data-ingestion",
+        ":real_time_data_ingestion",
     ],
 )
 
@@ -108,7 +108,7 @@ java_library(
     deps = [
         "@maven//:com_google_inject_guice",
         ":market-data-ingestion",
-        ":real-time-data-ingestion",
+        ":real_time_data_ingestion",
     ],
 )
 
@@ -138,7 +138,7 @@ oci_push(
 )
 
 java_library(
-    name = "real-time-data-ingestion",
+    name = "real_time_data_ingestion",
     srcs = ["RealTimeDataIngestion.java"],
     deps = [
         "@maven//:com_google_inject_guice",


### PR DESCRIPTION
Standardized the naming convention by renaming `real-time-data-ingestion` to `real_time_data_ingestion` across the `BUILD` file. Updated all relevant dependencies to ensure consistency.