### PR TITLE
Add Support for Currency Pair Metadata and Suppliers 

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -106,6 +106,7 @@ java_library(
     name = "currency_pair_supplier",
     srcs = ["CurrencyPairSupplier.java"],
     deps = [
+        "@maven//:com_google_guava_guava",
         ":currency_pair_metadata",
     ],
 )

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -93,6 +93,23 @@ container_structure_test(
     tags = ["requires-docker"],
 )
 
+java_library(
+    name = "currency_pair_metadata",
+    srcs = ["CurrencyPairMetadata.java"],
+    deps = [
+        "@maven//:org_knowm_xchange_xchange_core",
+        "//:autovalue",
+    ],
+)
+
+java_library(
+    name = "currency_pair_supplier",
+    srcs = ["CurrencyPairSupplier.java"],
+    deps = [
+        ":currency_pair_metadata",
+    ],
+)
+
 oci_image(
     name = "image",
     base = "@openjdk_java",

--- a/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairMetadata.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairMetadata.java
@@ -1,0 +1,31 @@
+package com.verlumen.tradestream.ingestion;
+
+import com.google.auto.value.AutoValue;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.currency.CurrencyPair;
+
+import java.math.BigDecimal;
+
+@AutoValue
+abstract class CurrencyPairMetadata {
+  static CurrencyPairMetadata create(String pair, BigDecimal marketCapValue) {
+    CurrencyPair currencyPair = new CurrencyPair(pair);
+    MarketCap marketCap = MarketCap.create(marketCapValue, Currency.USD);
+    return new AutoValue_CurrencyPairMetadata(currencyPair);
+  }
+
+  abstract CurrencyPair currencyPair();
+
+  abstract BigDecimal marketCapIn();
+
+  @AutoValue
+  abstract static class MarketCap {
+    private static MarketCap create(BigDecimal value, Currency currency) {
+      return new AutoValue_CurrencyPairMetadata_MarketCap();
+    }
+
+    abstract BigDecimal value();
+
+    abstract Currency currency();
+  }
+}

--- a/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairMetadata.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairMetadata.java
@@ -16,7 +16,7 @@ abstract class CurrencyPairMetadata {
 
   abstract CurrencyPair currencyPair();
 
-  abstract BigDecimal marketCapIn();
+  abstract MarketCap marketCap();
 
   @AutoValue
   abstract static class MarketCap {

--- a/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairMetadata.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairMetadata.java
@@ -11,7 +11,7 @@ abstract class CurrencyPairMetadata {
   static CurrencyPairMetadata create(String pair, BigDecimal marketCapValue) {
     CurrencyPair currencyPair = new CurrencyPair(pair);
     MarketCap marketCap = MarketCap.create(marketCapValue, Currency.USD);
-    return new AutoValue_CurrencyPairMetadata(currencyPair);
+    return new AutoValue_CurrencyPairMetadata(currencyPair, marketCap);
   }
 
   abstract CurrencyPair currencyPair();
@@ -21,7 +21,7 @@ abstract class CurrencyPairMetadata {
   @AutoValue
   abstract static class MarketCap {
     private static MarketCap create(BigDecimal value, Currency currency) {
-      return new AutoValue_CurrencyPairMetadata_MarketCap();
+      return new AutoValue_CurrencyPairMetadata_MarketCap(value, currency);
     }
 
     abstract BigDecimal value();

--- a/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairSupplier.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairSupplier.java
@@ -1,0 +1,5 @@
+package com.verlumen.tradestream.ingestion;
+
+import java.util.function.Supplier;
+
+interface CurrencyPairSupplier extends Supplier<ImmutableSet<CurrencyPairMetadata>> {}

--- a/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairSupplier.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairSupplier.java
@@ -1,5 +1,7 @@
 package com.verlumen.tradestream.ingestion;
 
+import com.google.common.collect.ImmutableSet;
+
 import java.util.function.Supplier;
 
 interface CurrencyPairSupplier extends Supplier<ImmutableSet<CurrencyPairMetadata>> {}


### PR DESCRIPTION
This update introduces the following features to enhance currency pair management in the TradeStream ingestion module:  

1. **CurrencyPairMetadata Class**:  
   - Implements metadata for currency pairs, including a `MarketCap` nested class for storing value and currency information.
   - Uses `AutoValue` for immutability and easy instantiation.  

2. **CurrencyPairSupplier Interface**:  
   - Defines a supplier for a set of `CurrencyPairMetadata` objects, leveraging Guava's `ImmutableSet` for efficient collection management.  

3. **Build File Updates**:  
   - Adds two new library targets, `currency_pair_metadata` and `currency_pair_supplier`, to the `BUILD` file.  
   - Includes dependencies for `xchange_core`, `AutoValue`, and `Guava` to support the new classes.  

These changes enable efficient handling of currency pair data, including market capitalization, enhancing data ingestion and processing capabilities.