### PR TITLE
Enhance `CurrencyPairMetadata` MarketCap Initialization with Dynamic Counter Currency

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairMetadata.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairMetadata.java
@@ -17,7 +17,7 @@ abstract class CurrencyPairMetadata {
   }
 
   static CurrencyPairMetadata create(CurrencyPair currencyPair, BigDecimal marketCapValue) {
-    MarketCap marketCap = MarketCap.create(marketCapValue, Currency.USD);
+    MarketCap marketCap = MarketCap.create(marketCapValue, currencyPair.counter());
     return new AutoValue_CurrencyPairMetadata(currencyPair, marketCap);
   }
 

--- a/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairMetadata.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairMetadata.java
@@ -17,7 +17,7 @@ abstract class CurrencyPairMetadata {
   }
 
   private static CurrencyPairMetadata create(CurrencyPair currencyPair, BigDecimal marketCapValue) {
-    MarketCap marketCap = MarketCap.create(marketCapValue, currencyPair.counter());
+    MarketCap marketCap = MarketCap.create(marketCapValue, currencyPair.getCounter());
     return new AutoValue_CurrencyPairMetadata(currencyPair, marketCap);
   }
 


### PR DESCRIPTION
This update modifies the `create` method in the `CurrencyPairMetadata` class to use the counter currency from the provided `CurrencyPair` for `MarketCap` creation. 

### Key Changes:
1. **Dynamic Counter Currency**:
   - Replaced the static use of `Currency.USD` with `currencyPair.getCounter()` when creating a `MarketCap`. This ensures the metadata reflects the specific counter currency associated with the `CurrencyPair`.

2. **Improved Flexibility**:
   - Allows `CurrencyPairMetadata` to support diverse currency pairs dynamically, aligning metadata construction with the actual trading pair context.

This change simplifies the handling of non-USD counter currencies and increases adaptability in multi-currency trading environments.