### PR TITLE
Refactor `shutdown` Method in `RealTimeDataIngestion`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestion.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestion.java
@@ -48,9 +48,7 @@ final class RealTimeDataIngestion implements MarketDataIngestion {
 
     @Override
     public void shutdown() {
-        for (Disposable subscription : subscriptions) {
-            subscription.dispose();
-        }
+        subscriptions.forEach(Disposable::dispose);
         if (thinMarketTimer != null) {
             thinMarketTimer.cancel();
         }


### PR DESCRIPTION
Simplifies the `shutdown` method in `RealTimeDataIngestion` by replacing the `for` loop with a `forEach` to dispose of subscriptions. Ensures the `ThinMarketTimer` cancellation remains intact for proper cleanup. Enhances readability and maintains existing functionality.