### PR TITLE
Update `IngestionModule` to Bind `Timer` via Provider

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -9,7 +9,9 @@ import com.google.inject.TypeLiteral;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import info.bitrich.xchangestream.core.StreamingExchange;
 import net.sourceforge.argparse4j.inf.Namespace;
+
 import java.util.Properties;
+import java.util.Timer;
 
 @AutoValue
 abstract class IngestionModule extends AbstractModule {

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -28,6 +28,7 @@ abstract class IngestionModule extends AbstractModule {
 
     bind(CurrencyPairSupplier.class).to(CurrencyPairSupplierImpl.class);
     bind(MarketDataIngestion.class).to(RealTimeDataIngestion.class);
+    bind(Timer.class).toProvider(Timer::new);
 
     install(new FactoryModuleBuilder()
         .implement(CandleManager.class, CandleManagerImpl.class)
@@ -54,7 +55,7 @@ abstract class IngestionModule extends AbstractModule {
     String runModeName = namespace.getString("runMode").toUpperCase();
     return RunMode.valueOf(runModeName);
   }
- 
+
   @Provides
   TradeProcessor provideTradeProcessor(Namespace namespace) {
     long candleIntervalMillis = namespace.getInt("candleIntervalSeconds") * 1000;


### PR DESCRIPTION
This change modifies the `IngestionModule` to include a binding for the `Timer` class. The `Timer` instances are now provided using a `Provider`, ensuring a clean and centralized configuration for creating `Timer` objects in the dependency injection framework.  

### Key Changes:  

1. **`Timer` Binding:**
   - Added `bind(Timer.class).toProvider(Timer::new);` to the `configure()` method.
   - This ensures that `Timer` instances are created and injected properly when needed.

2. **Whitespace Adjustment:**
   - Minor formatting updates for code cleanliness.

### Benefits:  
- Centralized and explicit configuration for `Timer` instances simplifies dependency injection.
- Improves modularity and flexibility for managing `Timer` objects in the application.  
- Adheres to best practices in dependency injection by avoiding direct instantiation within the code.