### PR TITLE
Add Candle Publisher Topic to Data Ingestion Arguments

### DIFF
--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -25,6 +25,7 @@ kafka:
 dataIngestion:
   args:
     - "--runMode=wet"
+    - "--candlePublisherTopic=your-topic-name"
   replicaCount: 1
   image:
     repository: "tradestreamhq/tradestream-data-ingestion"

--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -25,7 +25,7 @@ kafka:
 dataIngestion:
   args:
     - "--runMode=wet"
-    - "--candlePublisherTopic=your-topic-name"
+    - "--candlePublisherTopic=candles"
   replicaCount: 1
   image:
     repository: "tradestreamhq/tradestream-data-ingestion"


### PR DESCRIPTION
Updated the `dataIngestion.args` section in the `tradestream` Helm chart `values.yaml` file by adding the argument:  
```yaml
- "--candlePublisherTopic=candles"
```  

This enhancement allows the configuration of the `candlePublisherTopic` to specify the Kafka topic (`candles`) used for publishing candle data, improving flexibility and alignment with the application's data flow requirements.