### PR TITLE
Restrict `create` Method Access in `CurrencyPairMetadata`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairMetadata.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CurrencyPairMetadata.java
@@ -16,7 +16,7 @@ abstract class CurrencyPairMetadata {
     return create(currencyPair, BigDecimal.valueOf(marketCapValue));
   }
 
-  static CurrencyPairMetadata create(CurrencyPair currencyPair, BigDecimal marketCapValue) {
+  private static CurrencyPairMetadata create(CurrencyPair currencyPair, BigDecimal marketCapValue) {
     MarketCap marketCap = MarketCap.create(marketCapValue, Currency.USD);
     return new AutoValue_CurrencyPairMetadata(currencyPair, marketCap);
   }


### PR DESCRIPTION
The `create` method in `CurrencyPairMetadata` that accepts a `CurrencyPair` and a `BigDecimal` for market capitalization was changed from `static` with package-private access to `private`. This limits the creation of `CurrencyPairMetadata` instances to within the class itself, enforcing better encapsulation and preventing unintended usage from other classes.