### PR TITLE
Integrate StreamingExchange Support for Real-Time Market Data Ingestion

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -16,6 +16,7 @@ java_binary(
         ":ingestion_module",
         ":market_data_ingestion",
         ":real_time_data_ingestion",
+        ":streaming_exchange_provider",
     ],
 )
 
@@ -195,6 +196,16 @@ java_library(
         ":candle_manager",
         ":candle_publisher",
         ":market_data_ingestion",
+    ]
+)
+
+java_library(
+    name = "streaming_exchange_provider",
+    srcs = ["StreamingExchangeProvider.java"],
+    deps = [
+        "@maven//:com_google_inject_guice",
+        "@maven//:org_knowm_xchange_xchange_core",
+        "@maven//:org_knowm_xchange_xchange_stream_core",
     ]
 )
 

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -128,6 +128,7 @@ java_library(
         ":market_data_ingestion",
         ":properties_provider",
         ":real_time_data_ingestion",
+        ":streaming_exchange_provider",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -120,7 +120,7 @@ java_library(
         "@maven//:com_google_inject_extensions_guice_assistedinject",
         "@maven//:com_google_inject_guice",
         "@maven//:org_apache_kafka_kafka_clients",
-        "@maven//:org_knowm_xchange_xchange_stream_core"
+        "@maven//:org_knowm_xchange_xchange_stream_core",
         ":candle_manager",
         ":candle_manager_impl",
         ":candle_publisher",

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -120,6 +120,7 @@ java_library(
         "@maven//:com_google_inject_extensions_guice_assistedinject",
         "@maven//:com_google_inject_guice",
         "@maven//:org_apache_kafka_kafka_clients",
+        "@maven//:org_knowm_xchange_xchange_stream_core"
         ":candle_manager",
         ":candle_manager_impl",
         ":candle_publisher",

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -168,6 +168,8 @@ java_library(
     srcs = ["RealTimeDataIngestion.java"],
     deps = [
         "@maven//:com_google_inject_guice",
+        "@maven//:org_knowm_xchange_xchange_core",
+        "@maven//:org_knowm_xchange_xchange_stream_core",
         ":candle_manager",
         ":candle_publisher",
         ":market_data_ingestion",

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -4,6 +4,7 @@ import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.AbstractModule;
 import com.google.inject.TypeLiteral;
 import org.apache.kafka.clients.producer.KafkaProducer;
+import info.bitrich.xchangestream.core.StreamingExchange;
 
 import java.util.Properties;
 
@@ -13,6 +14,7 @@ final class IngestionModule extends AbstractModule {
     bind(new TypeLiteral<KafkaProducer<String, byte[]>>() {})
         .toProvider(KafkaProducerProvider.class);
     bind(Properties.class).toProvider(PropertiesProvider.class);
+    bind(StreamingExchange.class).toProvider(StreamingExchangeProvider.class);
 
     bind(MarketDataIngestion.class).to(RealTimeDataIngestion.class);
 

--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestion.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestion.java
@@ -1,19 +1,20 @@
 package com.verlumen.tradestream.ingestion;
 
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 import info.bitrich.xchangestream.core.StreamingExchange;
 import info.bitrich.xchangestream.core.StreamingMarketDataService;
 
 final class RealTimeDataIngestion implements MarketDataIngestion {
     private final CandleManager.Factory candleManagerFactory;
     private final CandlePublisher.Factory candlePublisherFactory;
-    private final StreamingExchange exchange;
+    private final Provider<StreamingExchange> exchange;
     
     @Inject
     RealTimeDataIngestion(
         CandleManager.Factory candleManagerFactory,
         CandlePublisher.Factory candlePublisherFactory,
-        StreamingExchange exchange
+        Provider<StreamingExchange> exchange
     ) {
         this.candleManagerFactory = candleManagerFactory;
         this.candlePublisherFactory = candlePublisherFactory;

--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestion.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestion.java
@@ -1,6 +1,8 @@
 package com.verlumen.tradestream.ingestion;
 
 import com.google.inject.Inject;
+import info.bitrich.xchangestream.core.StreamingExchange;
+import info.bitrich.xchangestream.core.StreamingMarketDataService;
 
 final class RealTimeDataIngestion implements MarketDataIngestion {
     private final CandleManager.Factory candleManagerFactory;

--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestion.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestion.java
@@ -5,14 +5,17 @@ import com.google.inject.Inject;
 final class RealTimeDataIngestion implements MarketDataIngestion {
     private final CandleManager.Factory candleManagerFactory;
     private final CandlePublisher.Factory candlePublisherFactory;
+    private final StreamingExchange exchange;
     
     @Inject
     RealTimeDataIngestion(
         CandleManager.Factory candleManagerFactory,
-        CandlePublisher.Factory candlePublisherFactory
+        CandlePublisher.Factory candlePublisherFactory,
+        StreamingExchange exchange
     ) {
         this.candleManagerFactory = candleManagerFactory;
         this.candlePublisherFactory = candlePublisherFactory;
+        this.exchange = exchange;
     }
 
     @Override

--- a/src/main/java/com/verlumen/tradestream/ingestion/StreamingExchangeProvider.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/StreamingExchangeProvider.java
@@ -17,7 +17,7 @@ final class StreamingExchangeProvider implements Provider<StreamingExchange> {
 
   @Override
   public StreamingExchange get() {
-    String exchangeName = properties.get("xchange.exchangeName").toString();
+    String exchangeName = properties.getProperty("xchange.exchangeName");
     return StreamingExchangeFactory.INSTANCE.createExchange(exchangeName);
   }
 }

--- a/src/main/java/com/verlumen/tradestream/ingestion/StreamingExchangeProvider.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/StreamingExchangeProvider.java
@@ -4,6 +4,8 @@ import com.google.inject.Inject;
 import info.bitrich.xchangestream.core.StreamingExchange;
 import info.bitrich.xchangestream.core.StreamingExchangeFactory;
 
+import java.util.Properties;
+
 final class StreamingExchangeProvider implements Provider<StreamingExchange> {
   private final Properties properties;
 

--- a/src/main/java/com/verlumen/tradestream/ingestion/StreamingExchangeProvider.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/StreamingExchangeProvider.java
@@ -1,6 +1,7 @@
 package com.verlumen.tradestream.ingestion;
 
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 import info.bitrich.xchangestream.core.StreamingExchange;
 import info.bitrich.xchangestream.core.StreamingExchangeFactory;
 

--- a/src/main/java/com/verlumen/tradestream/ingestion/StreamingExchangeProvider.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/StreamingExchangeProvider.java
@@ -1,0 +1,20 @@
+package com.verlumen.tradestream.ingestion;
+
+import com.google.inject.Inject;
+import info.bitrich.xchangestream.core.StreamingExchange;
+import info.bitrich.xchangestream.core.StreamingExchangeFactory;
+
+final class StreamingExchangeProvider implements Provider<StreamingExchange> {
+  private final Properties properties;
+
+  @Inject
+  StreamingExchangeProvider(Properties properties) {
+    this.properties = properties;
+  }
+
+  @Override
+  public StreamingExchange get() {
+    String exchangeName = properties.get("xchange.exchangeName");
+    return StreamingExchangeFactory.INSTANCE.createExchange(exchangeName);
+  }
+}

--- a/src/main/java/com/verlumen/tradestream/ingestion/StreamingExchangeProvider.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/StreamingExchangeProvider.java
@@ -17,7 +17,7 @@ final class StreamingExchangeProvider implements Provider<StreamingExchange> {
 
   @Override
   public StreamingExchange get() {
-    String exchangeName = properties.get("xchange.exchangeName");
+    String exchangeName = properties.get("xchange.exchangeName").toString();
     return StreamingExchangeFactory.INSTANCE.createExchange(exchangeName);
   }
 }

--- a/src/main/java/com/verlumen/tradestream/ingestion/config.properties
+++ b/src/main/java/com/verlumen/tradestream/ingestion/config.properties
@@ -1,0 +1,1 @@
+xchange.exchange


### PR DESCRIPTION
This update enhances the TradeStream ingestion module by adding support for `StreamingExchange` integration. It introduces a `StreamingExchangeProvider` class to dynamically provide a streaming exchange instance based on configuration properties. The `RealTimeDataIngestion` class is updated to utilize the `StreamingExchange` for real-time market data. Corresponding build files are updated to include the new dependencies and module configurations. The configuration now supports specifying the exchange name via `config.properties`.