### PR TITLE
 Refactor `CandlePublisher` Interface Accessibility

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/CandlePublisher.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CandlePublisher.java
@@ -4,7 +4,7 @@ import com.verlumen.tradestream.marketdata.Candle;
 
 import java.time.Duration;
 
-public interface CandlePublisher {
+interface CandlePublisher {
     void publishCandle(Candle candle);
 
     void close();


### PR DESCRIPTION
- Changed the `CandlePublisher` interface from `public` to package-private by removing the `public` modifier.  
- Improves encapsulation by restricting the interface's visibility to the package.