### PR TITLE
Reposition `auto-value-gson` Dependencies in `MODULE.bazel`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -25,9 +25,6 @@ register_toolchains(
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(
     artifacts = [
-        "com.ryanharter.auto.value:auto-value-gson:1.3.1",
-        "com.ryanharter.auto.value:auto-value-gson-annotations:0.8.0",
-        "com.ryanharter.auto.value:auto-value-gson-factory:1.3.1",
         "com.google.auto.factory:auto-factory:1.0.1",
         "com.google.auto.value:auto-value:1.10",
         "com.google.auto.value:auto-value-annotations:1.10",
@@ -42,6 +39,9 @@ maven.install(
         "com.google.guava:guava:31.1-jre",
         "com.google.inject:guice:7.0.0",
         "com.google.protobuf:protobuf-java:3.21.12",
+        "com.ryanharter.auto.value:auto-value-gson:1.3.1",
+        "com.ryanharter.auto.value:auto-value-gson-annotations:0.8.0",
+        "com.ryanharter.auto.value:auto-value-gson-factory:1.3.1",
         "org.apache.kafka:kafka-clients:3.6.1",
         "org.slf4j:slf4j-api:2.0.12",
 


### PR DESCRIPTION
- Moved `auto-value-gson` dependencies (`auto-value-gson`, `auto-value-gson-annotations`, `auto-value-gson-factory`) below core libraries like `guava` and `protobuf` to maintain logical grouping.  
- Ensures that dependent libraries (`auto-value-gson`) appear after their base dependencies (`gson`) for better readability and logical structure.

This update improves clarity and alignment within the `MODULE.bazel` file, enhancing maintainability.