### PR TITLE
Add Currency Pair Supplier Implementation and Integration in RealTimeDataIngestion  

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -237,6 +237,7 @@ java_library(
         "@maven//:org_knowm_xchange_xchange_stream_core",
         ":candle_manager",
         ":candle_publisher",
+        ":currency_pair_supplier",
         ":market_data_ingestion",
         ":trade_processor",
     ],

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -172,6 +172,8 @@ java_library(
         ":candle_publisher",
         ":candle_publisher_impl",
         ":config_arguments",
+        ":currency_pair_supplier",
+        ":currency_pair_supplier_impl",
         ":kafka_producer_provider",
         ":market_data_ingestion",
         ":properties_provider",

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -111,6 +111,16 @@ java_library(
     ],
 )
 
+java_library(
+    name = "currency_pair_supplier_impl",
+    srcs = ["CurrencyPairSupplierImpl.java"],
+    deps = [
+        "@maven//:com_google_guava_guava",
+        ":currency_pair_metadata",
+        ":currency_pair_supplier",
+    ],
+)
+
 oci_image(
     name = "image",
     base = "@openjdk_java",

--- a/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairSupplierImpl.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairSupplierImpl.java
@@ -1,0 +1,10 @@
+package com.verlumen.tradestream.ingestion;
+
+import com.google.common.collect.ImmutableSet;
+
+final class CurrencyPairSupplierImpl implements CurrencyPairSupplier {
+  @Override
+  public ImmutableSet<CurrencyPairMetadata> get() {
+    throw new java.lang.UnsupportedOperationException(); 
+  }
+}

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -28,6 +28,7 @@ abstract class IngestionModule extends AbstractModule {
     bind(Properties.class).toProvider(PropertiesProvider.class);
     bind(StreamingExchange.class).toProvider(StreamingExchangeProvider.class);
 
+    bind(CurrencyPairSupplier.class).to(CurrencyPairSupplierImpl.class);
     bind(MarketDataIngestion.class).to(RealTimeDataIngestion.class);
 
     install(new FactoryModuleBuilder()

--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestion.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestion.java
@@ -13,6 +13,7 @@ import java.util.Timer;
 final class RealTimeDataIngestion implements MarketDataIngestion {
     private final CandleManager candleManager;
     private final CandlePublisher candlePublisher;
+    private final CurrencyPairSupplier currencyPairSupplier;
     private final Provider<StreamingExchange> exchange;
     private final List<Disposable> subscriptions;
     private final TradeProcessor tradeProcessor;
@@ -22,11 +23,13 @@ final class RealTimeDataIngestion implements MarketDataIngestion {
     RealTimeDataIngestion(
         CandleManager candleManager,
         CandlePublisher candlePublisher,
+        CurrencyPairSupplier currencyPairSupplier,
         Provider<StreamingExchange> exchange,
         TradeProcessor tradeProcessor
     ) {
         this.candleManager = candleManager;
         this.candlePublisher = candlePublisher;
+        this.currencyPairSupplier = currencyPairSupplier;
         this.exchange = exchange;
         this.subscriptions = new ArrayList<>();
         this.tradeProcessor = tradeProcessor;


### PR DESCRIPTION
This update enhances the TradeStream ingestion module with the following additions:  

1. **CurrencyPairSupplierImpl Class**:  
   - Implements the `CurrencyPairSupplier` interface.
   - Provides a placeholder implementation with `UnsupportedOperationException`, ready for customization.  

2. **Integration in RealTimeDataIngestion**:  
   - Adds `CurrencyPairSupplier` as a dependency in the `RealTimeDataIngestion` class for supplying currency pair metadata.  

3. **Build File Enhancements**:  
   - Adds the `currency_pair_supplier_impl` target to the build file with dependencies on `Guava`, `currency_pair_metadata`, and `currency_pair_supplier`.  
   - Updates the `real_time_data_ingestion` target to depend on `currency_pair_supplier`.  

These changes prepare the system for future enhancements involving dynamic currency pair management while maintaining extensibility and modularity.