### PR TITLE
Reorder Dependencies in `MODULE.bazel`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -25,13 +25,13 @@ register_toolchains(
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(
     artifacts = [
-        "com.ryanharter.auto.value:auto-value-gson:1.3.1",
-        "com.ryanharter.auto.value:auto-value-gson-annotations:0.8.0",
-        "com.ryanharter.auto.value:auto-value-gson-factory:1.3.1",
         "com.google.auto.factory:auto-factory:1.0.1",
         "com.google.auto.value:auto-value:1.10",
         "com.google.auto.value:auto-value-annotations:1.10",
         "com.google.code.gson:gson:2.9.1",
+        "com.ryanharter.auto.value:auto-value-gson:1.3.1",
+        "com.ryanharter.auto.value:auto-value-gson-annotations:0.8.0",
+        "com.ryanharter.auto.value:auto-value-gson-factory:1.3.1",
         "org.knowm.xchange:xchange-core:5.2.0",
         "org.knowm.xchange:xchange-stream-core:5.2.0",
         "org.knowm.xchange:xchange-coinbasepro:5.2.0",


### PR DESCRIPTION
- Reordered dependencies in `MODULE.bazel` to align related libraries for better logical grouping and readability.  
- Moved the `auto-value-gson` dependencies below `gson` to reflect their dependency hierarchy and maintain consistency.  

This enhancement improves the maintainability of the Bazel module configuration by making the dependencies list easier to understand and navigate.