### PR TITLE
Refactor Candle Manager Tests and Dependency References

### DIFF
--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -35,11 +35,10 @@ java_test(
         "@maven//:com_google_truth_truth",
         "@maven//:junit_junit",
         "@maven//:org_mockito_mockito_core",
-        "@maven//:com_google_testparameterinjector_test_parameter_injector",
         "@maven//:com_google_guava_guava",
         "//protos:marketdata_java_proto",
         "//src/main/java/com/verlumen/tradestream/ingestion:candle_manager",
-        "//src/main/java/com/verlumen/tradestream/ingestion:candle_publisher_impl",
+        "//src/main/java/com/verlumen/tradestream/ingestion:candle_publisher",
         "//src/main/java/com/verlumen/tradestream/ingestion:price_tracker",
     ],
 )

--- a/src/test/java/com/verlumen/tradestream/ingestion/CandleManagerTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/CandleManagerTest.java
@@ -11,12 +11,12 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runner.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-import com.google.testing.junit.testparameterinjector.TestParameterInjector;
 
-@RunWith(TestParameterInjector.class)
+@RunWith(JUnit4.class)
 public class CandleManagerTest {
     @Rule public MockitoRule rule = MockitoJUnit.rule();
     

--- a/src/test/java/com/verlumen/tradestream/ingestion/CandleManagerTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/CandleManagerTest.java
@@ -23,7 +23,7 @@ public class CandleManagerTest {
     private static final long CANDLE_INTERVAL = 60000L;
     private static final String TEST_PAIR = "BTC/USD";
     
-    @Mock private CandlePublisherImpl mockPublisher;
+    @Mock private CandlePublisher mockPublisher;
     @Mock private PriceTracker mockPriceTracker;
     private CandleManager manager;
 

--- a/src/test/java/com/verlumen/tradestream/ingestion/CandleManagerTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/CandleManagerTest.java
@@ -11,7 +11,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runner.runners.JUnit4;
+import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;


### PR DESCRIPTION
- Replaced `CandlePublisherImpl` with `CandlePublisher` in `CandleManagerTest` to align with updated interface usage.  
- Simplified `BUILD` dependencies by removing `TestParameterInjector` where unnecessary.  
- Updated test runner in `CandleManagerTest` to use `JUnit4` for consistency across the test suite.  
- Adjusted `BUILD` file references to match refactored dependency names (`candle_publisher` instead of `candle_publisher_impl`).  

This update improves test clarity, aligns dependencies with the refactored codebase, and simplifies test configurations.