### PR TITLE
Enhance Bazel Test Workflow with Caching for Faster Builds

### DIFF
--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -12,9 +12,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Bazelisk
-      uses: philwo/bazelisk-action@v1
-
     - name: Compute Cache Key
       id: compute-cache-key
       run: |
@@ -28,7 +25,7 @@ jobs:
         path: |
           ~/.cache/bazel
           .bazel-disk-cache
-          external_dependency_dir # Replace with actual dependency directories if any
+
         key: ${{ env.CACHE_KEY }}
         restore-keys: |
           bazel-cache-${{ env.BAZEL_VERSION }}-

--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -11,9 +11,35 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Mount bazel cache
+
+    - name: Set up Bazelisk
+      uses: philwo/bazelisk-action@v1
+
+    - name: Compute Cache Key
+      id: compute-cache-key
+      run: |
+        BAZEL_VERSION=$(bazel version | grep 'Build label' | awk '{print $3}')
+        WORKSPACE_HASH=$(sha256sum WORKSPACE | awk '{print $1}')
+        echo "CACHE_KEY=bazel-cache-${BAZEL_VERSION}-${WORKSPACE_HASH}" >> $GITHUB_ENV
+
+    - name: Cache Bazel Directories
       uses: actions/cache@v4
       with:
-        path: "~/.cache/bazel"
-        key: bazel
-    - run: bazel test //... --test_output=all
+        path: |
+          ~/.cache/bazel
+          .bazel-disk-cache
+          external_dependency_dir # Replace with actual dependency directories if any
+        key: ${{ env.CACHE_KEY }}
+        restore-keys: |
+          bazel-cache-${{ env.BAZEL_VERSION }}-
+          bazel-cache-
+
+    - name: Run Bazel Tests
+      run: |
+        mkdir -p .bazel-disk-cache
+        bazel test //... --test_output=all --disk_cache=$(pwd)/.bazel-disk-cache
+
+    - name: Post Build Cache Info
+      if: always()
+      run: |
+        echo "Used Cache Key: ${{ env.CACHE_KEY }}"

--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -12,31 +12,15 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Compute Cache Key
-      id: compute-cache-key
-      run: |
-        BAZEL_VERSION=$(bazel version | grep 'Build label' | awk '{print $3}')
-        WORKSPACE_HASH=$(sha256sum WORKSPACE | awk '{print $1}')
-        echo "CACHE_KEY=bazel-cache-${BAZEL_VERSION}-${WORKSPACE_HASH}" >> $GITHUB_ENV
-
-    - name: Cache Bazel Directories
+    - name: Cache Bazel Build
       uses: actions/cache@v4
       with:
         path: |
           ~/.cache/bazel
-          .bazel-disk-cache
-
-        key: ${{ env.CACHE_KEY }}
+        key: ${{ runner.os }}-bazel-${{ github.ref_name }}-${{ hashFiles('WORKSPACE', '**/BUILD', '**/*.bzl', 'bazel.rc') }}
         restore-keys: |
-          bazel-cache-${{ env.BAZEL_VERSION }}-
-          bazel-cache-
+          ${{ runner.os }}-bazel-${{ github.ref_name }}-
+          ${{ runner.os }}-bazel-
 
     - name: Run Bazel Tests
-      run: |
-        mkdir -p .bazel-disk-cache
-        bazel test //... --test_output=all --disk_cache=$(pwd)/.bazel-disk-cache
-
-    - name: Post Build Cache Info
-      if: always()
-      run: |
-        echo "Used Cache Key: ${{ env.CACHE_KEY }}"
+      run: bazel test //... --test_output=errors


### PR DESCRIPTION
This PR improves the GitHub Actions workflow for Bazel tests by adding a caching mechanism to speed up build and test times. 

#### Changes:
- Replaced the "Mount bazel cache" step with a dedicated caching mechanism using `actions/cache@v4`.
- Configured caching to include relevant Bazel files such as `WORKSPACE`, `BUILD`, `.bzl`, and `bazel.rc` files.
- Added `restore-keys` to ensure partial cache retrieval in case of cache misses.
- Updated the Bazel test command to output errors only for better readability in logs.

These updates aim to reduce workflow runtime and improve the efficiency of CI builds.