### PR TITLE
Add Kafka producer configuration file and Bazel runfiles dependency

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -18,6 +18,9 @@ java_binary(
         ":market_data_ingestion",
         ":real_time_data_ingestion",
     ],
+    data = [
+        ":config.properties",
+    ]
 )
 
 java_library(

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -11,6 +11,7 @@ java_binary(
     srcs = ["App.java"],
     main_class = "com.verlumen.tradestream.ingestion.App",
     deps = [
+        "@bazel_tools//tools/java/runfiles",
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_inject_guice",
         ":ingestion_module",

--- a/src/main/java/com/verlumen/tradestream/ingestion/config.properties
+++ b/src/main/java/com/verlumen/tradestream/ingestion/config.properties
@@ -1,0 +1,8 @@
+bootstrap.servers=localhost:9092
+acks=all
+retries=0
+batch.size=16384
+linger.ms=1
+buffer.memory=33554432
+key.serializer=org.apache.kafka.common.serialization.StringSerializer
+value.serializer=org.apache.kafka.common.serialization.StringSerializer


### PR DESCRIPTION
This PR adds Kafka producer configuration and the necessary build setup to access it at runtime.

Changes:
- Added config.properties with standard Kafka producer settings
- Added Bazel runfiles dependency to access configuration file at runtime
- Updated BUILD file to include config.properties as a data dependency

Technical Details:
- Kafka configuration includes common producer settings like bootstrap servers, acks, batching, and serializers
- Using bazel_tools//tools/java/runfiles to properly access the config file in both development and production environments