### PR TITLE
Add Flogger for Enhanced Logging in TradeStream Ingestion

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -29,6 +29,8 @@ maven.install(
         "com.google.auto.value:auto-value:1.10",
         "com.google.auto.value:auto-value-annotations:1.10",
         "com.google.code.gson:gson:2.9.1",
+        "com.google.flogger:flogger:0.8'",
+        "com.google.flogger:flogger-system-backend:0.8",
         "com.google.guava:guava:31.1-jre",
         "com.google.inject.extensions:guice-assistedinject:7.0.0",
         "com.google.inject:guice:7.0.0",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -29,7 +29,7 @@ maven.install(
         "com.google.auto.value:auto-value:1.10",
         "com.google.auto.value:auto-value-annotations:1.10",
         "com.google.code.gson:gson:2.9.1",
-        "com.google.flogger:flogger:0.8'",
+        "com.google.flogger:flogger:0.8",
         "com.google.flogger:flogger-system-backend:0.8",
         "com.google.guava:guava:31.1-jre",
         "com.google.inject.extensions:guice-assistedinject:7.0.0",

--- a/src/main/java/com/verlumen/tradestream/ingestion/App.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/App.java
@@ -1,9 +1,12 @@
 package com.verlumen.tradestream.ingestion;
 
+import com.google.common.flogger.FluentLogger;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 
 final class App {
+  private static final FluentLogger logger = FluentLogger.forEnclosingClass();
+
   private final MarketDataIngestion marketDataIngestion;
 
   @Inject
@@ -12,7 +15,7 @@ final class App {
   }
 
   void run() {
-    System.out.println("Starting real-time data ingestion...");
+    logger.atInfo().log("Starting real-time data ingestion...");
     marketDataIngestion.start();
   }
 

--- a/src/main/java/com/verlumen/tradestream/ingestion/App.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/App.java
@@ -1,8 +1,15 @@
 package com.verlumen.tradestream.ingestion;
 
+import com.google.common.flogger.backend.system.DefaultPlatform;
 import com.google.common.flogger.FluentLogger;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
+
+static {
+  System.setProperty(
+      "flogger.backend_factory",
+      "com.google.common.flogger.backend.system.DefaultPlatform$SystemBackendFactory");
+}
 
 final class App {
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();

--- a/src/main/java/com/verlumen/tradestream/ingestion/App.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/App.java
@@ -23,5 +23,4 @@ final class App {
     App app = Guice.createInjector(new IngestionModule()).getInstance(App.class);
     app.run();
   }
-
 }

--- a/src/main/java/com/verlumen/tradestream/ingestion/App.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/App.java
@@ -1,15 +1,8 @@
 package com.verlumen.tradestream.ingestion;
 
-import com.google.common.flogger.backend.system.DefaultPlatform;
 import com.google.common.flogger.FluentLogger;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
-
-static {
-  System.setProperty(
-      "flogger.backend_factory",
-      "com.google.common.flogger.backend.system.DefaultPlatform$SystemBackendFactory");
-}
 
 final class App {
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -12,12 +12,14 @@ java_binary(
     main_class = "com.verlumen.tradestream.ingestion.App",
     deps = [
         "@maven//:com_google_flogger_flogger",
-        "@maven//:com_google_flogger_flogger_system_backend",        
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_inject_guice",
         ":ingestion_module",
         ":market_data_ingestion",
         ":real_time_data_ingestion",
+    ],
+    runtime_deps = [
+        "@maven//:com_google_flogger_flogger_system_backend",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -12,15 +12,13 @@ java_binary(
     main_class = "com.verlumen.tradestream.ingestion.App",
     deps = [
         "@maven//:com_google_flogger_flogger",
+        "@maven//:com_google_flogger_flogger_system_backend",        
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_inject_guice",
         ":ingestion_module",
         ":market_data_ingestion",
         ":real_time_data_ingestion",
     ],
-    runtime_deps = [
-        "@maven//:com_google_flogger_flogger_system_backend",
-    ]
 )
 
 java_library(

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -11,12 +11,16 @@ java_binary(
     srcs = ["App.java"],
     main_class = "com.verlumen.tradestream.ingestion.App",
     deps = [
+        "@maven//:com_google_flogger_flogger",
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_inject_guice",
         ":ingestion_module",
         ":market_data_ingestion",
         ":real_time_data_ingestion",
     ],
+    runtime_deps = [
+        "@maven//:com_google_flogger_flogger_system_backend",
+    ]
 )
 
 java_library(

--- a/src/main/java/com/verlumen/tradestream/ingestion/container-structure-test.yaml
+++ b/src/main/java/com/verlumen/tradestream/ingestion/container-structure-test.yaml
@@ -4,4 +4,4 @@ commandTests:
   - name: test
     command: java
     args: ['-jar', '/src/main/java/com/verlumen/tradestream/ingestion/app_deploy.jar']
-    expectedOutput: ['Starting real-time data ingestion...']
+    expectedOutput: ['INFO: Starting real-time data ingestion...']

--- a/src/main/java/com/verlumen/tradestream/ingestion/container-structure-test.yaml
+++ b/src/main/java/com/verlumen/tradestream/ingestion/container-structure-test.yaml
@@ -4,4 +4,4 @@ commandTests:
   - name: test
     command: java
     args: ['-jar', '/src/main/java/com/verlumen/tradestream/ingestion/app_deploy.jar']
-    expectedOutput: ['INFO: Starting real-time data ingestion...']
+    expectedError: ['.*Starting real-time data ingestion...']

--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -14,6 +14,9 @@ java_test(
         "//src/main/java/com/verlumen/tradestream/ingestion:app",
         "//src/main/java/com/verlumen/tradestream/ingestion:market_data_ingestion",
     ],
+    runtime_deps = [
+        "@maven//:com_google_flogger_flogger_system_backend",
+    ]
 )
 
 java_test(

--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -16,7 +16,7 @@ java_test(
     ],
     runtime_deps = [
         "@maven//:com_google_flogger_flogger_system_backend",
-    ]
+    ],
 )
 
 java_test(


### PR DESCRIPTION
This update integrates Google's Flogger as the logging framework for the TradeStream ingestion application. The `App` class replaces standard `System.out.println` statements with Flogger's structured logging. The build configuration includes dependencies for `flogger` and its system backend. Tests and runtime environments are updated to include the necessary backend, ensuring consistent and robust logging throughout the application.