### PR TITLE
Enhance Ingestion Module with Command-Line Arguments Support and AutoValue Integration 

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/App.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/App.java
@@ -16,9 +16,8 @@ final class App {
     marketDataIngestion.start();
   }
 
-  public static void main(String... args) throws Exception {
-    App app = Guice.createInjector(new IngestionModule()).getInstance(App.class);
+  public static void main(String[] args) throws Exception {
+    App app = Guice.createInjector(IngestionModule.create(args)).getInstance(App.class);
     app.run();
   }
-
 }

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -121,6 +121,7 @@ java_library(
         "@maven//:com_google_inject_guice",
         "@maven//:org_apache_kafka_kafka_clients",
         "@maven//:org_knowm_xchange_xchange_stream_core",
+        "//:autovalue",
         ":candle_manager",
         ":candle_manager_impl",
         ":candle_publisher",

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -117,6 +117,7 @@ java_library(
     name = "ingestion_module",
     srcs = ["IngestionModule.java"],
     deps = [
+        "@maven//:com_google_guava_guava",
         "@maven//:com_google_inject_extensions_guice_assistedinject",
         "@maven//:com_google_inject_guice",
         "@maven//:org_apache_kafka_kafka_clients",

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -1,5 +1,6 @@
 package com.verlumen.tradestream.ingestion;
 
+import com.google.auto.value.AutoValue;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.AbstractModule;
 import com.google.inject.TypeLiteral;

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -1,6 +1,7 @@
 package com.verlumen.tradestream.ingestion;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.AbstractModule;
 import com.google.inject.TypeLiteral;
@@ -12,10 +13,10 @@ import java.util.Properties;
 @AutoValue
 abstract class IngestionModule extends AbstractModule {
   static IngestionModule create(String[] commandLineArgs) {
-    return new AutoValue_IngestionModule(commandLineArgs);
+    return new AutoValue_IngestionModule(ImmutableList.copyOf(commandLineArgs));
   }
 
-  abstract String[] commandLineArgs();
+  abstract ImmutableList<String> commandLineArgs();
   
   @Override
   protected void configure() {

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -8,7 +8,14 @@ import info.bitrich.xchangestream.core.StreamingExchange;
 
 import java.util.Properties;
 
+@AutoValue
 final class IngestionModule extends AbstractModule {
+  static IngestionModule create(String[] commandLineArgs) {
+    return new AutoValue_IngestionModule(commandLineArgs);
+  }
+
+  abstract String[] commandLineArgs();
+  
   @Override
   protected void configure() {
     bind(new TypeLiteral<KafkaProducer<String, byte[]>>() {})

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -10,7 +10,7 @@ import info.bitrich.xchangestream.core.StreamingExchange;
 import java.util.Properties;
 
 @AutoValue
-final class IngestionModule extends AbstractModule {
+abstract class IngestionModule extends AbstractModule {
   static IngestionModule create(String[] commandLineArgs) {
     return new AutoValue_IngestionModule(commandLineArgs);
   }


### PR DESCRIPTION
This update introduces support for passing command-line arguments to the `IngestionModule` via a new `AutoValue`-based design. The `main` method in `App` is updated to utilize the `IngestionModule.create(args)` factory method. The build file now includes dependencies for Guava and AutoValue to support the new implementation. These changes improve modularity and enable runtime configuration via command-line inputs.