### PR TITLE
Remove TestParameterInjector from CandlePublisherImplTest

### DIFF
--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -48,7 +48,6 @@ java_test(
     name = "CandlePublisherImplTest",
     srcs = ["CandlePublisherImplTest.java"],
     deps = [
-        "@maven//:com_google_testparameterinjector_test_parameter_injector",
         "@maven//:junit_junit",
         "@maven//:org_apache_kafka_kafka_clients",
         "@maven//:org_mockito_mockito_core",

--- a/src/test/java/com/verlumen/tradestream/ingestion/CandlePublisherImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/CandlePublisherImplTest.java
@@ -10,16 +10,16 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-import com.google.testing.junit.testparameterinjector.TestParameterInjector;
 import java.time.Duration; 
 
 
 import com.google.testing.junit.testparameterinjector.TestParameterInjector;
 
-@RunWith(TestParameterInjector.class)
+@RunWith(JUnit4.class)
 public class CandlePublisherImplTest {
     @Rule public MockitoRule rule = MockitoJUnit.rule();
 

--- a/src/test/java/com/verlumen/tradestream/ingestion/CandlePublisherImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/CandlePublisherImplTest.java
@@ -16,9 +16,6 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import java.time.Duration; 
 
-
-import com.google.testing.junit.testparameterinjector.TestParameterInjector;
-
 @RunWith(JUnit4.class)
 public class CandlePublisherImplTest {
     @Rule public MockitoRule rule = MockitoJUnit.rule();


### PR DESCRIPTION
- Removed `TestParameterInjector` dependency from `CandlePublisherImplTest` as it was unused.  
- Updated `BUILD` file to exclude `@maven//:com_google_testparameterinjector_test_parameter_injector`.  
- Switched test runner in `CandlePublisherImplTest` to `JUnit4` for consistency with other tests.  

This cleanup simplifies dependencies and standardizes test configurations across the project.