### PR TITLE
Add Singleton Scope for `StreamingExchange`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -28,7 +28,7 @@ abstract class IngestionModule extends AbstractModule {
     bind(new TypeLiteral<KafkaProducer<String, byte[]>>() {})
         .toProvider(KafkaProducerProvider.class);
     bind(Namespace.class).toProvider(ConfigArguments.create(commandLineArgs()));
-    bind(StreamingExchange.class).toProvider(StreamingExchangeProvider.class);
+    bind(StreamingExchange.class).toProvider(StreamingExchangeProvider.class).in(Singleton.class);
 
     bind(CurrencyPairSupply.class).toProvider(CurrencyPairSupplyProvider.class);
     bind(HttpClient.class).to(HttpClientImpl.class);

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
+import com.google.inject.Singleton;
 import com.google.inject.TypeLiteral;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import info.bitrich.xchangestream.core.ProductSubscription;


### PR DESCRIPTION
- Modified `IngestionModule` to bind `StreamingExchange` with `Singleton` scope.  
- Ensures a single instance of `StreamingExchange` across the application's lifecycle, reducing resource consumption and improving efficiency.  
- Updated dependencies to reflect best practices for managing long-lived connections.