### PR TITLE
Rename `candle-manager` to `candle_manager`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -28,7 +28,7 @@ java_library(
 )
 
 java_library(
-    name = "candle-manager",
+    name = "candle_manager",
     srcs = ["CandleManager.java"],
     deps = [
         ":candle_builder",

--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -38,7 +38,7 @@ java_test(
         "@maven//:com_google_testparameterinjector_test_parameter_injector",
         "@maven//:com_google_guava_guava",
         "//protos:marketdata_java_proto",
-        "//src/main/java/com/verlumen/tradestream/ingestion:candle-manager",
+        "//src/main/java/com/verlumen/tradestream/ingestion:candle_manager",
         "//src/main/java/com/verlumen/tradestream/ingestion:candle_publisher_impl",
         "//src/main/java/com/verlumen/tradestream/ingestion:price-tracker",
     ],


### PR DESCRIPTION
Renamed the target `candle-manager` to `candle_manager` in both source and test `BUILD` files to maintain consistency with the project's naming conventions. This update ensures uniformity across all build target names.