### PR TITLE
Refactor ThinMarketTimerTaskImpl to Use CurrencyPairSupply

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -313,7 +313,7 @@ java_library(
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_inject_guice",
         ":candle_manager",
-        ":currency_pair_supplier",
+        ":currency_pair_supply",
         ":thin_market_timer_task",
     ],
 )

--- a/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairMetadata.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairMetadata.java
@@ -9,7 +9,14 @@ import java.math.BigDecimal;
 @AutoValue
 abstract class CurrencyPairMetadata {
   static CurrencyPairMetadata create(String pair, BigDecimal marketCapValue) {
-    CurrencyPair currencyPair = new CurrencyPair(pair);
+    return create(new CurrencyPair(pair), marketCap);
+  }
+
+  static CurrencyPairMetadata create(CurrencyPair currencyPair, long marketCapValue) {
+    return new AutoValue_CurrencyPairMetadata(currencyPair, BigDecimal.valueOf(marketCapValue));
+  }
+
+  static CurrencyPairMetadata create(CurrencyPair currencyPair, BigDecimal marketCapValue) {
     MarketCap marketCap = MarketCap.create(marketCapValue, Currency.USD);
     return new AutoValue_CurrencyPairMetadata(currencyPair, marketCap);
   }

--- a/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairMetadata.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairMetadata.java
@@ -9,7 +9,7 @@ import java.math.BigDecimal;
 @AutoValue
 abstract class CurrencyPairMetadata {
   static CurrencyPairMetadata create(String pair, BigDecimal marketCapValue) {
-    return create(new CurrencyPair(pair), marketCap);
+    return create(new CurrencyPair(pair), marketCapValue);
   }
 
   static CurrencyPairMetadata create(CurrencyPair currencyPair, long marketCapValue) {

--- a/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairMetadata.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairMetadata.java
@@ -13,7 +13,7 @@ abstract class CurrencyPairMetadata {
   }
 
   static CurrencyPairMetadata create(CurrencyPair currencyPair, long marketCapValue) {
-    return new AutoValue_CurrencyPairMetadata(currencyPair, BigDecimal.valueOf(marketCapValue));
+    return create(currencyPair, BigDecimal.valueOf(marketCapValue));
   }
 
   static CurrencyPairMetadata create(CurrencyPair currencyPair, BigDecimal marketCapValue) {

--- a/src/main/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImpl.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImpl.java
@@ -7,7 +7,7 @@ import com.google.inject.Inject;
 
 final class ThinMarketTimerTaskImpl extends ThinMarketTimerTask {
   private final CandleManager candleManager;
-  private final CurrencyPairSupplier currencyPairSupply;
+  private final CurrencyPairSupply currencyPairSupply;
 
   @Inject
   ThinMarketTimerTaskImpl (CandleManager candleManager, CurrencyPairSupply currencyPairSupply) {

--- a/src/main/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImpl.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImpl.java
@@ -7,18 +7,18 @@ import com.google.inject.Inject;
 
 final class ThinMarketTimerTaskImpl extends ThinMarketTimerTask {
   private final CandleManager candleManager;
-  private final CurrencyPairSupplier currencyPairSupplier;
+  private final CurrencyPairSupplier currencyPairSupply;
 
   @Inject
-  ThinMarketTimerTaskImpl (CandleManager candleManager, CurrencyPairSupplier currencyPairSupplier) {
+  ThinMarketTimerTaskImpl (CandleManager candleManager, CurrencyPairSupply currencyPairSupply) {
       this.candleManager = candleManager;
-      this.currencyPairSupplier = currencyPairSupplier;
+      this.currencyPairSupply = currencyPairSupply;
   }
 
   @Override
   public void run() {
       ImmutableList<String> currencyPairs =
-        currencyPairSupplier
+        currencyPairSupply
         .currencyPairs()
         .stream()
         .map(Object::toString)

--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -120,7 +120,8 @@ java_test(
         "@maven//:org_knowm_xchange_xchange_core",
         "@maven//:org_mockito_mockito_core",
         "//src/main/java/com/verlumen/tradestream/ingestion:candle_manager",
-        "//src/main/java/com/verlumen/tradestream/ingestion:currency_pair_supplier",
+        "//src/main/java/com/verlumen/tradestream/ingestion:currency_pair_metadata",
+        "//src/main/java/com/verlumen/tradestream/ingestion:currency_pair_supply",
         "//src/main/java/com/verlumen/tradestream/ingestion:thin_market_timer_task_impl",
     ],
 )

--- a/src/test/java/com/verlumen/tradestream/ingestion/CurrencyPairSupply.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/CurrencyPairSupply.java
@@ -1,0 +1,1 @@
+interface CurrencyPairSupply {}

--- a/src/test/java/com/verlumen/tradestream/ingestion/CurrencyPairSupply.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/CurrencyPairSupply.java
@@ -1,1 +1,3 @@
+package com.verlumen.tradestream.ingestion;
+
 interface CurrencyPairSupply {}

--- a/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
@@ -5,83 +5,81 @@ import static org.junit.Assert.*;
 
 import com.google.inject.Guice;
 import com.google.inject.Inject;
-import com.google.inject.Provider;
 import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import com.google.common.collect.ImmutableList;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import java.util.concurrent.atomic.AtomicReference;
-
+@RunWith(JUnit4.class)
 public class ThinMarketTimerTaskImplTest {
     @Rule public MockitoRule mocks = MockitoJUnit.rule();
 
-    private static final AtomicReference<CurrencyPairSupply> CURRENCY_PAIR_SUPPLY = new AtomicReference<>();
-    private static final CurrencyPairMetadata AAA_BBB = CurrencyPairMetadata.create(new CurrencyPair("AAA", "BBB"), 123L);
-    private static final CurrencyPairMetadata CCC_DDD = CurrencyPairMetadata.create(new CurrencyPair("CCC", "DDD"), 234L);
-    private static final CurrencyPairMetadata EEE_FFF = CurrencyPairMetadata.create(new CurrencyPair("EEE", "FFF"), 345L);
-    private static final CurrencyPairMetadata BTC_USD = CurrencyPairMetadata.create(new CurrencyPair("BTC", "USD"), 456L);
-    private static final CurrencyPairMetadata ETH_EUR = CurrencyPairMetadata.create(new CurrencyPair("ETH", "EUR"), 567L);
+    private static final CurrencyPairMetadata BTC_USD = 
+        CurrencyPairMetadata.create(new CurrencyPair("BTC", "USD"), 456L);
+    private static final CurrencyPairMetadata ETH_EUR = 
+        CurrencyPairMetadata.create(new CurrencyPair("ETH", "EUR"), 567L);
 
     @Mock @Bind private CandleManager candleManager;
-    @Bind private Provider<CurrencyPairSupply> currencyPairSupplyProvider;
-    @Inject private ThinMarketTimerTaskImpl thinMarketTimerTask;
-    
+    @Mock @Bind private CurrencyPairSupply currencyPairSupply;
+    @Inject private ThinMarketTimerTaskImpl timerTask;
+
     @Before
     public void setUp() {
-        this.currencyPairSupplyProvider = CURRENCY_PAIR_SUPPLY::get;
-        CURRENCY_PAIR_SUPPLY.set(CurrencyPairSupply.create(ImmutableList.of()));
         Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+        // Default to empty list of currency pairs
+        when(currencyPairSupply.currencyPairs())
+            .thenReturn(ImmutableList.of());
     }
 
     @Test
     public void run_withValidCurrencyPairs_callsHandleThinlyTradedMarketsWithCorrectList() {
         // Arrange
-        ImmutableList<CurrencyPairMetadata> metadataList = ImmutableList.of(BTC_USD, ETH_EUR);
-        CURRENCY_PAIR_SUPPLY.set(CurrencyPairSupply.create(metadataList));
+        ImmutableList<CurrencyPair> pairs = ImmutableList.of(
+            BTC_USD.currencyPair(), 
+            ETH_EUR.currencyPair()
+        );
+        when(currencyPairSupply.currencyPairs()).thenReturn(pairs);
 
         // Act
-        thinMarketTimerTask.run();
+        timerTask.run();
 
         // Assert
-        ImmutableList<String> expected =
-            ImmutableList.of(BTC_USD.currencyPair().toString(), ETH_EUR.currencyPair().toString());
+        ImmutableList<String> expected = ImmutableList.of(
+            BTC_USD.currencyPair().toString(), 
+            ETH_EUR.currencyPair().toString()
+        );
         verify(candleManager).handleThinlyTradedMarkets(expected);
     }
 
     @Test
     public void run_withEmptyCurrencyPairs_callsHandleThinlyTradedMarketsWithEmptyList() {
-        // Arrange
-        ImmutableList<CurrencyPairMetadata> metadataList = ImmutableList.of();
-        CURRENCY_PAIR_SUPPLY.set(CurrencyPairSupply.create(metadataList));
-
         // Act
-        thinMarketTimerTask.run();
+        timerTask.run();
 
         // Assert
-        ImmutableList<String> expected = ImmutableList.of();
-        verify(candleManager).handleThinlyTradedMarkets(expected);
+        verify(candleManager).handleThinlyTradedMarkets(ImmutableList.of());
     }
 
     @Test
     public void run_handleThinlyTradedMarketsThrowsException_exceptionIsPropagated() {
         // Arrange
-        ImmutableList<CurrencyPairMetadata> metadataList = ImmutableList.of(BTC_USD);
-        CURRENCY_PAIR_SUPPLY.set(CurrencyPairSupply.create(metadataList));
-        doThrow(new RuntimeException("Test exception")).when(candleManager).handleThinlyTradedMarkets(any());
+        when(currencyPairSupply.currencyPairs())
+            .thenReturn(ImmutableList.of(BTC_USD.currencyPair()));
+        doThrow(new RuntimeException("Test exception"))
+            .when(candleManager)
+            .handleThinlyTradedMarkets(any());
 
         // Act & Assert
         try {
-            thinMarketTimerTask.run();
+            timerTask.run();
             fail("Expected RuntimeException");
         } catch (RuntimeException e) {
             assertEquals("Test exception", e.getMessage());
@@ -91,32 +89,40 @@ public class ThinMarketTimerTaskImplTest {
     @Test
     public void run_currencyPairsOrderIsPreserved() {
         // Arrange
-        ImmutableList<CurrencyPairMetadata> metadataList = ImmutableList.of(AAA_BBB, CCC_DDD, EEE_FFF);
-        CURRENCY_PAIR_SUPPLY.set(CurrencyPairSupply.create(metadataList));
-        ImmutableList<String> expected = ImmutableList.of(
-            AAA_BBB.currencyPair().toString(),
-            CCC_DDD.currencyPair().toString(),
-            EEE_FFF.currencyPair().toString());
+        ImmutableList<CurrencyPair> pairs = ImmutableList.of(
+            new CurrencyPair("AAA", "BBB"),
+            new CurrencyPair("CCC", "DDD"),
+            new CurrencyPair("EEE", "FFF")
+        );
+        when(currencyPairSupply.currencyPairs()).thenReturn(pairs);
 
         // Act
-        thinMarketTimerTask.run();
+        timerTask.run();
 
         // Assert
+        ImmutableList<String> expected = ImmutableList.of(
+            "AAA/BBB", "CCC/DDD", "EEE/FFF"
+        );
         verify(candleManager).handleThinlyTradedMarkets(expected);
     }
 
-    @Test
+    @Test 
     public void run_withDuplicateCurrencyPairs_duplicatesAreIncludedInResultList() {
         // Arrange
-        ImmutableList<CurrencyPairMetadata> metadataList = ImmutableList.of(BTC_USD, BTC_USD);
-        CURRENCY_PAIR_SUPPLY.set(CurrencyPairSupply.create(metadataList));
+        ImmutableList<CurrencyPair> pairs = ImmutableList.of(
+            BTC_USD.currencyPair(),
+            BTC_USD.currencyPair()
+        );
+        when(currencyPairSupply.currencyPairs()).thenReturn(pairs);
 
         // Act
-        thinMarketTimerTask.run();
+        timerTask.run();
 
         // Assert
-        ImmutableList<String> expected =
-            ImmutableList.of(BTC_USD.currencyPair().toString(), BTC_USD.currencyPair().toString());
+        ImmutableList<String> expected = ImmutableList.of(
+            BTC_USD.currencyPair().toString(),
+            BTC_USD.currencyPair().toString()
+        );
         verify(candleManager).handleThinlyTradedMarkets(expected);
     }
 }

--- a/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
@@ -47,7 +47,8 @@ public class ThinMarketTimerTaskImplTest {
         thinMarketTimerTask.run();
 
         // Assert
-        ImmutableList<String> expected = ImmutableList.of(btcUsd.toString(), ethEur.toString());
+        ImmutableList<String> expected =
+            ImmutableList.of(BTC_USD.currencyPair().toString(), ETH_EUR.currencyPair().toString());
         verify(candleManager).handleThinlyTradedMarkets(expected);
     }
 

--- a/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.*;
 
 import com.google.inject.Guice;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import com.google.common.collect.ImmutableList;
@@ -21,9 +22,11 @@ import org.mockito.junit.MockitoRule;
 
 public class ThinMarketTimerTaskImplTest {
     @Rule public MockitoRule mocks = MockitoJUnit.rule();
+    private static final CurrencyPairMetadata BTC_USD = CurrencyPairMetadata.create(CurrencyPair.BTC_USD);
+    private static final CurrencyPairMetadata ETH_USD = CurrencyPairMetadata.create(CurrencyPair.ETH_USD);
 
     @Mock @Bind private CandleManager candleManager;
-    @Mock @Bind private CurrencyPairSupplier currencyPairSupplier;
+    @Mock @Bind private Provider<CurrencyPairSupply> currencyPairSupply;
     @Inject private ThinMarketTimerTaskImpl thinMarketTimerTask;
 
     @Before

--- a/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
@@ -24,8 +24,11 @@ import java.util.concurrent.atomic.AtomicReference;
 public class ThinMarketTimerTaskImplTest {
     @Rule public MockitoRule mocks = MockitoJUnit.rule();
     private static final AtomicReference<CurrencyPairSupply> CURRENCY_PAIR_SUPPLY = new AtomicReference<>();
-    private static final CurrencyPairMetadata BTC_USD = CurrencyPairMetadata.create(new CurrencyPair("BTC", "USD"), 123L);
-    private static final CurrencyPairMetadata ETH_EUR = CurrencyPairMetadata.create(new CurrencyPair("ETH", "EUR"), 456L);
+    private static final CurrencyPairMetadata AAA_BBB = CurrencyPairMetadata.create(new CurrencyPair("AAA", "BBB"), 123L);
+    private static final CurrencyPairMetadata CCC_DDD = CurrencyPairMetadata.create(new CurrencyPair("CCC", "DDD"), 234L);
+    private static final CurrencyPairMetadata EEE_FFF = CurrencyPairMetadata.create(new CurrencyPair("EEE", "FFF"), 345L);
+    private static final CurrencyPairMetadata BTC_USD = CurrencyPairMetadata.create(new CurrencyPair("BTC", "USD"), 456L);
+    private static final CurrencyPairMetadata ETH_EUR = CurrencyPairMetadata.create(new CurrencyPair("ETH", "EUR"), 567L);
 
     @Mock @Bind private CandleManager candleManager;
     @Bind private Provider<CurrencyPairSupply> currencyPairSupply;
@@ -85,9 +88,6 @@ public class ThinMarketTimerTaskImplTest {
     @Test
     public void run_currencyPairsOrderIsPreserved() {
         // Arrange
-        CurrencyPair pair1 = new CurrencyPair("AAA", "BBB");
-        CurrencyPair pair2 = new CurrencyPair("CCC", "DDD");
-        CurrencyPair pair3 = new CurrencyPair("EEE", "FFF");
         ImmutableList<CurrencyPair> currencyPairs =ImmutableList.of(pair1, pair2, pair3);
         ImmutableList<String> expected = ImmutableList.of(pair1.toString(), pair2.toString(), pair3.toString());
 

--- a/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
@@ -37,7 +37,15 @@ public class ThinMarketTimerTaskImplTest {
 
     @Before
     public void setUp() {
+        // Initialize with empty supply before each test
+        CURRENCY_PAIR_SUPPLY.set(CurrencyPairSupply.create(ImmutableList.of()));
         Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+    }
+
+    @After
+    public void tearDown() {
+        // Clear the reference after each test
+        CURRENCY_PAIR_SUPPLY.set(null);
     }
 
     @Test

--- a/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
@@ -25,6 +25,7 @@ public class ThinMarketTimerTaskImplTest {
     @Rule public MockitoRule mocks = MockitoJUnit.rule();
 
     private static final AtomicReference<CurrencyPairSupply> CURRENCY_PAIR_SUPPLY = new AtomicReference<>();
+    @Bind private static final Provider<CurrencyPairSupply> CURRENCY_PAIR_SUPPLY_PROVIDER = CURRENCY_PAIR_SUPPLY::get;
     private static final CurrencyPairMetadata AAA_BBB = CurrencyPairMetadata.create(new CurrencyPair("AAA", "BBB"), 123L);
     private static final CurrencyPairMetadata CCC_DDD = CurrencyPairMetadata.create(new CurrencyPair("CCC", "DDD"), 234L);
     private static final CurrencyPairMetadata EEE_FFF = CurrencyPairMetadata.create(new CurrencyPair("EEE", "FFF"), 345L);
@@ -32,12 +33,10 @@ public class ThinMarketTimerTaskImplTest {
     private static final CurrencyPairMetadata ETH_EUR = CurrencyPairMetadata.create(new CurrencyPair("ETH", "EUR"), 567L);
 
     @Mock @Bind private CandleManager candleManager;
-    @Bind private Provider<CurrencyPairSupply> currencyPairSupply;
     @Inject private ThinMarketTimerTaskImpl thinMarketTimerTask;
 
     @Before
     public void setUp() {
-        this.currencyPairSupply = CURRENCY_PAIR_SUPPLY::get;
         Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
     }
 

--- a/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
@@ -88,7 +88,8 @@ public class ThinMarketTimerTaskImplTest {
     @Test
     public void run_currencyPairsOrderIsPreserved() {
         // Arrange
-        ImmutableList<CurrencyPairMetadata> metadataList =ImmutableList.of(AAA_BBB, CCC_DDD, EEE_FFF);
+        ImmutableList<CurrencyPairMetadata> metadataList = ImmutableList.of(AAA_BBB, CCC_DDD, EEE_FFF);
+        CURRENCY_PAIR_SUPPLY.set(CurrencyPairSupply.create(metadataList));
         ImmutableList<String> expected = ImmutableList.of(
             AAA_BBB.currencyPair().toString(),
             CCC_DDD.currencyPair().toString(),

--- a/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
@@ -109,7 +109,8 @@ public class ThinMarketTimerTaskImplTest {
         thinMarketTimerTask.run();
 
         // Assert
-        ImmutableList<String> expected = ImmutableList.of(btcUsd.toString(), btcUsd.toString());
+        ImmutableList<String> expected =
+            ImmutableList.of(BTC_USD.currencyPair().toString(), BTC_USD.currencyPair().toString());
         verify(candleManager).handleThinlyTradedMarkets(expected);
     }
 }

--- a/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
@@ -11,6 +11,7 @@ import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import com.google.common.collect.ImmutableList;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
@@ -89,7 +89,6 @@ public class ThinMarketTimerTaskImplTest {
         CurrencyPair pair3 = new CurrencyPair("EEE", "FFF");
         ImmutableList<CurrencyPair> currencyPairs =ImmutableList.of(pair1, pair2, pair3);
         ImmutableList<String> expected = ImmutableList.of(pair1.toString(), pair2.toString(), pair3.toString());
-        when(currencyPairSupplier.currencyPairs()).thenReturn(currencyPairs);
 
         // Act
         thinMarketTimerTask.run();
@@ -101,9 +100,8 @@ public class ThinMarketTimerTaskImplTest {
     @Test
     public void run_withDuplicateCurrencyPairs_duplicatesAreIncludedInResultList() {
         // Arrange
-        CurrencyPair btcUsd = new CurrencyPair("BTC", "USD");
-        ImmutableList<CurrencyPair> currencyPairs = ImmutableList.of(btcUsd, btcUsd);
-        when(currencyPairSupplier.currencyPairs()).thenReturn(currencyPairs);
+        ImmutableList<CurrencyPairMetadata> metadataList = ImmutableList.of(BTC_USD, BTC_USD);
+        CURRENCY_PAIR_SUPPLY.set(CurrencyPairSupply.create(metadataList));
 
         // Act
         thinMarketTimerTask.run();

--- a/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
@@ -43,11 +43,6 @@ public class ThinMarketTimerTaskImplTest {
         Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
     }
 
-    @After
-    public void tearDown() {
-        CURRENCY_PAIR_SUPPLY.set(null);
-    }
-
     @Test
     public void run_withValidCurrencyPairs_callsHandleThinlyTradedMarketsWithCorrectList() {
         // Arrange

--- a/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
@@ -88,7 +88,7 @@ public class ThinMarketTimerTaskImplTest {
     @Test
     public void run_currencyPairsOrderIsPreserved() {
         // Arrange
-        ImmutableList<CurrencyPair> currencyPairs =ImmutableList.of(pair1, pair2, pair3);
+        ImmutableList<CurrencyPairMetadata> metadataList =ImmutableList.of(AAA_BBB, CCC_DDD, EEE_FFF);
         ImmutableList<String> expected = ImmutableList.of(
             AAA_BBB.currencyPair().toString(),
             CCC_DDD.currencyPair().toString(),

--- a/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
@@ -90,7 +90,10 @@ public class ThinMarketTimerTaskImplTest {
     public void run_currencyPairsOrderIsPreserved() {
         // Arrange
         ImmutableList<CurrencyPair> currencyPairs =ImmutableList.of(pair1, pair2, pair3);
-        ImmutableList<String> expected = ImmutableList.of(pair1.toString(), pair2.toString(), pair3.toString());
+        ImmutableList<String> expected = ImmutableList.of(
+            AAA_BBB.currencyPair().toString(),
+            CCC_DDD.currencyPair().toString(),
+            EEE_FFF.currencyPair().toString());
 
         // Act
         thinMarketTimerTask.run();

--- a/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
@@ -26,7 +26,6 @@ public class ThinMarketTimerTaskImplTest {
     @Rule public MockitoRule mocks = MockitoJUnit.rule();
 
     private static final AtomicReference<CurrencyPairSupply> CURRENCY_PAIR_SUPPLY = new AtomicReference<>();
-    @Bind private static final Provider<CurrencyPairSupply> CURRENCY_PAIR_SUPPLY_PROVIDER = CURRENCY_PAIR_SUPPLY::get;
     private static final CurrencyPairMetadata AAA_BBB = CurrencyPairMetadata.create(new CurrencyPair("AAA", "BBB"), 123L);
     private static final CurrencyPairMetadata CCC_DDD = CurrencyPairMetadata.create(new CurrencyPair("CCC", "DDD"), 234L);
     private static final CurrencyPairMetadata EEE_FFF = CurrencyPairMetadata.create(new CurrencyPair("EEE", "FFF"), 345L);
@@ -34,18 +33,18 @@ public class ThinMarketTimerTaskImplTest {
     private static final CurrencyPairMetadata ETH_EUR = CurrencyPairMetadata.create(new CurrencyPair("ETH", "EUR"), 567L);
 
     @Mock @Bind private CandleManager candleManager;
+    @Bind private Provider<CurrencyPairSupply> currencyPairSupplyProvider;
     @Inject private ThinMarketTimerTaskImpl thinMarketTimerTask;
-
+    
     @Before
     public void setUp() {
-        // Initialize with empty supply before each test
+        this.currencyPairSupplyProvider = CURRENCY_PAIR_SUPPLY::get;
         CURRENCY_PAIR_SUPPLY.set(CurrencyPairSupply.create(ImmutableList.of()));
         Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
     }
 
     @After
     public void tearDown() {
-        // Clear the reference after each test
         CURRENCY_PAIR_SUPPLY.set(null);
     }
 

--- a/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 public class ThinMarketTimerTaskImplTest {
     @Rule public MockitoRule mocks = MockitoJUnit.rule();
+
     private static final AtomicReference<CurrencyPairSupply> CURRENCY_PAIR_SUPPLY = new AtomicReference<>();
     private static final CurrencyPairMetadata AAA_BBB = CurrencyPairMetadata.create(new CurrencyPair("AAA", "BBB"), 123L);
     private static final CurrencyPairMetadata CCC_DDD = CurrencyPairMetadata.create(new CurrencyPair("CCC", "DDD"), 234L);

--- a/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
@@ -68,9 +68,8 @@ public class ThinMarketTimerTaskImplTest {
     @Test
     public void run_handleThinlyTradedMarketsThrowsException_exceptionIsPropagated() {
         // Arrange
-        CurrencyPair btcUsd = new CurrencyPair("BTC", "USD");
-        ImmutableList<CurrencyPair> currencyPairs = ImmutableList.of(btcUsd);
-        when(currencyPairSupplier.currencyPairs()).thenReturn(currencyPairs);
+        ImmutableList<CurrencyPairMetadata> metadataList = ImmutableList.of(BTC_USD);
+        CURRENCY_PAIR_SUPPLY.set(CurrencyPairSupply.create(metadataList));
         doThrow(new RuntimeException("Test exception")).when(candleManager).handleThinlyTradedMarkets(any());
 
         // Act & Assert


### PR DESCRIPTION
This update transitions the `ThinMarketTimerTaskImpl` class to use `CurrencyPairSupply` instead of `CurrencyPairSupplier`. Key updates include:  

- **Dependency Injection Refactor:** `CurrencyPairSupply` is now injected into `ThinMarketTimerTaskImpl` to align with the updated architecture.  
- **Method Adjustment:** Replaces references to `currencyPairSupplier` with `currencyPairSupply` for fetching and processing currency pairs.  
- **Build File Update:** Updates the Bazel build configuration to replace `currency_pair_supplier` with `currency_pair_supply` as a dependency.  

These changes improve consistency with the new `CurrencyPairSupply` abstraction, ensuring modularity and maintainability across the codebase.