### PR TITLE
Add HttpURLConnectionFactory Binding and Update Dependencies

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -232,6 +232,8 @@ java_library(
         ":currency_pair_supply_impl",
         ":http_client",
         ":http_client_impl",
+        ":http_url_connection_factory",
+        ":http_url_connection_factory_impl",
         ":kafka_producer_provider",
         ":real_time_data_ingestion",
         ":real_time_data_ingestion_impl",

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -230,6 +230,8 @@ java_library(
         ":config_arguments",
         ":currency_pair_supply",
         ":currency_pair_supply_impl",
+        ":http_client",
+        ":http_client_impl",
         ":kafka_producer_provider",
         ":real_time_data_ingestion",
         ":real_time_data_ingestion_impl",

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -30,6 +30,7 @@ abstract class IngestionModule extends AbstractModule {
     bind(StreamingExchange.class).toProvider(StreamingExchangeProvider.class);
 
     bind(CurrencyPairSupply.class).toInstance(CurrencyPairSupplyImpl.create(ImmutableList.of()));
+    bind(HttpClient.class).to(HttpClientImpl.class);
     bind(RealTimeDataIngestion.class).to(RealTimeDataIngestionImpl.class);
     bind(ThinMarketTimer.class).to(ThinMarketTimerImpl.class);
     bind(ThinMarketTimerTask.class).to(ThinMarketTimerTaskImpl.class);

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -31,6 +31,7 @@ abstract class IngestionModule extends AbstractModule {
 
     bind(CurrencyPairSupply.class).toInstance(CurrencyPairSupplyImpl.create(ImmutableList.of()));
     bind(HttpClient.class).to(HttpClientImpl.class);
+    bind(HttpURLConnectionFactory.class).to(HttpURLConnectionFactoryImpl.class);
     bind(RealTimeDataIngestion.class).to(RealTimeDataIngestionImpl.class);
     bind(ThinMarketTimer.class).to(ThinMarketTimerImpl.class);
     bind(ThinMarketTimerTask.class).to(ThinMarketTimerTaskImpl.class);


### PR DESCRIPTION
This update adds a binding for the `HttpURLConnectionFactory` interface to the `HttpURLConnectionFactoryImpl` implementation in the `IngestionModule`, complementing the existing `HttpClient` binding. Additionally, the `BUILD` file has been updated to include both `http_url_connection_factory` and `http_url_connection_factory_impl` libraries as dependencies. These changes enable robust HTTP connection management and enhance the modularity and extensibility of the ingestion system.