### PR TITLE
Integrate CurrencyPairSupply into Ingestion Module

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -192,6 +192,7 @@ java_library(
         ":config_arguments",
         ":currency_pair_supplier",
         ":currency_pair_supplier_impl",
+        ":currency_pair_supply",
         ":kafka_producer_provider",
         ":real_time_data_ingestion",
         ":real_time_data_ingestion_impl",

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -30,6 +30,7 @@ abstract class IngestionModule extends AbstractModule {
     bind(StreamingExchange.class).toProvider(StreamingExchangeProvider.class);
 
     bind(CurrencyPairSupplier.class).to(CurrencyPairSupplierImpl.class);
+    bind(CurrencyPairSupply.class).toInstance(CurrencyPairSupply.create(ImmutableList.of()));
     bind(RealTimeDataIngestion.class).to(RealTimeDataIngestionImpl.class);
     bind(ThinMarketTimer.class).to(ThinMarketTimerImpl.class);
     bind(ThinMarketTimerTask.class).to(ThinMarketTimerTaskImpl.class);


### PR DESCRIPTION
This update incorporates `CurrencyPairSupply` into the `IngestionModule` for streamlined currency pair management. Key changes include:

- **Binding Addition:** `CurrencyPairSupply` is bound as a singleton instance using an empty `ImmutableList` for initialization.
- **Build Dependency:** The `currency_pair_supply` target is added to the relevant Bazel library to ensure proper inclusion.
- **Improved Modular Design:** This integration enhances modularity by centralizing currency pair metadata handling in the ingestion pipeline.

These changes prepare the system for efficient currency pair metadata management, improving scalability and code clarity.