### PR TITLE
Refactor `AppTest` to Use `JUnit4` and Mockito Rule

### DIFF
--- a/src/test/java/com/verlumen/tradestream/ingestion/AppTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/AppTest.java
@@ -9,11 +9,14 @@ import com.google.inject.Inject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(JUnit4.class)
 public class AppTest {
+  @Rule public MockitoRule rule = MockitoJUnit.rule();
 
   @Bind @Mock
   private MarketDataIngestion mockMarketDataIngestion;

--- a/src/test/java/com/verlumen/tradestream/ingestion/AppTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/AppTest.java
@@ -7,6 +7,7 @@ import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;


### PR DESCRIPTION
- Updated `AppTest` to use `JUnit4` instead of `MockitoJUnitRunner`.  
- Introduced `MockitoRule` for improved flexibility and better integration with `JUnit4`.  
- Adjusted dependency binding for `MarketDataIngestion` mock to align with the new test runner.

This change modernizes the test setup and provides a more modular and maintainable testing framework.