### PR TITLE
Transition `CurrencyPairSupply` to Dynamic Provider

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -231,6 +231,7 @@ java_library(
         ":config_arguments",
         ":currency_pair_supply",
         ":currency_pair_supply_impl",
+        ":currency_pair_supply_provider",
         ":http_client",
         ":http_client_impl",
         ":http_url_connection_factory",

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -230,7 +230,6 @@ java_library(
         ":coin_market_cap_config",
         ":config_arguments",
         ":currency_pair_supply",
-        ":currency_pair_supply_impl",
         ":currency_pair_supply_provider",
         ":http_client",
         ":http_client_impl",

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -29,7 +29,7 @@ abstract class IngestionModule extends AbstractModule {
     bind(Namespace.class).toProvider(ConfigArguments.create(commandLineArgs()));
     bind(StreamingExchange.class).toProvider(StreamingExchangeProvider.class);
 
-    bind(CurrencyPairSupply.class).toInstance(CurrencyPairSupplyImpl.create(ImmutableList.of()));
+    bind(CurrencyPairSupply.class).toProvider(CurrencyPairSupplyProvider.class);
     bind(HttpClient.class).to(HttpClientImpl.class);
     bind(HttpURLConnectionFactory.class).to(HttpURLConnectionFactoryImpl.class);
     bind(RealTimeDataIngestion.class).to(RealTimeDataIngestionImpl.class);

--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
@@ -19,7 +19,7 @@ final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
     private final CandlePublisher candlePublisher;
     private final Provider<CurrencyPairSupply> currencyPairSupply;
     private final Provider<StreamingExchange> exchange;
-    private final ProductSubscription productSubscription;
+    private final Provider<ProductSubscription> productSubscription;
     private final List<Disposable> subscriptions;
     private final Provider<ThinMarketTimer> thinMarketTimer;
     private final TradeProcessor tradeProcessor;
@@ -30,7 +30,7 @@ final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
         CandlePublisher candlePublisher,
         Provider<CurrencyPairSupply> currencyPairSupply,
         Provider<StreamingExchange> exchange,
-        ProductSubscription productSubscription,
+        Provider<ProductSubscription> productSubscription,
         Provider<ThinMarketTimer> thinMarketTimer,
         TradeProcessor tradeProcessor
     ) {
@@ -46,7 +46,7 @@ final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
 
     @Override
     public void start() {
-        exchange.get().connect(productSubscription).blockingAwait();
+        exchange.get().connect(productSubscription.get()).blockingAwait();
         subscribeToTradeStreams();
         thinMarketTimer.get().start();
     }


### PR DESCRIPTION
- Updated `IngestionModule` to bind `CurrencyPairSupply` to `CurrencyPairSupplyProvider` for dynamic provisioning of currency pairs at runtime.  
- Replaced `currency_pair_supply_impl` with `currency_pair_supply_provider` in the BUILD file to align with the new binding approach.  
- Enhances flexibility by integrating live data sourcing capabilities via `CurrencyPairSupplyProvider`.