### PR TITLE
Simplify Kafka Deployment Configuration for Tradestream

### DIFF
--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -1,7 +1,5 @@
 kafka:
   replicaCount: 2
-  nodeSelector:
-    kubernetes.io/arch: arm64
   persistence:
     enabled: true
     size: 10Gi


### PR DESCRIPTION
This update refines the Kafka configuration by removing the node selector targeting ARM64 architecture. Key changes include:

1. **Node Selector Removal**:  
   - The `nodeSelector` for ARM64 has been removed, enabling Kafka pods to deploy on any available node regardless of architecture.

2. **Unchanged Persistence Settings**:  
   - Persistence remains enabled with a 10Gi volume size to maintain data durability across restarts.

This change improves deployment flexibility, making Kafka compatible with a broader range of Kubernetes clusters and node architectures.