### PR TITLE
Refactor `MessageHandler` to a Static Inner Class in `CoinbaseStreamingClient`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/CoinbaseStreamingClient.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CoinbaseStreamingClient.java
@@ -42,7 +42,7 @@ final class CoinbaseStreamingClient implements ExchangeStreamingClient {
         this.httpClient = httpClient;
         this.pendingMessages = new ConcurrentHashMap<>();
         this.connector = new WebSocketConnector();
-        this.messageHandler = new MessageHandler();
+        this.messageHandler = new MessageHandler(this); // Pass reference to parent
     }
 
     @Override
@@ -119,9 +119,16 @@ final class CoinbaseStreamingClient implements ExchangeStreamingClient {
     }
 
     /**
-     * Inner class responsible for handling and parsing incoming JSON messages.
+     * Static inner class responsible for handling and parsing incoming JSON messages.
+     * This class now requires a reference to the outer class instance to access instance-specific fields.
      */
-    private class MessageHandler {
+    private static class MessageHandler {
+        private final CoinbaseStreamingClient parent;
+
+        MessageHandler(CoinbaseStreamingClient parent) {
+            this.parent = parent;
+        }
+
         void handle(JsonObject message) {
             logger.atFiner().log("Received message: %s", message);
 
@@ -177,15 +184,15 @@ final class CoinbaseStreamingClient implements ExchangeStreamingClient {
 
                         Trade trade = Trade.newBuilder()
                             .setTimestamp(timestamp)
-                            .setExchange(getExchangeName())
+                            .setExchange(parent.getExchangeName())
                             .setCurrencyPair(tradeJson.get("product_id").getAsString().replace("-", "/"))
                             .setPrice(tradeJson.get("price").getAsDouble())
                             .setVolume(tradeJson.get("size").getAsDouble())
                             .setTradeId(tradeJson.get("trade_id").getAsString())
                             .build();
 
-                        if (tradeHandler != null) {
-                            tradeHandler.accept(trade);
+                        if (parent.tradeHandler != null) {
+                            parent.tradeHandler.accept(trade);
                         } else {
                             logger.atWarning().log("Received trade but no handler is registered");
                         }


### PR DESCRIPTION
The `MessageHandler` class in `CoinbaseStreamingClient` was converted to a static inner class for better encapsulation. A reference to the parent `CoinbaseStreamingClient` instance is passed to the `MessageHandler` during construction, enabling access to instance-specific fields like `tradeHandler` and methods like `getExchangeName`. This approach improves clarity and maintains a clean separation of concerns while allowing `MessageHandler` to interact with the outer class effectively.