### PR TITLE
Refactor Plugins and Dependencies for Auto* Frameworks

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,70 +1,94 @@
+package(default_visibility = ["//visibility:public"])
+
 java_library(
-    name = "autofactory",
-    exported_plugins = [
-        ":autofactory_plugin",
+    name = "common",
+    exports = ["@com_google_auto_auto_common//jar"],
+)
+
+java_plugin(
+    name = "auto_value_processor",
+    processor_class = "com.google.auto.value.processor.AutoValueProcessor",
+    visibility = ["//visibility:private"],
+    deps = [
+        ":common",
+        ":service",
+        "//third_party/java/guava",
+        "@com_google_auto_value_auto_value//jar",
     ],
-    neverlink = 1,
-    visibility = ["//visibility:public"],
-    exports = [
-        "@maven//:com_google_auto_auto_common",
-        "@maven//:com_google_auto_factory_auto_factory",
-        "@maven//:javax_annotation_javax_annotation_api",
-        "@maven//:javax_inject_javax_inject",
+)
+
+java_plugin(
+    name = "auto_annotation_processor",
+    processor_class = "com.google.auto.value.processor.AutoAnnotationProcessor",
+    visibility = ["//visibility:private"],
+    deps = [
+        ":common",
+        ":service",
+        "//third_party/java/guava",
+        "@com_google_auto_value_auto_value//jar",
+    ],
+)
+
+java_plugin(
+    name = "auto_oneof_processor",
+    processor_class = "com.google.auto.value.processor.AutoOneOfProcessor",
+    visibility = ["//visibility:private"],
+    deps = [
+        ":common",
+        ":service",
+        "//third_party/java/guava",
+        "@com_google_auto_value_auto_value//jar",
     ],
 )
 
 java_library(
     name = "autovalue",
     exported_plugins = [
-        ":autovalue_plugin",
+        ":auto_annotation_processor",
+        ":auto_oneof_processor",
+        ":auto_value_processor",
     ],
-    neverlink = 1,
-    visibility = ["//visibility:public"],
+    tags = ["maven:compile_only"],
     exports = [
-        "@maven//:com_google_auto_value_auto_value",
+        # "//third_party/java/jsr250_annotations",  # TODO(ronshapiro) Can this be removed?
         "@maven//:com_google_auto_value_auto_value_annotations",
     ],
 )
 
-java_library(
-    name = "autovalue_gson",
-    exported_plugins = [
-        ":autovalue_gson_plugin",
-    ],
-    neverlink = 1,
-    visibility = ["//visibility:public"],
-    exports = [
-        "@maven//:com_google_code_gson_gson",
-        "@maven//:com_ryanharter_auto_value_auto_value_gson",
-        "@maven//:com_ryanharter_auto_value_auto_value_gson_annotations",
-        "@maven//:com_ryanharter_auto_value_auto_value_gson_factory",
-    ],
-)
-
 java_plugin(
-    name = "autofactory_plugin",
+    name = "auto_factory_processor",
+    generates_api = 1,
     processor_class = "com.google.auto.factory.processor.AutoFactoryProcessor",
+    visibility = ["//visibility:private"],
     deps = [
-        "@maven//:com_google_auto_auto_common",
+        ":common",
+        ":service",
+        "//third_party/java/guava",
+        "//third_party/java/javapoet",
         "@maven//:com_google_auto_factory_auto_factory",
-        "@maven//:javax_annotation_javax_annotation_api",
-        "@maven//:javax_inject_javax_inject",
     ],
 )
 
-java_plugin(
-    name = "autovalue_plugin",
-    processor_class = "com.google.auto.value.processor.AutoValueProcessor",
-    deps = [
-        "@maven//:com_google_auto_value_auto_value",
-        "@maven//:com_ryanharter_auto_value_auto_value_gson_factory",
-    ],
+java_library(
+    name = "autofactory",
+    exported_plugins = [":auto_factory_processor"],
+    exports = ["@maven//:com_google_auto_factory_auto_factory"],
 )
 
 java_plugin(
-    name = "autovalue_gson_plugin",
-    processor_class = "com.ryanharter.auto.value.gson.factory.AutoValueGsonAdapterFactoryProcessor",
+    name = "auto_service_processor",
+    processor_class = "com.google.auto.service.processor.AutoServiceProcessor",
+    visibility = ["//visibility:private"],
     deps = [
-        "@maven//:com_ryanharter_auto_value_auto_value_gson",
+        ":common",
+        "//third_party/java/guava",
+        "@maven//:com_google_auto_service_auto_service",
     ],
+)
+
+java_library(
+    name = "service",
+    exported_plugins = [":auto_service_processor"],
+    tags = ["maven:compile_only"],
+    exports = ["@maven//:com_google_auto_service_auto_service"],
 )

--- a/BUILD
+++ b/BUILD
@@ -66,6 +66,7 @@ java_plugin(
         "@maven//:com_google_guava_guava",
         "@maven//:com_squareup_javapoet",
         "@maven//:com_google_auto_factory_auto_factory",
+        "@maven//:javax_inject_javax_inject",
     ],
 )
 

--- a/BUILD
+++ b/BUILD
@@ -64,7 +64,7 @@ java_plugin(
         ":common",
         ":service",
         "@maven//:com_google_guava_guava",
-        "//third_party/java/javapoet",
+        "@maven//:com_squareup_javapoet",
         "@maven//:com_google_auto_factory_auto_factory",
     ],
 )

--- a/BUILD
+++ b/BUILD
@@ -73,7 +73,10 @@ java_plugin(
 java_library(
     name = "autofactory",
     exported_plugins = [":auto_factory_processor"],
-    exports = ["@maven//:com_google_auto_factory_auto_factory"],
+    exports = [
+        "@maven//:com_google_auto_factory_auto_factory",
+        "@maven//:javax_inject_javax_inject",        
+    ],
 )
 
 java_plugin(

--- a/BUILD
+++ b/BUILD
@@ -2,7 +2,7 @@ package(default_visibility = ["//visibility:public"])
 
 java_library(
     name = "common",
-    exports = ["@com_google_auto_auto_common//jar"],
+    exports = ["@maven//:com_google_auto_auto_common"],
 )
 
 java_plugin(
@@ -12,8 +12,8 @@ java_plugin(
     deps = [
         ":common",
         ":service",
-        "//third_party/java/guava",
-        "@com_google_auto_value_auto_value//jar",
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_auto_value_auto_value",
     ],
 )
 
@@ -24,8 +24,8 @@ java_plugin(
     deps = [
         ":common",
         ":service",
-        "//third_party/java/guava",
-        "@com_google_auto_value_auto_value//jar",
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_auto_value_auto_value",
     ],
 )
 
@@ -36,8 +36,8 @@ java_plugin(
     deps = [
         ":common",
         ":service",
-        "//third_party/java/guava",
-        "@com_google_auto_value_auto_value//jar",
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_auto_value_auto_value",
     ],
 )
 
@@ -63,7 +63,7 @@ java_plugin(
     deps = [
         ":common",
         ":service",
-        "//third_party/java/guava",
+        "@maven//:com_google_guava_guava",
         "//third_party/java/javapoet",
         "@maven//:com_google_auto_factory_auto_factory",
     ],
@@ -81,7 +81,7 @@ java_plugin(
     visibility = ["//visibility:private"],
     deps = [
         ":common",
-        "//third_party/java/guava",
+        "@maven//:com_google_guava_guava",
         "@maven//:com_google_auto_service_auto_service",
     ],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -26,6 +26,7 @@ maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(
     artifacts = [
         "com.google.auto.factory:auto-factory:1.1.0",
+        "com.google.auto.service:auto-service:1.1.1",
         "com.google.auto.value:auto-value:1.10",
         "com.google.auto.value:auto-value-annotations:1.10",
         "com.google.code.gson:gson:2.9.1",
@@ -35,7 +36,7 @@ maven.install(
         "com.ryanharter.auto.value:auto-value-gson:1.3.1",
         "com.ryanharter.auto.value:auto-value-gson-annotations:0.8.0",
         "com.ryanharter.auto.value:auto-value-gson-factory:1.3.1",
-        "com.squareup:javapoet:jar:1.13.0",
+        "com.squareup:javapoet:1.13.0",
         "io.reactivex.rxjava3:rxjava:3.1.6",
         "javax.inject:javax.inject:1",
         "org.apache.kafka:kafka-clients:3.6.1",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -35,6 +35,7 @@ maven.install(
         "com.ryanharter.auto.value:auto-value-gson:1.3.1",
         "com.ryanharter.auto.value:auto-value-gson-annotations:0.8.0",
         "com.ryanharter.auto.value:auto-value-gson-factory:1.3.1",
+        "com.squareup:javapoet:jar:1.13.0",
         "io.reactivex.rxjava3:rxjava:3.1.6",
         "javax.inject:javax.inject:1",
         "org.apache.kafka:kafka-clients:3.6.1",


### PR DESCRIPTION
- Reorganized and modularized the `BUILD` file to improve readability and maintainability:
  - Introduced separate `java_plugin` definitions for `auto_value`, `auto_factory`, and `auto_service`.
  - Added `common` and `service` modules for shared configurations.
  - Consolidated plugin references and updated export declarations for clarity.
- Updated `MODULE.bazel` to include:
  - `com.google.auto.service:auto-service:1.1.1` and its dependencies.
  - `com.squareup:javapoet:1.13.0` for enhanced code generation support.
- Simplified the build by removing unnecessary annotations and redundant references.
- Ensured plugins and libraries are tagged and scoped correctly for compilation and runtime needs.  

This refactor makes the build system more modular and paves the way for smoother future integrations with Auto* frameworks.