### PR TITLE
Rename `candle-builder` to `candle_builder`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -20,7 +20,7 @@ java_binary(
 )
 
 java_library(
-    name = "candle-builder",
+    name = "candle_builder",
     srcs = ["CandleBuilder.java"],
     deps = [
         "//protos:marketdata_java_proto",
@@ -31,7 +31,7 @@ java_library(
     name = "candle-manager",
     srcs = ["CandleManager.java"],
     deps = [
-        ":candle-builder",
+        ":candle_builder",
         ":candle_publisher",
         ":price-tracker",
         "//protos:marketdata_java_proto",

--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -24,7 +24,7 @@ java_test(
         "@maven//:junit_junit",
         "@maven//:com_google_testparameterinjector_test_parameter_injector",
         "//protos:marketdata_java_proto",
-        "//src/main/java/com/verlumen/tradestream/ingestion:candle-builder",
+        "//src/main/java/com/verlumen/tradestream/ingestion:candle_builder",
     ],
 )
 


### PR DESCRIPTION
Updated the target name for `candle-builder` to `candle_builder` in both the `BUILD` files for source and test directories to ensure consistent naming conventions across the project. This change aligns with the project's standard naming style.