### PR TITLE
Enable Configurable Command-Line Arguments for Data Ingestion in Helm

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Install TradeStream Helm Chart
         run: |
           helm dependency update charts/tradestream && \
-          helm install my-tradestream charts/tradestream --namespace tradestream-namespace --set dataIngestion.args="--runMode=dry"
+          helm install my-tradestream charts/tradestream --namespace tradestream-namespace --set 'dataIngestion.args[0]=--runMode=dry'
 
       - name: Wait for All Pods to be Ready
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Install TradeStream Helm Chart
         run: |
           helm dependency update charts/tradestream && \
-          helm install my-tradestream charts/tradestream --namespace tradestream-namespace
+          helm install my-tradestream charts/tradestream --namespace tradestream-namespace --set dataIngestion.args="--runMode=dry"
 
       - name: Wait for All Pods to be Ready
         run: |

--- a/charts/tradestream/templates/data-ingestion-deployment.yaml
+++ b/charts/tradestream/templates/data-ingestion-deployment.yaml
@@ -21,6 +21,7 @@ spec:
     spec:
       containers:
         - name: data-ingestion
+          args: {{ .Values.dataIngestion.args | default "" | quote }}
           image: "{{ .Values.dataIngestion.image.repository }}:{{ .Values.dataIngestion.image.tag }}"
           imagePullPolicy: IfNotPresent
           ports:

--- a/charts/tradestream/templates/data-ingestion-deployment.yaml
+++ b/charts/tradestream/templates/data-ingestion-deployment.yaml
@@ -21,7 +21,9 @@ spec:
     spec:
       containers:
         - name: data-ingestion
-          args: {{ .Values.dataIngestion.args | default "" | quote }}
+          {{- if .Values.dataIngestion.args }}
+          args: {{ .Values.dataIngestion.args | toYaml | nindent 12 }}
+          {{- end }}
           image: "{{ .Values.dataIngestion.image.repository }}:{{ .Values.dataIngestion.image.tag }}"
           imagePullPolicy: IfNotPresent
           ports:

--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -23,7 +23,7 @@ kafka:
     transaction.state.log.replication.factor=3
     transaction.state.log.min.isr=2
 dataIngestion:
-  runMode: "wet"
+  args: "--runMode=wet"
   replicaCount: 1
   image:
     repository: "tradestreamhq/tradestream-data-ingestion"

--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -23,6 +23,7 @@ kafka:
     transaction.state.log.replication.factor=3
     transaction.state.log.min.isr=2
 dataIngestion:
+  runMode: "wet"
   replicaCount: 1
   image:
     repository: "tradestreamhq/tradestream-data-ingestion"

--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -23,7 +23,7 @@ kafka:
     transaction.state.log.replication.factor=3
     transaction.state.log.min.isr=2
 dataIngestion:
-  args: "--runMode=wet"
+  args: ["--runMode=wet"]
   replicaCount: 1
   image:
     repository: "tradestreamhq/tradestream-data-ingestion"


### PR DESCRIPTION
- Added support for passing configurable `args` to the `data-ingestion` container via Helm.  
- Updated `data-ingestion-deployment.yaml` to set container `args` dynamically using `Values.dataIngestion.args`.  
- Set default `args` value in `values.yaml` to `--runMode=wet`.  
- Modified the CI workflow to override the `args` value for testing (`--runMode=dry`).  

This change provides flexibility to customize runtime configurations for the `data-ingestion` container directly through Helm, enhancing deployment adaptability.