### PR TITLE
Add WebSocket Health Monitor

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -253,6 +253,7 @@ java_library(
         ":thin_market_timer_task",
         ":thin_market_timer_task_impl",
         ":trade_processor",
+        ":websocket_health_monitor",
     ],
 )
 
@@ -384,3 +385,17 @@ java_library(
         "@maven//:com_google_flogger_flogger_system_backend",
     ],
 )
+
+java_library(
+    name = "websocket_health_monitor",
+    srcs = ["WebSocketHealthMonitor.java"],
+    deps = [
+        "@maven//:com_google_flogger_flogger",
+        "@maven//:com_google_inject_guice",
+        "@maven//:org_knowm_xchange_xchange_stream_core",
+    ],
+    runtime_deps = [
+        "@maven//:com_google_flogger_flogger_system_backend",
+    ],
+)
+

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -25,6 +25,8 @@ abstract class IngestionModule extends AbstractModule {
   
   @Override
   protected void configure() {
+    bind(WebSocketHealthMonitor.class).in(Singleton.class);
+
     bind(new TypeLiteral<KafkaProducer<String, byte[]>>() {})
         .toProvider(KafkaProducerProvider.class);
     bind(Namespace.class).toProvider(ConfigArguments.create(commandLineArgs()));
@@ -37,8 +39,6 @@ abstract class IngestionModule extends AbstractModule {
     bind(ThinMarketTimer.class).to(ThinMarketTimerImpl.class);
     bind(ThinMarketTimerTask.class).to(ThinMarketTimerTaskImpl.class);
     bind(Timer.class).toProvider(Timer::new);
-
-    bind(WebSocketHealthMonitor.class).in(Singleton.class);
 
     install(new FactoryModuleBuilder()
         .implement(CandleManager.class, CandleManagerImpl.class)

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -38,6 +38,8 @@ abstract class IngestionModule extends AbstractModule {
     bind(ThinMarketTimerTask.class).to(ThinMarketTimerTaskImpl.class);
     bind(Timer.class).toProvider(Timer::new);
 
+    bind(WebSocketHealthMonitor.class).in(Singleton.class);
+
     install(new FactoryModuleBuilder()
         .implement(CandleManager.class, CandleManagerImpl.class)
         .build(CandleManager.Factory.class));    

--- a/src/main/java/com/verlumen/tradestream/ingestion/WebSocketHealthMonitor.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/WebSocketHealthMonitor.java
@@ -9,14 +9,15 @@ import java.util.concurrent.TimeUnit;
 
 public class WebSocketHealthMonitor {
     private static final FluentLogger logger = FluentLogger.forEnclosingClass();
-    private final StreamingExchange exchange;
-    private final ScheduledExecutorService scheduler;
     private static final int HEALTH_CHECK_INTERVAL_SECONDS = 30;
 
+    private final StreamingExchange exchange;
+    private final ScheduledExecutorService scheduler;
+
     @Inject
-    public WebSocketHealthMonitor(StreamingExchange exchange) {
+    WebSocketHealthMonitor(StreamingExchange exchange, ScheduledExecutorService scheduler) {
         this.exchange = exchange;
-        this.scheduler = Executors.newSingleThreadScheduledExecutor();
+        this.scheduler = scheduler;
     }
 
     public void start() {

--- a/src/main/java/com/verlumen/tradestream/ingestion/WebSocketHealthMonitor.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/WebSocketHealthMonitor.java
@@ -1,0 +1,53 @@
+package com.verlumen.tradestream.ingestion;
+
+import com.google.common.flogger.FluentLogger;
+import com.google.inject.Inject;
+import info.bitrich.xchangestream.core.StreamingExchange;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class WebSocketHealthMonitor {
+    private static final FluentLogger logger = FluentLogger.forEnclosingClass();
+    private final StreamingExchange exchange;
+    private final ScheduledExecutorService scheduler;
+    private static final int HEALTH_CHECK_INTERVAL_SECONDS = 30;
+
+    @Inject
+    public WebSocketHealthMonitor(StreamingExchange exchange) {
+        this.exchange = exchange;
+        this.scheduler = Executors.newSingleThreadScheduledExecutor();
+    }
+
+    public void start() {
+        scheduler.scheduleAtFixedRate(
+            this::checkHealth, 
+            HEALTH_CHECK_INTERVAL_SECONDS, 
+            HEALTH_CHECK_INTERVAL_SECONDS, 
+            TimeUnit.SECONDS
+        );
+        logger.atInfo().log("WebSocket health monitoring started");
+    }
+
+    private void checkHealth() {
+        boolean isConnected = exchange.isAlive();
+        logger.atInfo().log("WebSocket health check - Connected: %b", isConnected);
+        
+        if (!isConnected) {
+            logger.atSevere().log("WebSocket connection appears to be down!");
+        }
+    }
+
+    public void stop() {
+        logger.atInfo().log("Stopping WebSocket health monitor");
+        scheduler.shutdown();
+        try {
+            if (!scheduler.awaitTermination(5, TimeUnit.SECONDS)) {
+                scheduler.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            scheduler.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/src/main/java/com/verlumen/tradestream/ingestion/WebSocketHealthMonitor.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/WebSocketHealthMonitor.java
@@ -3,52 +3,132 @@ package com.verlumen.tradestream.ingestion;
 import com.google.common.flogger.FluentLogger;
 import com.google.inject.Inject;
 import info.bitrich.xchangestream.core.StreamingExchange;
+
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-public class WebSocketHealthMonitor {
+/**
+ * Monitors the health of WebSocket connections to cryptocurrency exchanges.
+ * Performs periodic health checks and logs connection status.
+ * 
+ * This monitor:
+ * - Runs health checks at configurable intervals
+ * - Logs connection status changes
+ * - Attempts reconnection when connection is lost
+ * - Provides clean shutdown handling
+ */
+class WebSocketHealthMonitor {
     private static final FluentLogger logger = FluentLogger.forEnclosingClass();
+    
+    // Run health checks every 30 seconds by default
     private static final int HEALTH_CHECK_INTERVAL_SECONDS = 30;
+    
+    // Maximum time to wait for graceful shutdown
+    private static final int SHUTDOWN_TIMEOUT_SECONDS = 5;
 
     private final StreamingExchange exchange;
     private final ScheduledExecutorService scheduler;
+    private boolean isRunning;
 
+    /**
+     * Creates a new WebSocket health monitor.
+     *
+     * @param exchange The streaming exchange to monitor
+     * @param scheduler Scheduler for periodic health checks
+     */
     @Inject
     WebSocketHealthMonitor(StreamingExchange exchange, ScheduledExecutorService scheduler) {
         this.exchange = exchange;
         this.scheduler = scheduler;
+        this.isRunning = false;
     }
 
+    /**
+     * Starts the health monitoring service.
+     * Schedules periodic health checks at fixed intervals.
+     */
     public void start() {
+        if (isRunning) {
+            logger.atWarning().log("Health monitor is already running");
+            return;
+        }
+
         scheduler.scheduleAtFixedRate(
-            this::checkHealth, 
-            HEALTH_CHECK_INTERVAL_SECONDS, 
-            HEALTH_CHECK_INTERVAL_SECONDS, 
+            this::checkHealth,
+            HEALTH_CHECK_INTERVAL_SECONDS,
+            HEALTH_CHECK_INTERVAL_SECONDS,
             TimeUnit.SECONDS
         );
+        isRunning = true;
         logger.atInfo().log("WebSocket health monitoring started");
     }
 
+    /**
+     * Performs a health check of the WebSocket connection.
+     * Attempts reconnection if the connection is down.
+     */
     private void checkHealth() {
-        boolean isConnected = exchange.isAlive();
-        logger.atInfo().log("WebSocket health check - Connected: %b", isConnected);
-        
-        if (!isConnected) {
-            logger.atSevere().log("WebSocket connection appears to be down!");
+        try {
+            boolean isConnected = exchange.isAlive();
+            logger.atInfo().log("WebSocket health check - Connected: %b", isConnected);
+            
+            if (!isConnected) {
+                logger.atSevere().log("WebSocket connection appears to be down! Attempting reconnect...");
+                attemptReconnect();
+            }
+        } catch (Exception e) {
+            logger.atSevere().withCause(e).log("Error during health check");
         }
     }
 
+    /**
+     * Attempts to reconnect to the exchange by:
+     * 1. Disconnecting the current session (if any)
+     * 2. Establishing a new connection
+     * 
+     * Will timeout after 5 seconds for each operation.
+     */
+    private void attemptReconnect() {
+        try {
+            // First disconnect existing connection
+            exchange.disconnect().get(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            
+            // Then establish new connection
+            exchange.connect().get(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            logger.atInfo().log("Successfully reconnected WebSocket");
+        } catch (Exception e) {
+            logger.atSevere().withCause(e).log("Failed to reconnect WebSocket");
+        }
+    }
+
+    /**
+     * Stops the health monitoring service.
+     * Attempts graceful shutdown of the scheduler.
+     */
     public void stop() {
+        if (!isRunning) {
+            logger.atWarning().log("Health monitor is not running");
+            return;
+        }
+
         logger.atInfo().log("Stopping WebSocket health monitor");
         scheduler.shutdown();
         try {
-            if (!scheduler.awaitTermination(5, TimeUnit.SECONDS)) {
+            if (!scheduler.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
                 scheduler.shutdownNow();
             }
         } catch (InterruptedException e) {
             scheduler.shutdownNow();
             Thread.currentThread().interrupt();
         }
+        isRunning = false;
+    }
+
+    /**
+     * @return true if the health monitor is currently running
+     */
+    public boolean isRunning() {
+        return isRunning;
     }
 }

--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -185,4 +185,7 @@ java_test(
         "@maven//:org_knowm_xchange_xchange_stream_core",
         "//src/main/java/com/verlumen/tradestream/ingestion:websocket_health_monitor",
     ],
+    runtime_deps = [
+        "@maven//:com_google_flogger_flogger_system_backend",
+    ],
 )

--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -177,12 +177,12 @@ java_test(
     name = "WebSocketHealthMonitorTest",
     srcs = ["WebSocketHealthMonitorTest.java"],
     deps = [
-        ":websocket_health_monitor",
         "@maven//:com_google_inject_extensions_guice_testlib",
         "@maven//:com_google_inject_guice",
         "@maven//:com_google_truth_truth",
         "@maven//:junit_junit",
         "@maven//:org_mockito_mockito_core",
         "@maven//:org_knowm_xchange_xchange_stream_core",
+        "//src/main/java/com/verlumen/tradestream/ingestion:websocket_health_monitor",
     ],
 )

--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -172,3 +172,17 @@ java_test(
         "//src/main/java/com/verlumen/tradestream/ingestion:trade_processor",
     ],
 )
+
+java_test(
+    name = "WebSocketHealthMonitorTest",
+    srcs = ["WebSocketHealthMonitorTest.java"],
+    deps = [
+        ":websocket_health_monitor",
+        "@maven//:com_google_inject_extensions_guice_testlib",
+        "@maven//:com_google_inject_guice",
+        "@maven//:com_google_truth_truth",
+        "@maven//:junit_junit",
+        "@maven//:org_mockito_mockito_core",
+        "@maven//:org_knowm_xchange_xchange_stream_core",
+    ],
+)

--- a/src/test/java/com/verlumen/tradestream/ingestion/WebSocketHealthMonitorTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/WebSocketHealthMonitorTest.java
@@ -13,10 +13,13 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 @RunWith(JUnit4.class)

--- a/src/test/java/com/verlumen/tradestream/ingestion/WebSocketHealthMonitorTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/WebSocketHealthMonitorTest.java
@@ -30,18 +30,18 @@ public class WebSocketHealthMonitorTest {
     @Mock @Bind private ScheduledExecutorService mockScheduler;
     @Inject private WebSocketHealthMonitor monitor;
 
-    private ScheduledFuture<?> mockFuture;
+    @SuppressWarnings("unchecked")  // Safe for mocking
+    private ScheduledFuture<?> mockFuture = mock(ScheduledFuture.class);
 
     @Before
     public void setUp() {
-        mockFuture = mock(ScheduledFuture.class);
-        // Mock the scheduler's scheduleAtFixedRate to capture and verify the runnable
+        // Note the cast to handle generics properly
         when(mockScheduler.scheduleAtFixedRate(
             any(Runnable.class), 
             anyLong(), 
             anyLong(), 
             any(TimeUnit.class)
-        )).thenReturn(mockFuture);
+        )).thenReturn((ScheduledFuture<?>) mockFuture);
 
         Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
     }

--- a/src/test/java/com/verlumen/tradestream/ingestion/WebSocketHealthMonitorTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/WebSocketHealthMonitorTest.java
@@ -1,0 +1,76 @@
+package com.verlumen.tradestream.ingestion;
+
+import static org.mockito.Mockito.*;
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.testing.fieldbinder.Bind;
+import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import info.bitrich.xchangestream.core.StreamingExchange;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+@RunWith(JUnit4.class)
+public class WebSocketHealthMonitorTest {
+    @Rule public MockitoRule mocks = MockitoJUnit.rule();
+
+    @Mock @Bind private StreamingExchange mockExchange;
+    @Inject private WebSocketHealthMonitor monitor;
+
+    @Before
+    public void setUp() {
+        Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+    }
+
+    @Test
+    public void start_schedulesHealthCheck() throws InterruptedException {
+        // Arrange
+        when(mockExchange.isAlive()).thenReturn(true);
+
+        // Act
+        monitor.start();
+        Thread.sleep(100); // Allow scheduled task to run
+
+        // Assert
+        verify(mockExchange, atLeastOnce()).isAlive();
+    }
+
+    @Test
+    public void stop_shutsDownScheduler() throws InterruptedException {
+        // Arrange
+        monitor.start();
+
+        // Act
+        monitor.stop();
+        Thread.sleep(100); // Allow shutdown to complete
+
+        // Assert
+        // Verify no more health checks after stop
+        int callCount = mockingDetails(mockExchange).getInvocations().size();
+        Thread.sleep(100);
+        assertThat(mockingDetails(mockExchange).getInvocations().size())
+            .isEqualTo(callCount);
+    }
+
+    @Test
+    public void checkHealth_logsWarning_whenDisconnected() throws InterruptedException {
+        // Arrange
+        when(mockExchange.isAlive()).thenReturn(false);
+
+        // Act
+        monitor.start();
+        Thread.sleep(100); // Allow scheduled task to run
+
+        // Assert
+        verify(mockExchange, atLeastOnce()).isAlive();
+        // Note: Would ideally verify log message, but FluentLogger makes this difficult
+        // Consider using a logging framework that's more testable if this is important
+    }
+}

--- a/src/test/java/com/verlumen/tradestream/ingestion/WebSocketHealthMonitorTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/WebSocketHealthMonitorTest.java
@@ -17,6 +17,8 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
+import java.util.concurrent.TimeUnit;
+
 @RunWith(JUnit4.class)
 public class WebSocketHealthMonitorTest {
     @Rule public MockitoRule mocks = MockitoJUnit.rule();


### PR DESCRIPTION
- Introduced `WebSocketHealthMonitor` to check the health of the WebSocket connection at regular intervals.
- Integrated the health monitor as a singleton in `IngestionModule`.
- Added corresponding test `WebSocketHealthMonitorTest` for validation of health checks and lifecycle management.
- Updated Bazel build files to include new classes and dependencies:
  - Added `websocket_health_monitor` target.
  - Included `WebSocketHealthMonitorTest` in the test build.
- Ensures the WebSocket connection status is periodically logged, with warnings on disconnection.