### PR TITLE
Add Candle Interval Configuration and TradeProcessor Integration

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -145,6 +145,7 @@ java_library(
         ":properties_provider",
         ":real_time_data_ingestion",
         ":streaming_exchange_provider",
+        ":trade_processor",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/ingestion/ConfigArguments.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/ConfigArguments.java
@@ -31,6 +31,11 @@ abstract class ConfigArguments implements Provider<Namespace> {
       .defaultHelp(true)
       .description("Configuration for Kafka producer and exchange settings");
 
+    parser.addArgument("--candleIntervalSeconds")
+          .type(Integer.class)
+          .setDefault(60)
+          .help("Candle interval in seconds");
+
     // Kafka configuration
     parser.addArgument("--kafka.bootstrap.servers")
       .setDefault("localhost:9092")

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -4,6 +4,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
 import com.google.inject.TypeLiteral;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import info.bitrich.xchangestream.core.StreamingExchange;
@@ -35,5 +36,11 @@ abstract class IngestionModule extends AbstractModule {
     install(new FactoryModuleBuilder()
         .implement(CandlePublisher.class, CandlePublisherImpl.class)
         .build(CandlePublisher.Factory.class));
+  }
+
+  @Provides
+  TradeProcessor provideTradeProcessor(Namespace namespace) {
+    long candleIntervalMillis = namespace.getInt("candleIntervalSeconds") * 1000;
+    return TradeProcessor.create(candleIntervalMillis);
   }
 }


### PR DESCRIPTION
This update introduces a configurable `candleIntervalSeconds` argument in `ConfigArguments`, allowing users to specify the candle interval duration dynamically. The `IngestionModule` is updated to provide a `TradeProcessor` instance based on the parsed `candleIntervalSeconds`. The build file now includes a dependency on `trade_processor` to integrate this functionality seamlessly. These changes enhance flexibility and improve configuration for real-time trading data processing.