### PR TITLE
Introduce CurrencyPairSupply for Managing Currency Pair Metadata

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -130,6 +130,7 @@ java_library(
         "@maven//:com_google_guava_guava",
         "@maven//:org_knowm_xchange_xchange_core",        
         "//:autovalue",
+        ":currency_pair_metadata",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -125,7 +125,7 @@ java_library(
 
 java_library(
     name = "currency_pair_supply",
-    name = "CurrencyPairSupply.java",
+    srcs = ["CurrencyPairSupply.java"],
     deps = [
         "@maven//:com_google_guava_guava",
         "@maven//:org_knowm_xchange_xchange_core",        

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -123,6 +123,16 @@ java_library(
     ],
 )
 
+java_library(
+    name = "currency_pair_supply",
+    name = "CurrencyPairSupply.java",
+    deps = [
+        "@maven//:com_google_guava_guava",
+        "@maven//:org_knowm_xchange_xchange_core",        
+        "//:autovalue",
+    ],
+)
+
 genrule(
     name = "hash",
     srcs = [":index"],

--- a/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairSupply.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairSupply.java
@@ -7,7 +7,7 @@ import com.google.common.collect.ImmutableList;
 import org.knowm.xchange.currency.CurrencyPair;
 
 @AutoValue
-abstract CurrencyPairSupply {
+abstract class CurrencyPairSupply {
   static CurrencyPairSupply create(ImmutableList<CurrencyPairMetadata> metadataList) {
     return AutoValue_CurrencyPairSupply(metadataList);
   }

--- a/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairSupply.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairSupply.java
@@ -6,6 +6,10 @@ import com.google.common.collect.ImmutableList;
 import org.knowm.xchange.currency.CurrencyPair;
 
 abstract CurrencyPairSupply {
+  static CurrencyPairSupply create(ImmutableList<CurrencyPairMetadata> metadataList) {
+    return AutoValue_CurrencyPairSupply(metadataList);
+  }
+
   abstract ImmutableList<CurrencyPairMetadata> metadataList();
   
   ImmutableList<CurrencyPair> currencyPairs() {

--- a/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairSupply.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairSupply.java
@@ -1,0 +1,17 @@
+package com.verlumen.tradestream.ingestion;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+import com.google.common.collect.ImmutableList;
+import org.knowm.xchange.currency.CurrencyPair;
+
+abstract CurrencyPairSupply {
+  abstract ImmutableList<CurrencyPairMetadata> metadataList();
+  
+  ImmutableList<CurrencyPair> currencyPairs() {
+    return metadataList()
+      .stream()
+      .map(CurrencyPairMetadata::currencyPair)
+      .collect(toImmutableList());
+  }
+}

--- a/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairSupply.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairSupply.java
@@ -9,7 +9,7 @@ import org.knowm.xchange.currency.CurrencyPair;
 @AutoValue
 abstract class CurrencyPairSupply {
   static CurrencyPairSupply create(ImmutableList<CurrencyPairMetadata> metadataList) {
-    return AutoValue_CurrencyPairSupply(metadataList);
+    return new AutoValue_CurrencyPairSupply(metadataList);
   }
 
   abstract ImmutableList<CurrencyPairMetadata> metadataList();

--- a/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairSupply.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairSupply.java
@@ -2,9 +2,11 @@ package com.verlumen.tradestream.ingestion;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
+import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import org.knowm.xchange.currency.CurrencyPair;
 
+@AutoValue
 abstract CurrencyPairSupply {
   static CurrencyPairSupply create(ImmutableList<CurrencyPairMetadata> metadataList) {
     return AutoValue_CurrencyPairSupply(metadataList);


### PR DESCRIPTION
This update adds the `CurrencyPairSupply` class to centralize the management and transformation of currency pair metadata. Key features include:  

- **AutoValue Integration:** The class leverages `AutoValue` for immutability and streamlined object creation.  
- **Metadata Handling:** Accepts a list of `CurrencyPairMetadata` objects and provides an `ImmutableList` of `CurrencyPair` objects.  
- **Utility Method:** Includes a `currencyPairs()` method to extract currency pairs from metadata.  
- **Build Configuration:** A new Bazel target, `currency_pair_supply`, is added with dependencies on Guava, AutoValue, and XChange Core.  

This enhancement simplifies currency pair management, improving modularity and code clarity.