### PR TITLE
Enhance RealTimeDataIngestion with Subscription and Resource Cleanup

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -214,7 +214,7 @@ java_library(
     srcs = ["RealTimeDataIngestion.java"],
     deps = [
         "@maven//:com_google_inject_guice",
-        "@maven//:io_reactivex_rxjava3_rxjava"
+        "@maven//:io_reactivex_rxjava3_rxjava",
         "@maven//:org_knowm_xchange_xchange_core",
         "@maven//:org_knowm_xchange_xchange_stream_core",
         ":candle_manager",

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -214,6 +214,7 @@ java_library(
     srcs = ["RealTimeDataIngestion.java"],
     deps = [
         "@maven//:com_google_inject_guice",
+        "@maven//:io_reactivex_rxjava3_rxjava"
         "@maven//:org_knowm_xchange_xchange_core",
         "@maven//:org_knowm_xchange_xchange_stream_core",
         ":candle_manager",

--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestion.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestion.java
@@ -6,6 +6,8 @@ import info.bitrich.xchangestream.core.StreamingExchange;
 import info.bitrich.xchangestream.core.StreamingMarketDataService;
 import io.reactivex.rxjava3.disposables.Disposable;
 
+import java.util.List;
+
 final class RealTimeDataIngestion implements MarketDataIngestion {
     private final CandleManager candleManager;
     private final CandlePublisher candlePublisher;

--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestion.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestion.java
@@ -4,6 +4,7 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 import info.bitrich.xchangestream.core.StreamingExchange;
 import info.bitrich.xchangestream.core.StreamingMarketDataService;
+import io.reactivex.rxjava3.disposables.Disposable;
 
 final class RealTimeDataIngestion implements MarketDataIngestion {
     private final CandleManager candleManager;

--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestion.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestion.java
@@ -28,7 +28,7 @@ final class RealTimeDataIngestion implements MarketDataIngestion {
         this.candleManager = candleManager;
         this.candlePublisher = candlePublisher;
         this.exchange = exchange;
-        this.subscriptions =  = new ArrayList<>();
+        this.subscriptions = new ArrayList<>();
         this.tradeProcessor = tradeProcessor;
     }
 

--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestion.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestion.java
@@ -6,6 +6,7 @@ import info.bitrich.xchangestream.core.StreamingExchange;
 import info.bitrich.xchangestream.core.StreamingMarketDataService;
 import io.reactivex.rxjava3.disposables.Disposable;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Timer;
 

--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestion.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestion.java
@@ -9,6 +9,7 @@ final class RealTimeDataIngestion implements MarketDataIngestion {
     private final CandleManager candleManager;
     private final CandlePublisher candlePublisher;
     private final Provider<StreamingExchange> exchange;
+    private final List<Disposable> subscriptions;
     private final TradeProcessor tradeProcessor;
     
     @Inject
@@ -21,6 +22,7 @@ final class RealTimeDataIngestion implements MarketDataIngestion {
         this.candleManager = candleManager;
         this.candlePublisher = candlePublisher;
         this.exchange = exchange;
+        this.subscriptions =  = new ArrayList<>();
         this.tradeProcessor = tradeProcessor;
     }
 


### PR DESCRIPTION
This update improves the `RealTimeDataIngestion` class by:  
1. Adding a `subscriptions` list to manage `Disposable` subscriptions for RxJava streams.  
2. Introducing a `thinMarketTimer` for additional timed operations.  
3. Enhancing the `shutdown` method to:  
   - Dispose of all active subscriptions.  
   - Cancel the `thinMarketTimer` if initialized.  
   - Disconnect the `StreamingExchange` gracefully.  
   - Close the `CandlePublisher` resource.  

Dependency updates in the `BUILD` file include adding RxJava to support the new functionality. These changes ensure robust resource management and improve the reliability of the ingestion lifecycle.