### PR TITLE
Implement Trade Stream Subscription in `RealTimeDataIngestion`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestion.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestion.java
@@ -89,5 +89,11 @@ final class RealTimeDataIngestion implements MarketDataIngestion {
             .subscribe(trade -> handleTrade(trade, currencyPair.toString()));
     }
 
-    private void subscribeToTradeStreams() {}
+    private void subscribeToTradeStreams() {
+        currencyPairSupplier
+            .currencyPairs()
+            .stream()
+            .map(this::subscribeToTradeStream)
+            .forEach(subscriptions::add);
+    }
 }


### PR DESCRIPTION
Adds functionality to `subscribeToTradeStreams` in `RealTimeDataIngestion`. This method now subscribes to all currency pairs provided by the `CurrencyPairSupplier` by mapping each pair to a `Disposable` subscription and storing them in the `subscriptions` list. Improves trade stream management and ensures all relevant streams are handled dynamically.