### PR TITLE
Refactor Helm Chart Values for Data Ingestion Arguments

### DIFF
--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -23,7 +23,10 @@ kafka:
     transaction.state.log.replication.factor=3
     transaction.state.log.min.isr=2
 dataIngestion:
-  args: ["--runMode=wet"]
+  args: 
+    - "--runMode=wet"
+  replicaCount: 1
+  ...
   replicaCount: 1
   image:
     repository: "tradestreamhq/tradestream-data-ingestion"

--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -26,8 +26,7 @@ dataIngestion:
   args: 
     - "--runMode=wet"
   replicaCount: 1
-  ...
-  replicaCount: 1
+
   image:
     repository: "tradestreamhq/tradestream-data-ingestion"
     tag: v0.0.249-develop

--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -26,7 +26,6 @@ dataIngestion:
   args: 
     - "--runMode=wet"
   replicaCount: 1
-
   image:
     repository: "tradestreamhq/tradestream-data-ingestion"
     tag: v0.0.249-develop


### PR DESCRIPTION
Refactored the `dataIngestion.args` section in the `values.yaml` file for the `tradestream` Helm chart. The previous inline array format:  
```yaml
args: ["--runMode=wet"]
```  
has been updated to a multi-line YAML array format:  
```yaml
args: 
  - "--runMode=wet"
```  

This change improves readability and scalability, making it easier to manage additional arguments in the future while maintaining YAML best practices.