### PR TITLE
Adjust Default Top Cryptocurrencies Tracked in `ConfigArguments`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/ConfigArguments.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/ConfigArguments.java
@@ -92,7 +92,7 @@ abstract class ConfigArguments implements Provider<Namespace> {
 
     parser.addArgument("--coinmarketcap.topN")
       .type(Integer.class)
-      .setDefault(100)
+      .setDefault(10)
       .help("Number of top cryptocurrencies to track (default: 100)");
 
     // Run mode configuration


### PR DESCRIPTION
- Updated the default value for the `--coinmarketcap.topN` argument in `ConfigArguments` from **100** to **10**.
- This change reduces the number of top cryptocurrencies tracked by default when using the CoinMarketCap API.

This adjustment optimizes resource usage and better aligns with scenarios requiring a smaller dataset by default.