### PR TITLE
Streamlined Subscription to Trade Streams in `RealTimeDataIngestionImpl`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
@@ -106,8 +106,7 @@ final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
 
     private void subscribeToTradeStreams() {
         currencyPairSupply.get().currencyPairs().stream()
-            .forEach(pair -> {
-                subscriptions.add(subscribeToTradeStream(pair)); // Collect disposables
-            });
+            .map(this::subscribeToTradeStream)
+            .forEach(subscriptions::add);
     }
 }


### PR DESCRIPTION
- Simplified the `subscribeToTradeStreams` method by replacing the explicit `forEach` block with a streamlined `.map(...).forEach(...)` chain.
- The new implementation maps each currency pair to a subscription and directly adds it to the `subscriptions` list.

This change improves readability and conciseness while maintaining the same functionality.