### PR TITLE
Update Visibility of MarketData Protobuf Libraries

### DIFF
--- a/protos/BUILD
+++ b/protos/BUILD
@@ -7,5 +7,5 @@ proto_library(
 java_proto_library(
     name = "marketdata_java_proto",
     deps = [":marketdata_proto"],
-    visibility = ["//:__subpackages__"],
+    visibility = ["//..."],
 )

--- a/protos/BUILD
+++ b/protos/BUILD
@@ -1,11 +1,11 @@
 proto_library(
     name = "marketdata_proto",
     srcs = ["marketdata.proto"],
-    visibility = ["//visibility:public"],
+    visibility = ["//visibility:private"],
 )
 
 java_proto_library(
     name = "marketdata_java_proto",
     deps = [":marketdata_proto"],
-    visibility = ["//visibility:public"],
+    visibility = ["//:__subpackages__"],
 )

--- a/protos/BUILD
+++ b/protos/BUILD
@@ -7,5 +7,5 @@ proto_library(
 java_proto_library(
     name = "marketdata_java_proto",
     deps = [":marketdata_proto"],
-    visibility = ["//..."],
+    visibility = ["//:__subpackages__"],
 )


### PR DESCRIPTION
This update modifies the visibility of the `marketdata_proto` and `marketdata_java_proto` Protobuf libraries to restrict access. The `marketdata_proto` library is now private, and the `marketdata_java_proto` library is limited to subpackages using `//:__subpackages__`. These changes enhance encapsulation and maintain better control over library access within the codebase.