### PR TITLE
Add Logging for Trade Stream Subscription

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
@@ -92,6 +92,7 @@ final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
     }
 
     private Disposable subscribeToTradeStream(CurrencyPair currencyPair) {
+        logger.atInfo().log("Subscribing to trade stream for currency pair: %s", currencyPair);
         return exchange.get()
             .getStreamingMarketDataService()
             .getTrades(currencyPair)


### PR DESCRIPTION
- Introduced a log statement in the `subscribeToTradeStream` method to log when a trade stream subscription starts.  
- The log includes the currency pair being subscribed to, providing better traceability and debugging insights.  

This change enhances observability, helping to monitor which currency pairs are actively being processed.