### PR TITLE
Refactor Kafka Properties to Use Argparse4j Namespace for Configuration

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -163,6 +163,7 @@ java_library(
     srcs = ["KafkaProperties.java"],
     deps = [
         "@maven//:com_google_inject_guice",
+        "@maven//:net_sourceforge_argparse4j_argparse4j",
     ],    
 )
 

--- a/src/main/java/com/verlumen/tradestream/ingestion/KafkaProperties.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/KafkaProperties.java
@@ -2,16 +2,17 @@ package com.verlumen.tradestream.ingestion;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
+import net.sourceforge.argparse4j.inf.Namespace;
 
 import java.util.Properties;
 import java.util.function.Supplier;
 
 final class KafkaProperties implements Supplier<Properties> {
-  private final Properties properties;
+  private final Namespace namespace;
 
   @Inject
-  KafkaProperties(Properties properties) {
-    this.properties = properties;
+  KafkaProperties(Namespace namespace) {
+    this.namespace = namespace;
   }
 
   @Override
@@ -20,13 +21,13 @@ final class KafkaProperties implements Supplier<Properties> {
     Properties kafkaProperties = new Properties();
 
     // Iterate over the input properties
-    for (String key : properties.stringPropertyNames()) {
+    for (String key : namespace.getAttrs().keySet()) {
       // Check if the key starts with the "kafka." prefix
       if (!key.startsWith("kafka.")) continue;
 
       // Remove the prefix and add the key-value pair to the new Properties object
       String newKey = key.substring("kafka.".length());
-      kafkaProperties.setProperty(newKey, properties.getProperty(key));
+      kafkaProperties.setProperty(newKey, namespace.get(key));
     }
 
     return kafkaProperties;

--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -70,6 +70,7 @@ java_test(
         "@maven//:com_google_inject_extensions_guice_testlib",
         "@maven//:com_google_inject_guice",
         "@maven//:com_google_truth_truth",
+        "@maven//:net_sourceforge_argparse4j_argparse4j",
         "//src/main/java/com/verlumen/tradestream/ingestion:kafka_properties",
     ],
 )

--- a/src/test/java/com/verlumen/tradestream/ingestion/KafkaPropertiesTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/KafkaPropertiesTest.java
@@ -20,7 +20,7 @@ import java.util.Properties;
 public class KafkaPropertiesTest {
   private static final Map<String, Object> INPUT_PROPERTIES = new HashMap<>();
 
-  @Bind private static final Namespace NAMESPACE = new Properties();
+  @Bind private static final Namespace NAMESPACE = new Properties(INPUT_PROPERTIES);
 
   @Inject private KafkaProperties supplier;
 

--- a/src/test/java/com/verlumen/tradestream/ingestion/KafkaPropertiesTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/KafkaPropertiesTest.java
@@ -14,6 +14,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 @RunWith(JUnit4.class)

--- a/src/test/java/com/verlumen/tradestream/ingestion/KafkaPropertiesTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/KafkaPropertiesTest.java
@@ -21,7 +21,7 @@ import java.util.Properties;
 public class KafkaPropertiesTest {
   private static final Map<String, Object> INPUT_PROPERTIES = new HashMap<>();
 
-  @Bind private static final Namespace NAMESPACE = new Properties(INPUT_PROPERTIES);
+  @Bind private static final Namespace NAMESPACE = new Namespace(INPUT_PROPERTIES);
 
   @Inject private KafkaProperties supplier;
 

--- a/src/test/java/com/verlumen/tradestream/ingestion/KafkaPropertiesTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/KafkaPropertiesTest.java
@@ -6,17 +6,21 @@ import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import net.sourceforge.argparse4j.inf.Namespace;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.util.HashMap;
 import java.util.Properties;
 
 @RunWith(JUnit4.class)
 public class KafkaPropertiesTest {
-  @Bind private static final Properties INPUT_PROPERTIES = new Properties();
+  private static final Map<String, Object> INPUT_PROPERTIES = new HashMap<>();
+
+  @Bind private static final Namespace NAMESPACE = new Properties();
 
   @Inject private KafkaProperties supplier;
 
@@ -33,9 +37,9 @@ public class KafkaPropertiesTest {
   @Test
   public void testExtractKafkaProperties_containsOnlyKafkaProperties() {
     // Arrange
-    INPUT_PROPERTIES.setProperty("kafka.bootstrap.servers", "localhost:9092");
-    INPUT_PROPERTIES.setProperty("kafka.client.id", "client-1");
-    INPUT_PROPERTIES.setProperty("application.name", "TestApp");
+    INPUT_PROPERTIES.put("kafka.bootstrap.servers", "localhost:9092");
+    INPUT_PROPERTIES.put("kafka.client.id", "client-1");
+    INPUT_PROPERTIES.put("application.name", "TestApp");
     
     // Act
     Properties kafkaProperties = supplier.get();
@@ -49,9 +53,9 @@ public class KafkaPropertiesTest {
   @Test
   public void testExtractKafkaProperties_removesKafkaPrefix() {
     // Arrange
-    INPUT_PROPERTIES.setProperty("kafka.bootstrap.servers", "localhost:9092");
-    INPUT_PROPERTIES.setProperty("kafka.client.id", "client-1");
-    INPUT_PROPERTIES.setProperty("application.name", "TestApp");
+    INPUT_PROPERTIES.put("kafka.bootstrap.servers", "localhost:9092");
+    INPUT_PROPERTIES.put("kafka.client.id", "client-1");
+    INPUT_PROPERTIES.put("application.name", "TestApp");
 
     // Act
     Properties kafkaProperties = supplier.get();
@@ -73,7 +77,7 @@ public class KafkaPropertiesTest {
   @Test
   public void testExtractKafkaProperties_noKafkaPropertiesReturnsEmptyProperties() {
     // Arrange
-    INPUT_PROPERTIES.setProperty("application.name", "TestApp");
+    INPUT_PROPERTIES.put("application.name", "TestApp");
 
     // Act
     Properties kafkaProperties = supplier.get();


### PR DESCRIPTION
This update refactors the `KafkaProperties` class to leverage Argparse4j's `Namespace` for managing configuration, replacing the previous use of `Properties`. The tests for `KafkaProperties` are updated to use a `Namespace` backed by a `HashMap`, aligning with the new implementation. Dependency updates for Argparse4j are added to the relevant build files, ensuring streamlined and dynamic argument parsing. This change enhances flexibility and integration with command-line argument configurations.