### PR TITLE
Improve Candle Configuration and Real-Time Data Ingestion in TradeStream

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/ConfigArguments.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/ConfigArguments.java
@@ -36,6 +36,10 @@ abstract class ConfigArguments implements Provider<Namespace> {
           .setDefault(60)
           .help("Candle interval in seconds");
 
+    parser.addArgument("--candlePublisherTopic")
+          .setDefault("candles") 
+          .help("Kafka topic to publish candle data");
+
     // Kafka configuration
     parser.addArgument("--kafka.bootstrap.servers")
       .setDefault("localhost:9092")

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -39,15 +39,15 @@ abstract class IngestionModule extends AbstractModule {
   }
 
   @Provides
-  TradeProcessor provideCandleManager(Namespace namespace) {
+  TradeProcessor provideCandleManager(Namespace namespace, CandlePublisher candlePublisher) {
     long candleIntervalMillis = namespace.getInt("candleIntervalSeconds") * 1000;
     return TradeProcessor.create(candleIntervalMillis);
   }
 
   @Provides
-  TradeProcessor provideCandlePublisher(Namespace namespace) {
-    long candleIntervalMillis = namespace.getInt("candleIntervalSeconds") * 1000;
-    return TradeProcessor.create(candleIntervalMillis);
+  TradeProcessor provideCandlePublisher(Namespace namespace, CandlePublisher.Factory candlePublisherFactory) {
+    String topic = namespace.getString("candlePublisherTopic");
+    return candlePublisherFactory.create(topic);
   }
 
   @Provides

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -39,6 +39,18 @@ abstract class IngestionModule extends AbstractModule {
   }
 
   @Provides
+  TradeProcessor provideCandleManager(Namespace namespace) {
+    long candleIntervalMillis = namespace.getInt("candleIntervalSeconds") * 1000;
+    return TradeProcessor.create(candleIntervalMillis);
+  }
+
+  @Provides
+  TradeProcessor provideCandlePublisher(Namespace namespace) {
+    long candleIntervalMillis = namespace.getInt("candleIntervalSeconds") * 1000;
+    return TradeProcessor.create(candleIntervalMillis);
+  }
+
+  @Provides
   TradeProcessor provideTradeProcessor(Namespace namespace) {
     long candleIntervalMillis = namespace.getInt("candleIntervalSeconds") * 1000;
     return TradeProcessor.create(candleIntervalMillis);

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -39,7 +39,7 @@ abstract class IngestionModule extends AbstractModule {
   }
 
   @Provides
-  TradeProcessor provideCandleManager(Namespace namespace, CandlePublisher candlePublisher, CandleManager.Factory candleMangerFactory) {
+  CandleManager provideCandleManager(Namespace namespace, CandlePublisher candlePublisher, CandleManager.Factory candleMangerFactory) {
     long candleIntervalMillis = namespace.getInt("candleIntervalSeconds") * 1000;
     return candleMangerFactory.create(candleIntervalMillis, candlePublisher);
   }

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -39,13 +39,13 @@ abstract class IngestionModule extends AbstractModule {
   }
 
   @Provides
-  TradeProcessor provideCandleManager(Namespace namespace, CandlePublisher candlePublisher) {
+  TradeProcessor provideCandleManager(Namespace namespace, CandlePublisher candlePublisher, CandleManager.Factory candleMangerFactory) {
     long candleIntervalMillis = namespace.getInt("candleIntervalSeconds") * 1000;
-    return TradeProcessor.create(candleIntervalMillis);
+    return candleMangerFactory.create(candleIntervalMillis, candlePublisher);
   }
 
   @Provides
-  TradeProcessor provideCandlePublisher(Namespace namespace, CandlePublisher.Factory candlePublisherFactory) {
+  CandlePublisher provideCandlePublisher(Namespace namespace, CandlePublisher.Factory candlePublisherFactory) {
     String topic = namespace.getString("candlePublisherTopic");
     return candlePublisherFactory.create(topic);
   }

--- a/src/main/java/com/verlumen/tradestream/ingestion/KafkaProperties.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/KafkaProperties.java
@@ -27,7 +27,7 @@ final class KafkaProperties implements Supplier<Properties> {
 
       // Remove the prefix and add the key-value pair to the new Properties object
       String newKey = key.substring("kafka.".length());
-      kafkaProperties.setProperty(newKey, namespace.get(key));
+      kafkaProperties.setProperty(newKey, namespace.getString(key));
     }
 
     return kafkaProperties;

--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestion.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestion.java
@@ -13,8 +13,8 @@ final class RealTimeDataIngestion implements MarketDataIngestion {
     
     @Inject
     RealTimeDataIngestion(
-        CandleManager.Factory candleManager,
-        CandlePublisher.Factory candlePublisher,
+        CandleManager candleManager,
+        CandlePublisher candlePublisher,
         Provider<StreamingExchange> exchange,
         TradeProcessor tradeProcessor
     ) {

--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestion.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestion.java
@@ -6,20 +6,20 @@ import info.bitrich.xchangestream.core.StreamingExchange;
 import info.bitrich.xchangestream.core.StreamingMarketDataService;
 
 final class RealTimeDataIngestion implements MarketDataIngestion {
-    private final CandleManager.Factory candleManagerFactory;
-    private final CandlePublisher.Factory candlePublisherFactory;
+    private final CandleManager candleManager;
+    private final CandlePublisher candlePublisher;
     private final Provider<StreamingExchange> exchange;
     private final TradeProcessor tradeProcessor;
     
     @Inject
     RealTimeDataIngestion(
-        CandleManager.Factory candleManagerFactory,
-        CandlePublisher.Factory candlePublisherFactory,
+        CandleManager.Factory candleManager,
+        CandlePublisher.Factory candlePublisher,
         Provider<StreamingExchange> exchange,
         TradeProcessor tradeProcessor
     ) {
-        this.candleManagerFactory = candleManagerFactory;
-        this.candlePublisherFactory = candlePublisherFactory;
+        this.candleManager = candleManager;
+        this.candlePublisher = candlePublisher;
         this.exchange = exchange;
         this.tradeProcessor = tradeProcessor;
     }


### PR DESCRIPTION
This update introduces significant enhancements to the TradeStream ingestion module:  

1. **Configurable Candle Publisher and Manager**:  
   - Added a new `--candlePublisherTopic` argument for specifying the Kafka topic to publish candle data.
   - Updated `IngestionModule` to provide a `CandleManager` and `CandlePublisher` configured dynamically from the namespace.

2. **Namespace Integration in KafkaProperties**:  
   - Fixed namespace integration to retrieve Kafka-specific properties using `getString` for type safety.

3. **Simplified RealTimeDataIngestion**:  
   - Replaced factories with direct injection of `CandleManager` and `CandlePublisher`, simplifying the class and aligning it with the dependency injection best practices.

These changes improve runtime flexibility and ensure easier customization of candle intervals and publishing topics for real-time market data ingestion.