### PR TITLE
Introduce Command-Line Argument Parsing with Argparse4j for Configurable Ingestion

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -38,6 +38,7 @@ maven.install(
         "com.ryanharter.auto.value:auto-value-gson-factory:1.3.1",
         "io.reactivex.rxjava3:rxjava:3.1.6",
         "javax.inject:javax.inject:1",
+        "net.sourceforge.argparse4j:argparse4j:0.9.0",
         "org.apache.kafka:kafka-clients:3.6.1",
         "org.knowm.xchange:xchange-coinbasepro:5.2.0",
         "org.knowm.xchange:xchange-core:5.2.0",

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -136,6 +136,7 @@ java_library(
         ":candle_manager_impl",
         ":candle_publisher",
         ":candle_publisher_impl",
+        ":config_arguments",
         ":kafka_producer_provider",
         ":market_data_ingestion",
         ":properties_provider",

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -74,6 +74,9 @@ java_library(
 java_library(
     name = "config_arguments",
     srcs = ["ConfigArguments.java"],
+    deps = [
+        "@maven//:net_sourceforge_argparse4j_argparse4j",
+    ],
 )
 
 container_structure_test(

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -130,6 +130,7 @@ java_library(
     deps = [
         "@maven//:com_google_inject_extensions_guice_assistedinject",
         "@maven//:com_google_inject_guice",
+        "@maven//:net_sourceforge_argparse4j_argparse4j",
         "@maven//:org_apache_kafka_kafka_clients",
         "@maven//:org_knowm_xchange_xchange_stream_core",
         ":candle_manager",

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -71,6 +71,11 @@ java_library(
     ],
 )
 
+java_library(
+    name = "config_arguments",
+    srcs = ["ConfigArguments.java"],
+)
+
 container_structure_test(
     name = "container_test",
     configs = ["container-structure-test.yaml"],

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -75,6 +75,8 @@ java_library(
     name = "config_arguments",
     srcs = ["ConfigArguments.java"],
     deps = [
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_inject_guice",
         "@maven//:net_sourceforge_argparse4j_argparse4j",
         "//:autovalue",
     ],

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -76,6 +76,7 @@ java_library(
     srcs = ["ConfigArguments.java"],
     deps = [
         "@maven//:net_sourceforge_argparse4j_argparse4j",
+        "//:autovalue",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/ingestion/ConfigArguments.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/ConfigArguments.java
@@ -1,0 +1,76 @@
+package com.verlumen.tradestream.ingestion;
+
+import net.sourceforge.argparse4j.ArgumentParsers;
+import net.sourceforge.argparse4j.inf.ArgumentParser;
+import net.sourceforge.argparse4j.inf.ArgumentParserException;
+import net.sourceforge.argparse4j.inf.Namespace;
+
+@AutoValue
+abstract class ConfigArguments implements Provider<Namespace> {
+  static ConfigArguments create(ImmutableList<String> args) {
+    return new AutoValue_ConfigArguments(args);
+  }
+
+  abstract ImmutableList<String> args();
+
+  @Override
+  public Namespace get() {
+    ArgumentParser parser = createParser();
+    try {
+      return parser.parseArgs(args.toArray(String[0]));
+    } catch (ArgumentParserException e) {
+      throw new RuntimeException(e);
+    }  
+  }
+
+  private static ArgumentParser createParser() {
+    ArgumentParser parser = ArgumentParsers.newFor("KafkaExchangeConfig")
+      .build()
+      .defaultHelp(true)
+      .description("Configuration for Kafka producer and exchange settings");
+
+    // Kafka configuration
+    parser.addArgument("--kafka.bootstrap.servers")
+      .setDefault("localhost:9092")
+      .help("Kafka bootstrap servers");
+
+    parser.addArgument("--kafka.acks")
+      .setDefault("all")
+      .help("Kafka acknowledgment configuration");
+
+    parser.addArgument("--kafka.retries")
+      .type(Integer.class)
+      .setDefault(0)
+      .help("Number of retries");
+
+    parser.addArgument("--kafka.batch.size")
+      .type(Integer.class)
+      .setDefault(16384)
+      .help("Batch size in bytes");
+
+    parser.addArgument("--kafka.linger.ms")
+      .type(Integer.class)
+      .setDefault(1)
+      .help("Linger time in milliseconds");
+
+    parser.addArgument("--kafka.buffer.memory")
+      .type(Integer.class)
+      .setDefault(33554432)
+      .help("Buffer memory in bytes");
+
+    parser.addArgument("--kafka.key.serializer")
+      .setDefault("org.apache.kafka.common.serialization.StringSerializer")
+      .help("Key serializer class");
+
+    parser.addArgument("--kafka.value.serializer")
+      .setDefault("org.apache.kafka.common.serialization.StringSerializer")
+      .help("Value serializer class");
+
+    // Exchange configuration
+    parser.addArgument("--xchange.exchangeName")
+      .setDefault("info.bitrich.xchangestream.coinbasepro.CoinbaseProStreamingExchange")
+      .help("Exchange name");
+
+    return parser;
+  }
+}

--- a/src/main/java/com/verlumen/tradestream/ingestion/ConfigArguments.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/ConfigArguments.java
@@ -16,12 +16,7 @@ abstract class ConfigArguments implements Provider<Namespace> {
 
   @Override
   public Namespace get() {
-    ArgumentParser parser = createParser();
-    try {
-      return parser.parseArgs(args.toArray(String[0]));
-    } catch (ArgumentParserException e) {
-      throw new RuntimeException(e);
-    }  
+    return createParser().parseArgs(args().toArray(String[0]));
   }
 
   private static ArgumentParser createParser() {

--- a/src/main/java/com/verlumen/tradestream/ingestion/ConfigArguments.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/ConfigArguments.java
@@ -1,6 +1,8 @@
 package com.verlumen.tradestream.ingestion;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Provider;
 import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;

--- a/src/main/java/com/verlumen/tradestream/ingestion/ConfigArguments.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/ConfigArguments.java
@@ -1,5 +1,6 @@
 package com.verlumen.tradestream.ingestion;
 
+import com.google.auto.value.AutoValue;
 import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;

--- a/src/main/java/com/verlumen/tradestream/ingestion/ConfigArguments.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/ConfigArguments.java
@@ -18,7 +18,7 @@ abstract class ConfigArguments implements Provider<Namespace> {
 
   @Override
   public Namespace get() {
-    return createParser().parseArgs(args().toArray(String[0]));
+    return createParser().parseArgs(args().toArray(new String[0]));
   }
 
   private static ArgumentParser createParser() {

--- a/src/main/java/com/verlumen/tradestream/ingestion/ConfigArguments.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/ConfigArguments.java
@@ -18,11 +18,15 @@ abstract class ConfigArguments implements Provider<Namespace> {
 
   @Override
   public Namespace get() {
-    return createParser().parseArgs(args().toArray(new String[0]));
+    try {
+      return createParser().parseArgs(args().toArray(new String[0]));
+    } catch(ArgumentParserException e) {
+      throw new RuntimeException("Unable to parse arguments.", e);
+    }
   }
 
   private static ArgumentParser createParser() {
-    ArgumentParser parser = ArgumentParsers.newFor("KafkaExchangeConfig")
+    ArgumentParser parser = ArgumentParsers.newFor("TradeStreamDataIngestion")
       .build()
       .defaultHelp(true)
       .description("Configuration for Kafka producer and exchange settings");

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -9,7 +9,8 @@ import net.sourceforge.argparse4j.inf.Namespace;
 
 import java.util.Properties;
 
-final class IngestionModule extends AbstractModule {
+@AutoValue
+abstract class IngestionModule extends AbstractModule {
   @Override
   protected void configure() {
     bind(new TypeLiteral<KafkaProducer<String, byte[]>>() {})

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -14,7 +14,7 @@ final class IngestionModule extends AbstractModule {
   protected void configure() {
     bind(new TypeLiteral<KafkaProducer<String, byte[]>>() {})
         .toProvider(KafkaProducerProvider.class);
-    bind(Namespace.class).toProvider(Config.class);
+    bind(Namespace.class).toProvider(ConfigArguments.class);
     bind(Properties.class).toProvider(PropertiesProvider.class);
     bind(StreamingExchange.class).toProvider(StreamingExchangeProvider.class);
 

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -23,7 +23,7 @@ abstract class IngestionModule extends AbstractModule {
   protected void configure() {
     bind(new TypeLiteral<KafkaProducer<String, byte[]>>() {})
         .toProvider(KafkaProducerProvider.class);
-    bind(Namespace.class).toProvider(ConfigArguments.create(args()));
+    bind(Namespace.class).toProvider(ConfigArguments.create(commandLineArgs()));
     bind(Properties.class).toProvider(PropertiesProvider.class);
     bind(StreamingExchange.class).toProvider(StreamingExchangeProvider.class);
 

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -5,6 +5,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.TypeLiteral;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import info.bitrich.xchangestream.core.StreamingExchange;
+import net.sourceforge.argparse4j.inf.Namespace;
 
 import java.util.Properties;
 
@@ -13,6 +14,7 @@ final class IngestionModule extends AbstractModule {
   protected void configure() {
     bind(new TypeLiteral<KafkaProducer<String, byte[]>>() {})
         .toProvider(KafkaProducerProvider.class);
+    bind(Namespace.class).toProvider(Config.class);
     bind(Properties.class).toProvider(PropertiesProvider.class);
     bind(StreamingExchange.class).toProvider(StreamingExchangeProvider.class);
 

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -14,7 +14,7 @@ final class IngestionModule extends AbstractModule {
   protected void configure() {
     bind(new TypeLiteral<KafkaProducer<String, byte[]>>() {})
         .toProvider(KafkaProducerProvider.class);
-    bind(Namespace.class).toProvider(ConfigArguments.class);
+    bind(Namespace.class).toProvider(ConfigArguments.create());
     bind(Properties.class).toProvider(PropertiesProvider.class);
     bind(StreamingExchange.class).toProvider(StreamingExchangeProvider.class);
 


### PR DESCRIPTION
This update adds the `ConfigArguments` class to handle command-line argument parsing using Argparse4j, enabling dynamic configuration of Kafka producer and exchange settings. The `IngestionModule` is updated to bind `Namespace` to `ConfigArguments`, providing parsed configurations at runtime. Dependencies for Argparse4j are included in the `MODULE.bazel` and build files, and `ConfigArguments` supports key Kafka and exchange parameters with defaults and detailed help descriptions.