### PR TITLE
Add Trade Conversion Method to RealTimeDataIngestion

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestion.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestion.java
@@ -56,6 +56,17 @@ final class RealTimeDataIngestion implements MarketDataIngestion {
         candlePublisher.close();
     }
 
+    private Trade convertTrade(org.knowm.xchange.dto.marketdata.Trade xchangeTrade, String pair) {
+        return Trade.newBuilder()
+            .setTimestamp(xchangeTrade.getTimestamp().getTime())
+            .setExchange(exchange.getExchangeSpecification().getExchangeName())
+            .setCurrencyPair(pair)
+            .setPrice(xchangeTrade.getPrice().doubleValue())
+            .setVolume(xchangeTrade.getOriginalAmount().doubleValue())
+            .setTradeId(xchangeTrade.getId() != null ? xchangeTrade.getId() : UUID.randomUUID().toString())
+            .build();
+    }
+
     private void onTrade(Trade trade) {
         if (!tradeProcessor.isProcessed(trade)) {
             candleManager.processTrade(trade);

--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestion.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestion.java
@@ -11,6 +11,7 @@ import io.reactivex.rxjava3.disposables.Disposable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Timer;
+import java.util.UUID;
 
 final class RealTimeDataIngestion implements MarketDataIngestion {
     private final CandleManager candleManager;

--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestion.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestion.java
@@ -59,7 +59,7 @@ final class RealTimeDataIngestion implements MarketDataIngestion {
     private Trade convertTrade(org.knowm.xchange.dto.marketdata.Trade xchangeTrade, String pair) {
         return Trade.newBuilder()
             .setTimestamp(xchangeTrade.getTimestamp().getTime())
-            .setExchange(exchange.getExchangeSpecification().getExchangeName())
+            .setExchange(exchange.get().getExchangeSpecification().getExchangeName())
             .setCurrencyPair(pair)
             .setPrice(xchangeTrade.getPrice().doubleValue())
             .setVolume(xchangeTrade.getOriginalAmount().doubleValue())


### PR DESCRIPTION
This update introduces a `convertTrade` method in the `RealTimeDataIngestion` class to streamline the conversion of `org.knowm.xchange.dto.marketdata.Trade` objects into `Trade` protobuf objects. This addition simplifies the processing of raw trade data and ensures consistency when integrating data from different exchanges.

---

### Key Changes:

1. **New Method: `convertTrade`**
   - Converts `xchangeTrade` objects from the XChange library to `Trade` protobuf objects.
   - Includes mapping for:
     - **Timestamp**: Extracts the trade timestamp.
     - **Exchange**: Sets the exchange name from the specification.
     - **Currency Pair**: Uses the provided currency pair string.
     - **Price**: Converts the trade price to a double.
     - **Volume**: Converts the trade volume to a double.
     - **Trade ID**: Uses the provided ID or generates a UUID if no ID is present.

2. **UUID Integration for Missing Trade IDs:**
   - Ensures uniqueness for trades lacking an explicit identifier by generating a UUID.

3. **Encapsulation:**
   - Keeps `convertTrade` private, limiting its use to the `RealTimeDataIngestion` class.

4. **Usage Context:**
   - Prepares trades for further processing by downstream components like `candleManager` or `tradeProcessor`.

---

### Benefits:

- **Improved Data Handling:**
  - Centralizes trade conversion logic, reducing duplication and potential errors.

- **Flexibility with Exchange Data:**
  - Accommodates trades without IDs by generating a UUID, ensuring seamless processing.

- **Enhanced Readability and Maintainability:**
  - Clearly defines how external trade data is converted into the internal `Trade` representation.

This update improves the handling of market data ingestion by introducing a robust method for transforming raw exchange trades into actionable data.