### PR TITLE
Refactor `CurrencyPairMetadata` Factory Method for Enhanced Flexibility

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairMetadata.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairMetadata.java
@@ -8,12 +8,12 @@ import java.math.BigDecimal;
 
 @AutoValue
 abstract class CurrencyPairMetadata {
-  static CurrencyPairMetadata create(String pair, long marketCapValue) {
+  static CurrencyPairMetadata create(String pair, BigDecimal marketCapValue) {
     return create(new CurrencyPair(pair), marketCapValue);
   }
 
-  static CurrencyPairMetadata create(CurrencyPair currencyPair, long marketCapValue) {
-    MarketCap marketCap = MarketCap.create(BigDecimal.valueOf(marketCapValue), Currency.USD);
+  static CurrencyPairMetadata create(CurrencyPair currencyPair, BigDecimal marketCapValue) {
+    MarketCap marketCap = MarketCap.create(marketCapValue, currencyPair.counter());
     return new AutoValue_CurrencyPairMetadata(currencyPair, marketCap);
   }
 

--- a/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairMetadata.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairMetadata.java
@@ -8,7 +8,7 @@ import java.math.BigDecimal;
 
 @AutoValue
 abstract class CurrencyPairMetadata {
-  static CurrencyPairMetadata create(String pair, BigDecimal marketCapValue) {
+  static CurrencyPairMetadata create(String pair, long marketCapValue) {
     return create(new CurrencyPair(pair), marketCapValue);
   }
 

--- a/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairMetadata.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairMetadata.java
@@ -13,11 +13,7 @@ abstract class CurrencyPairMetadata {
   }
 
   static CurrencyPairMetadata create(CurrencyPair currencyPair, long marketCapValue) {
-    return create(currencyPair, BigDecimal.valueOf(marketCapValue));
-  }
-
-  static CurrencyPairMetadata create(CurrencyPair currencyPair, BigDecimal marketCapValue) {
-    MarketCap marketCap = MarketCap.create(marketCapValue, Currency.USD);
+    MarketCap marketCap = MarketCap.create(BigDecimal.valueOf(marketCapValue), Currency.USD);
     return new AutoValue_CurrencyPairMetadata(currencyPair, marketCap);
   }
 

--- a/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairMetadata.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairMetadata.java
@@ -13,7 +13,7 @@ abstract class CurrencyPairMetadata {
   }
 
   private static CurrencyPairMetadata create(CurrencyPair currencyPair, BigDecimal marketCapValue) {
-    MarketCap marketCap = MarketCap.create(marketCapValue, currencyPair.counter());
+    MarketCap marketCap = MarketCap.create(marketCapValue, currencyPair.getCounter());
     return new AutoValue_CurrencyPairMetadata(currencyPair, marketCap);
   }
 

--- a/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
@@ -23,9 +23,9 @@ public class ThinMarketTimerTaskImplTest {
     @Rule public MockitoRule mocks = MockitoJUnit.rule();
 
     private static final CurrencyPairMetadata BTC_USD = 
-        CurrencyPairMetadata.create(new CurrencyPair("BTC", "USD"), 456L);
+        CurrencyPairMetadata.create("BTC/USD", 456L);
     private static final CurrencyPairMetadata ETH_EUR = 
-        CurrencyPairMetadata.create(new CurrencyPair("ETH", "EUR"), 567L);
+        CurrencyPairMetadata.create("ETH/EUR", 567L);
 
     @Mock @Bind private CandleManager candleManager;
     @Mock @Bind private CurrencyPairSupply currencyPairSupply;

--- a/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
@@ -18,6 +18,8 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
+import java.math.BigDecimal;
+
 @RunWith(JUnit4.class)
 public class ThinMarketTimerTaskImplTest {
     @Rule public MockitoRule mocks = MockitoJUnit.rule();

--- a/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/ThinMarketTimerTaskImplTest.java
@@ -23,9 +23,9 @@ public class ThinMarketTimerTaskImplTest {
     @Rule public MockitoRule mocks = MockitoJUnit.rule();
 
     private static final CurrencyPairMetadata BTC_USD = 
-        CurrencyPairMetadata.create("BTC/USD", 456L);
+        CurrencyPairMetadata.create("BTC/USD", BigDecimal.valueOf(456L));
     private static final CurrencyPairMetadata ETH_EUR = 
-        CurrencyPairMetadata.create("ETH/EUR", 567L);
+        CurrencyPairMetadata.create("ETH/EUR", BigDecimal.valueOf(567L));
 
     @Mock @Bind private CandleManager candleManager;
     @Mock @Bind private CurrencyPairSupply currencyPairSupply;


### PR DESCRIPTION
1. **Removed Redundant Overload**:
   - The overloaded `create` method in `CurrencyPairMetadata` that accepted a `CurrencyPair` and a `long` market capitalization was removed. This simplifies the API and reduces redundancy.

2. **Dynamic Counter Currency**:
   - Updated the remaining `create` method to dynamically use the counter currency from the `CurrencyPair` for the `MarketCap` creation, improving flexibility and aligning the metadata with the specific currency context.

3. **Test Adjustments**:
   - Modified tests in `ThinMarketTimerTaskImplTest` to use the simplified `create` method that directly accepts a string representing the currency pair and a `BigDecimal` for market capitalization, ensuring consistency with the refactored implementation.