### PR TITLE
Add API Key Environment Variable to Data Ingestion Deployment

### DIFF
--- a/charts/tradestream/templates/data-ingestion-deployment.yaml
+++ b/charts/tradestream/templates/data-ingestion-deployment.yaml
@@ -39,3 +39,9 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: {{ .Values.dataIngestion.service.port }}
+          env:
+            - name: COINMARKETCAP_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: coinmarketcap-api-key
+                  key: apiKey


### PR DESCRIPTION
Updated the `data-ingestion-deployment.yaml` template to include an environment variable `COINMARKETCAP_API_KEY` in the container spec. This variable fetches its value from a Kubernetes `Secret` named `coinmarketcap-api-key` with the key `apiKey`. This change enables secure access to the CoinMarketCap API by injecting the API key directly into the container environment, adhering to best practices for managing sensitive data.