### PR TITLE
Add CoinMarketCap Configuration Support

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -227,6 +227,7 @@ java_library(
         ":candle_manager_impl",
         ":candle_publisher",
         ":candle_publisher_impl",
+        ":coin_market_cap_config",
         ":config_arguments",
         ":currency_pair_supply",
         ":currency_pair_supply_impl",

--- a/src/main/java/com/verlumen/tradestream/ingestion/ConfigArguments.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/ConfigArguments.java
@@ -10,6 +10,8 @@ import net.sourceforge.argparse4j.inf.Namespace;
 
 @AutoValue
 abstract class ConfigArguments implements Provider<Namespace> {
+  private static final String API_KEY_ENV_VAR = "TRADESTREAM_COINMARKETCAP_API_KEY";
+
   static ConfigArguments create(ImmutableList<String> args) {
     return new AutoValue_ConfigArguments(args);
   }
@@ -20,7 +22,7 @@ abstract class ConfigArguments implements Provider<Namespace> {
   public Namespace get() {
     try {
       return createParser().parseArgs(args().toArray(new String[0]));
-    } catch(ArgumentParserException e) {
+    } catch (ArgumentParserException e) {
       throw new RuntimeException("Unable to parse arguments.", e);
     }
   }
@@ -31,14 +33,15 @@ abstract class ConfigArguments implements Provider<Namespace> {
       .defaultHelp(true)
       .description("Configuration for Kafka producer and exchange settings");
 
+    // Existing arguments
     parser.addArgument("--candleIntervalSeconds")
-          .type(Integer.class)
-          .setDefault(60)
-          .help("Candle interval in seconds");
+      .type(Integer.class)
+      .setDefault(60)
+      .help("Candle interval in seconds");
 
     parser.addArgument("--candlePublisherTopic")
-          .setDefault("candles") 
-          .help("Kafka topic to publish candle data");
+      .setDefault("candles") 
+      .help("Kafka topic to publish candle data");
 
     // Kafka configuration
     parser.addArgument("--kafka.bootstrap.servers")
@@ -81,6 +84,16 @@ abstract class ConfigArguments implements Provider<Namespace> {
     parser.addArgument("--xchange.exchangeName")
       .setDefault("info.bitrich.xchangestream.coinbasepro.CoinbaseProStreamingExchange")
       .help("Exchange name");
+
+    // CoinMarketCap configuration
+    parser.addArgument("--coinmarketcap.apiKey")
+      .setDefault(System.getenv(API_KEY_ENV_VAR))
+      .help("CoinMarketCap API Key (default: value of TRADESTREAM_COINMARKETCAP_API_KEY environment variable)");
+
+    parser.addArgument("--coinmarketcap.topN")
+      .type(Integer.class)
+      .setDefault(100)
+      .help("Number of top cryptocurrencies to track (default: 100)");
 
     // Run mode configuration
     parser.addArgument("--runMode")

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -58,7 +58,7 @@ abstract class IngestionModule extends AbstractModule {
   }
 
   @Provides
-  CoinMarketCapConfig provideCoinMarketCapConfig() {
+  CoinMarketCapConfig provideCoinMarketCapConfig(Namespace namespace) {
     String apiKey = namespace.getString("coinmarketcap.apiKey");
     int topN = namespace.getInt("coinmarketcap.topN");
     return CoinMarketCapConfig.create(topN, apiKey);    

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -60,7 +60,7 @@ abstract class IngestionModule extends AbstractModule {
   @Provides
   CoinMarketCapConfig provideCoinMarketCapConfig() {
     String apiKey = namespace.getString("coinmarketcap.apiKey");
-    int topN = namespace.getString("coinmarketcap.topN");
+    int topN = namespace.getInt("coinmarketcap.topN");
     return CoinMarketCapConfig.create(topN, apiKey);    
   }
 

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -57,6 +57,12 @@ abstract class IngestionModule extends AbstractModule {
     return candlePublisherFactory.create(topic);
   }
 
+  @Provides
+  CoinMarketCapConfig provideCoinMarketCapConfig() {
+    String apiKey = namespace.getString("coinmarketcap.apiKey");
+    int topN = namespace.getString("coinmarketcap.topN");
+    return CoinMarketCapConfig.create(apiKey, topN);    
+  }
 
   @Provides
   ProductSubscription provideProductSubscription(CurrencyPairSupply currencyPairSupply) {

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -61,7 +61,7 @@ abstract class IngestionModule extends AbstractModule {
   CoinMarketCapConfig provideCoinMarketCapConfig() {
     String apiKey = namespace.getString("coinmarketcap.apiKey");
     int topN = namespace.getString("coinmarketcap.topN");
-    return CoinMarketCapConfig.create(apiKey, topN);    
+    return CoinMarketCapConfig.create(topN, apiKey);    
   }
 
   @Provides


### PR DESCRIPTION
- Added `coinmarketcap.apiKey` and `coinmarketcap.topN` arguments to `ConfigArguments`.  
- Defaults the API key to the `TRADESTREAM_COINMARKETCAP_API_KEY` environment variable.  
- Introduced a `provideCoinMarketCapConfig` method in `IngestionModule` for injecting `CoinMarketCapConfig`.  
- Updated dependencies in the BUILD file to include `coin_market_cap_config`.