### PR TITLE
Rename and Relocate `sealedsecrety.yaml` to `sealed-secret.yaml` 

### DIFF
--- a/charts/tradestream/templates/sealed-secret.yaml
+++ b/charts/tradestream/templates/sealed-secret.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:


### PR DESCRIPTION
The `sealedsecrety.yaml` file has been renamed to `sealed-secret.yaml` and relocated to the `charts/tradestream/templates/` directory. This update aligns the file naming convention with standard practices and organizes the Helm chart structure for better maintainability and clarity. The file continues to define a `SealedSecret` resource for secure key management.