### PR TITLE
Standardize Naming for Market Data Ingestion Targets

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -115,7 +115,7 @@ tar(
 )
 
 java_library(
-    name = "market-data-ingestion",
+    name = "market_data_ingestion",
     srcs = ["MarketDataIngestion.java"],
 )
 

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -14,7 +14,7 @@ java_binary(
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_inject_guice",
         ":ingestion_module",
-        ":market-data-ingestion",
+        ":market_data_ingestion",
         ":real_time_data_ingestion",
     ],
 )

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -104,7 +104,7 @@ java_library(
     srcs = ["IngestionModule.java"],
     deps = [
         "@maven//:com_google_inject_guice",
-        ":market-data-ingestion",
+        ":market_data_ingestion",
         ":real_time_data_ingestion",
     ],
 )
@@ -139,7 +139,7 @@ java_library(
     srcs = ["RealTimeDataIngestion.java"],
     deps = [
         "@maven//:com_google_inject_guice",
-        ":market-data-ingestion",
+        ":market_data_ingestion",
     ]
 )
 

--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -12,7 +12,7 @@ java_test(
         "@maven//:junit_junit",
         "@maven//:org_mockito_mockito_core",
         "//src/main/java/com/verlumen/tradestream/ingestion:app",
-        "//src/main/java/com/verlumen/tradestream/ingestion:market-data-ingestion",
+        "//src/main/java/com/verlumen/tradestream/ingestion:market_data_ingestion",
     ],
 )
 


### PR DESCRIPTION
Updated naming conventions for `market-data-ingestion` to `market_data_ingestion` across all Bazel build and test files.

**Key Changes:**
1. **Renamed Target:**
   - `market-data-ingestion` renamed to `market_data_ingestion` in `BUILD` files.
2. **Updated References:**
   - Adjusted all references to `market-data-ingestion` to match the new naming convention (`market_data_ingestion`).
3. **Maintained Dependency Integrity:**
   - Updated dependencies in related targets to ensure proper referencing of `market_data_ingestion`.

These changes improve consistency and adhere to the project's naming standards.