### PR TITLE
Refactor Helm Templates with Centralized Helper Definitions 

### DIFF
--- a/charts/tradestream/templates/_helpers.tpl
+++ b/charts/tradestream/templates/_helpers.tpl
@@ -1,0 +1,13 @@
+{{- define "tradestream.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "tradestream.name" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- $name -}}
+{{- end -}}

--- a/charts/tradestream/templates/data-ingestion-deployment.yaml
+++ b/charts/tradestream/templates/data-ingestion-deployment.yaml
@@ -1,17 +1,3 @@
-{{- define "tradestream.fullname" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-
-{{- define "tradestream.name" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- $name -}}
-{{- end -}}
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
This update centralizes the naming logic in the Helm chart by introducing a new `_helpers.tpl` file and moving `tradestream.fullname` and `tradestream.name` template definitions into it.  

### Changes Made:  
1. **New `_helpers.tpl` File:**  
   - Created a `_helpers.tpl` file in the `templates` directory to define reusable helper templates for naming.  
   - Added the following helper templates:  
     - `tradestream.fullname`: Generates a full name by combining the release name and chart name, ensuring a maximum length of 63 characters.  
     - `tradestream.name`: Resolves the chart name or uses a custom override (`nameOverride`).  

2. **Simplified `data-ingestion-deployment.yaml`:**  
   - Removed inlined naming logic from the deployment manifest.  
   - Updated to use the centralized `tradestream.fullname` and `tradestream.name` helpers for consistency.  

### Benefits:  
- **Reusability:** By centralizing naming logic in `_helpers.tpl`, it can be used across all templates, reducing redundancy.  
- **Maintainability:** Future changes to naming conventions only need to be made in `_helpers.tpl`.  
- **Readability:** Simplifies individual template files by offloading complex naming logic to the helpers.  

This change enhances the structure and maintainability of the Helm chart while ensuring consistent resource naming conventions.