### PR TITLE
Add Default Support Check for Currency Pairs in `ExchangeStreamingClient`  

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/ExchangeStreamingClient.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/ExchangeStreamingClient.java
@@ -30,9 +30,20 @@ interface ExchangeStreamingClient {
     String getExchangeName();
 
     /**
+     * Checks if the given currency pair is supported by the exchange.
+     * Default implementation always returns true until further implementation.
+     *
+     * @param currencyPair The currency pair to check (e.g., "BTC/USD").
+     * @return true if the currency pair is supported, false otherwise.
+     */
+    default boolean isSupportedCurrencyPair(String currencyPair) {
+        return true;
+    }
+
+    /**
      * Factory for creating exchange-specific streaming clients.
      */
-    interface Factory {       
+    interface Factory {
         ExchangeStreamingClient create(String exchangeName);
     }
 }


### PR DESCRIPTION
Enhance the `ExchangeStreamingClient` interface by introducing a default method to check the support status of a specific currency pair, allowing for future extensibility without breaking existing implementations.  

---

### Key Changes:  

1. **Added `isSupportedCurrencyPair` Method**:  
   - Introduced a default method `isSupportedCurrencyPair` to the `ExchangeStreamingClient` interface.  
   - Provides a default implementation that always returns `true`.  

2. **Future-Proofing for Exchange-Specific Logic**:  
   - The method enables exchange-specific implementations to override the default behavior and implement currency pair validation as needed.  

3. **Preserved Backward Compatibility**:  
   - Existing implementations of `ExchangeStreamingClient` remain unaffected due to the default method implementation.  

---

### Benefits:  

- **Enhanced Extensibility**: Allows future implementations to enforce exchange-specific currency pair restrictions without changing the interface structure.  
- **Ease of Implementation**: Developers can rely on the default behavior initially and override the method for stricter validation as needed.  
- **Backward Compatibility**: Ensures no breaking changes for existing implementations, reducing the risk during updates.  

This update prepares the framework for better currency pair validation while maintaining its current flexibility and compatibility.