### PR TITLE
Remove AutoFactory Dependencies from Ingestion Module

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -32,7 +32,6 @@ java_library(
     srcs = ["CandleManager.java"],
     deps = [
         "//protos:marketdata_java_proto",
-        "//:autofactory",
         ":candle_builder",
         ":candle_publisher",
         ":price_tracker",
@@ -52,7 +51,6 @@ java_library(
     srcs = ["CandlePublisherImpl.java"],
     deps = [
         "@maven//:org_apache_kafka_kafka_clients",
-        "//:autofactory",
         "//protos:marketdata_java_proto",
         ":candle_publisher",
     ],

--- a/src/main/java/com/verlumen/tradestream/ingestion/CandleManager.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CandleManager.java
@@ -1,7 +1,5 @@
 package com.verlumen.tradestream.ingestion;
 
-import com.google.auto.factory.AutoFactory;
-import com.google.auto.factory.Provided;
 import marketdata.Marketdata.Trade;
 import marketdata.Marketdata.Candle;
 import java.util.List;
@@ -14,12 +12,8 @@ class CandleManager {
     private final CandlePublisher publisher;
     private final PriceTracker priceTracker;
 
-    @AutoFactory
-    CandleManager(
-        long candleIntervalMillis,
-        CandlePublisher publisher,
-        @Provided PriceTracker priceTracker
-    ) {
+    CandleManager(long candleIntervalMillis, CandlePublisher publisher,
+                  PriceTracker priceTracker) {
         this.candleIntervalMillis = candleIntervalMillis;
         this.publisher = publisher;
         this.priceTracker = priceTracker;

--- a/src/main/java/com/verlumen/tradestream/ingestion/CandlePublisherImpl.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CandlePublisherImpl.java
@@ -1,7 +1,5 @@
 package com.verlumen.tradestream.ingestion;
 
-import com.google.auto.factory.AutoFactory;
-import com.google.auto.factory.Provided;
 import marketdata.Marketdata.Candle;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -11,10 +9,9 @@ final class CandlePublisherImpl implements CandlePublisher {
     private final KafkaProducer<String, byte[]> kafkaProducer;
     private final String topic;
 
-    @AutoFactory(implementing = CandlePublisher.Factory.class)
     CandlePublisherImpl(
         String topic,
-        @Provided KafkaProducer<String, byte[]> kafkaProducer
+        KafkaProducer<String, byte[]> kafkaProducer
     ) {
         this.topic = topic;
         this.kafkaProducer = kafkaProducer;


### PR DESCRIPTION
This PR refactors the `ingestion` module of the TradeStream project by removing dependencies on Google AutoFactory. The changes simplify class constructors and eliminate unnecessary factory generation, improving code clarity and maintainability.

#### Key Changes:
- Removed AutoFactory annotations and related imports from:
  - `CandleManager.java`
  - `CandlePublisherImpl.java`
- Updated constructor signatures to directly accept dependencies without requiring `@Provided` annotations.
- Deleted `//:autofactory` dependency from the `BUILD` file for `CandleManager` and `CandlePublisherImpl`.

These changes streamline the code by relying on manual dependency injection, reducing reliance on external libraries and enhancing testability.