### PR TITLE
Enhance ProductSubscription Provider to Include Currency Pairs

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -57,10 +57,10 @@ abstract class IngestionModule extends AbstractModule {
 
 
   @Provides
-  ProductSubscription provideProductSubscription() {
-    return ProductSubscription
-      .create()
-      .build();
+  ProductSubscription provideProductSubscription(CurrencyPairSupplier currencyPairSupplier) {
+    ProductSubscription.ProductSubscriptionBuilder builder = ProductSubscription.create();
+    currencyPairSupplier.currencyPairs().forEach(builder::addTrades);
+    return builder.build();
   }
   
   @Provides

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -1,4 +1,4 @@
-package com.verlumen.tradestream.ingestion;
+zpackage com.verlumen.tradestream.ingestion;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
@@ -57,9 +57,9 @@ abstract class IngestionModule extends AbstractModule {
 
 
   @Provides
-  ProductSubscription provideProductSubscription(CurrencyPairSupplier currencyPairSupplier) {
+  ProductSubscription provideProductSubscription(CurrencyPairSupply currencyPairSupply) {
     ProductSubscription.ProductSubscriptionBuilder builder = ProductSubscription.create();
-    currencyPairSupplier.currencyPairs().forEach(builder::addTrades);
+    currencyPairSupply.currencyPairs().forEach(builder::addTrades);
     return builder.build();
   }
   

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -1,4 +1,4 @@
-zpackage com.verlumen.tradestream.ingestion;
+package com.verlumen.tradestream.ingestion;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
@@ -17,7 +17,7 @@ import java.util.UUID;
 final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
     private final CandleManager candleManager;
     private final CandlePublisher candlePublisher;
-    private final CurrencyPairSupplier currencyPairSupplier;
+    private final Provider<CurrencyPairSupplier> currencyPairSupplier;
     private final Provider<StreamingExchange> exchange;
     private final ProductSubscription productSubscription;
     private final List<Disposable> subscriptions;
@@ -28,7 +28,7 @@ final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
     RealTimeDataIngestionImpl(
         CandleManager candleManager,
         CandlePublisher candlePublisher,
-        CurrencyPairSupplier currencyPairSupplier,
+        Provider<CurrencyPairSupplier> currencyPairSupplier,
         Provider<StreamingExchange> exchange,
         ProductSubscription productSubscription,
         Provider<ThinMarketTimer> thinMarketTimer,
@@ -92,6 +92,7 @@ final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
 
     private void subscribeToTradeStreams() {
         currencyPairSupplier
+            .get()
             .currencyPairs()
             .stream()
             .map(this::subscribeToTradeStream)


### PR DESCRIPTION
This update refines the `provideProductSubscription` method in the `IngestionModule` to dynamically include currency pairs from `CurrencyPairSupply`. Key changes include:  

- **Dynamic Subscription Creation:** The `ProductSubscription` now utilizes a builder pattern to add trade subscriptions for all currency pairs supplied by `CurrencyPairSupply`.  
- **Enhanced Flexibility:** Automatically integrates available currency pairs into the subscription, reducing manual configuration and improving scalability.  

This improvement streamlines the creation of `ProductSubscription`, ensuring it reflects the current set of currency pairs dynamically.