### PR TITLE
Remove CurrencyPairSupplier Mock from ThinMarketTimerImplTest 

### DIFF
--- a/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerImplTest.java
@@ -26,7 +26,6 @@ public class ThinMarketTimerImplTest {
     @Rule public MockitoRule mocks = MockitoJUnit.rule();
 
     @Mock @Bind private CandleManager candleManager;
-    @Mock @Bind private CurrencyPairSupplier currencyPairSupplier;
     @Mock @Bind private Timer timer;
     @Mock @Bind private ThinMarketTimerTask task;
     @Inject private ThinMarketTimerImpl thinMarketTimer;


### PR DESCRIPTION
This update removes the unused `CurrencyPairSupplier` mock from the `ThinMarketTimerImplTest` class. Key changes include:  

- **Simplified Test Setup:** The `@Mock @Bind` annotation for `CurrencyPairSupplier` is removed to reflect the updated logic that no longer relies on this abstraction.  
- **Focus on Relevant Dependencies:** The test now includes only necessary mocks such as `CandleManager`, `Timer`, and `ThinMarketTimerTask`.  

This change streamlines the test configuration, aligning it with the refactored codebase that utilizes `CurrencyPairSupply` instead of `CurrencyPairSupplier`.