### PR TITLE
Add ProductSubscription to RealTimeDataIngestionImpl for Streamlined Exchange Connectivity

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -7,6 +7,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.TypeLiteral;
 import org.apache.kafka.clients.producer.KafkaProducer;
+import info.bitrich.xchangestream.core.ProductSubscription;
 import info.bitrich.xchangestream.core.StreamingExchange;
 import net.sourceforge.argparse4j.inf.Namespace;
 

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -54,6 +54,14 @@ abstract class IngestionModule extends AbstractModule {
     return candlePublisherFactory.create(topic);
   }
 
+
+  @Provides
+  ProductSubscription provideProductSubscription() {
+    return ProductSubscription
+      .create()
+      .build();
+  }
+  
   @Provides
   RunMode provideRunMode(Namespace namespace) {
     String runModeName = namespace.getString("runMode").toUpperCase();

--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
@@ -18,6 +18,7 @@ final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
     private final CandlePublisher candlePublisher;
     private final CurrencyPairSupplier currencyPairSupplier;
     private final Provider<StreamingExchange> exchange;
+    private final ProductSubscription productSubscription;
     private final List<Disposable> subscriptions;
     private final Provider<ThinMarketTimer> thinMarketTimer;
     private final TradeProcessor tradeProcessor;
@@ -28,6 +29,7 @@ final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
         CandlePublisher candlePublisher,
         CurrencyPairSupplier currencyPairSupplier,
         Provider<StreamingExchange> exchange,
+        ProductSubscription productSubscription,
         Provider<ThinMarketTimer> thinMarketTimer,
         TradeProcessor tradeProcessor
     ) {
@@ -35,6 +37,7 @@ final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
         this.candlePublisher = candlePublisher;
         this.currencyPairSupplier = currencyPairSupplier;
         this.exchange = exchange;
+        this.productSubscription = productSubscription;
         this.subscriptions = new ArrayList<>();
         this.thinMarketTimer = thinMarketTimer;
         this.tradeProcessor = tradeProcessor;

--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
@@ -3,6 +3,7 @@ package com.verlumen.tradestream.ingestion;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.verlumen.tradestream.marketdata.Trade;
+import info.bitrich.xchangestream.core.ProductSubscription;
 import info.bitrich.xchangestream.core.StreamingExchange;
 import info.bitrich.xchangestream.core.StreamingMarketDataService;
 import io.reactivex.rxjava3.core.Observable;
@@ -45,7 +46,7 @@ final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
 
     @Override
     public void start() {
-        exchange.get().connect().blockingAwait();
+        exchange.get().connect(productSubscription).blockingAwait();
         subscribeToTradeStreams();
         thinMarketTimer.get().start();
     }


### PR DESCRIPTION
This update enhances the `RealTimeDataIngestionImpl` class by integrating `ProductSubscription` for more granular control over streaming subscriptions. Key changes include:

- Adding a `provideProductSubscription` method in the `IngestionModule` to supply a default `ProductSubscription` instance.
- Updating `RealTimeDataIngestionImpl` to inject and utilize `ProductSubscription` when connecting to the exchange.
- Modifying the `start` method in `RealTimeDataIngestionImpl` to connect using the `ProductSubscription` instance.

These changes improve the flexibility and scalability of subscription handling, making it easier to define and manage specific product streams for real-time data ingestion.