### PR TITLE
Add logging to CandlePublisher for monitoring Kafka interactions

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -68,11 +68,15 @@ java_library(
     name = "candle_publisher_impl",
     srcs = ["CandlePublisherImpl.java"],
     deps = [
+        "@maven//:com_google_flogger_flogger",
         "@maven//:com_google_inject_extensions_guice_assistedinject",
         "@maven//:com_google_inject_guice",
         "@maven//:org_apache_kafka_kafka_clients",
         "//protos:marketdata_java_proto",
         ":candle_publisher",
+    ],
+    runtime_deps = [
+        "@maven//:com_google_flogger_flogger_system_backend",
     ],
 )
 


### PR DESCRIPTION
Implement comprehensive logging in CandlePublisher to track Kafka publishing events and errors. This will help monitor the reliability of our data pipeline and quickly identify any publishing issues.