### PR TITLE
Refactor and Standardize Naming in Build Files

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -31,10 +31,10 @@ java_library(
     name = "candle-manager",
     srcs = ["CandleManager.java"],
     deps = [
+        "//protos:marketdata_java_proto",
         ":candle-builder",
         ":candle_publisher",
-        ":price-tracker",
-        "//protos:marketdata_java_proto",
+        ":price_tracker",
     ],
 )
 
@@ -119,7 +119,7 @@ java_library(
 )
 
 java_library(
-    name = "price-tracker",
+    name = "price_tracker",
     srcs = ["PriceTracker.java"],
     deps = [
         "@maven//:com_google_inject_guice",        

--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -48,10 +48,10 @@ java_test(
     name = "CandlePublisherImplTest",
     srcs = ["CandlePublisherImplTest.java"],
     deps = [
-        "@maven//:org_mockito_mockito_core",
-        "@maven//:junit_junit",
         "@maven//:com_google_testparameterinjector_test_parameter_injector",
+        "@maven//:junit_junit",
         "@maven//:org_apache_kafka_kafka_clients",
+        "@maven//:org_mockito_mockito_core",
         "//protos:marketdata_java_proto",
         "//src/main/java/com/verlumen/tradestream/ingestion:candle_publisher_impl",
     ],
@@ -65,7 +65,7 @@ java_test(
         "@maven//:com_google_truth_truth",
         "@maven//:junit_junit",
         "@maven//:com_google_testparameterinjector_test_parameter_injector",
-        "//src/main/java/com/verlumen/tradestream/ingestion:price-tracker",
+        "//src/main/java/com/verlumen/tradestream/ingestion:price_tracker",
     ],
 )
 

--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -21,8 +21,8 @@ java_test(
     srcs = ["CandleBuilderTest.java"],
     deps = [
         "@maven//:com_google_truth_truth",
-        "@maven//:junit_junit",
         "@maven//:com_google_testparameterinjector_test_parameter_injector",
+        "@maven//:junit_junit",
         "//protos:marketdata_java_proto",
         "//src/main/java/com/verlumen/tradestream/ingestion:candle-builder",
     ],

--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -40,7 +40,7 @@ java_test(
         "//protos:marketdata_java_proto",
         "//src/main/java/com/verlumen/tradestream/ingestion:candle-manager",
         "//src/main/java/com/verlumen/tradestream/ingestion:candle_publisher_impl",
-        "//src/main/java/com/verlumen/tradestream/ingestion:price-tracker",
+        "//src/main/java/com/verlumen/tradestream/ingestion:price_tracker",
     ],
 )
 


### PR DESCRIPTION
Updated Bazel build files to standardize naming conventions and dependency ordering, ensuring consistency across the project.

**Key Changes:**
1. Renamed `price-tracker` to `price_tracker` in both target names and references.
2. Adjusted dependency orders to maintain uniformity:
   - Moved `junit_junit` below `com_google_testparameterinjector_test_parameter_injector` where applicable.
   - Grouped dependencies logically.
3. Updated references to `price-tracker` in test targets to `price_tracker`.
4. Rearranged dependencies in `CandleBuilderTest` and `CandlePublisherImplTest` for consistency.

These changes improve clarity and align the build configuration with standard naming practices.