### PR TITLE
Add HttpClient Interface for HTTP GET Requests 

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -131,6 +131,11 @@ genrule(
     toolchains = ["@jq_toolchains//:resolved_toolchain"],
 )
 
+java_library(
+    name = "http_client",
+    srcs = ["HttpClient.java"],
+)
+
 oci_image(
     name = "image",
     base = "@openjdk_java",

--- a/src/main/java/com/verlumen/tradestream/ingestion/HttpClient.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/HttpClient.java
@@ -1,0 +1,8 @@
+package com.verlumen.tradestream.ingestion;
+
+import java.io.IOException;
+import java.util.Map;
+
+interface HttpClient {
+    String get(String url, Map<String, String> headers) throws IOException;
+}


### PR DESCRIPTION
This update introduces a new `HttpClient` interface to standardize HTTP GET operations within the application. Key features include:  

- A `get` method accepting a URL and headers, designed to handle HTTP GET requests.  
- Capability to throw `IOException` for robust error handling.  
- A new build target, `http_client`, is added to manage the interface in the Bazel configuration.  

This foundational update enables flexible and reusable HTTP operations across the codebase.