### PR TITLE
Filter Unsupported Symbols for Market Data Ingestion

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -338,6 +338,7 @@ java_library(
     srcs = ["RealTimeDataIngestionImpl.java"],
     deps = [
         "@maven//:com_google_flogger_flogger",
+        "@maven//:com_google_guava_guava",
         "@maven//:com_google_inject_guice",
         "//protos:marketdata_java_proto",
         ":candle_manager",

--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
@@ -38,12 +38,8 @@ final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
     public void start() {
         logger.atInfo().log("Starting real-time data ingestion for %s", 
             exchangeClient.getExchangeName());
-    
-        exchangeClient.startStreaming(
-            currencyPairSupply.get().symbols(),
-            this::processTrade
-        );
         
+        startMarketDataIngestion();
         logger.atInfo().log("Starting thin market timer...");
         thinMarketTimer.get().start();
         logger.atInfo().log("Real-time data ingestion system fully initialized and running");
@@ -89,5 +85,12 @@ final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
                 "Error processing trade: %s", trade.getTradeId());
             // Don't rethrow - we want to continue processing other trades
         }
+    }
+
+    private void startMarketDataIngestion() {
+        exchangeClient.startStreaming(
+            currencyPairSupply.get().symbols(),
+            this::processTrade
+        );
     }
 }

--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
@@ -91,14 +91,14 @@ final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
     }
 
     private void startMarketDataIngestion() {
-        ImmutableList<String> supportedSymbols = currencyPairSupply.get()
+        exchangeClient.startStreaming(supportedSymbols(), this::processTrade);
+    }
+
+    private ImmutableList<String> supportedSymbols() {
+        return currencyPairSupply.get()
             .symbols()
             .stream()
             .filter(exchangeClient::isSupportedCurrencyPair)
             .collect(toImmutableList());
-        exchangeClient.startStreaming(
-            currencyPairSupply.get().symbols().stream(),
-            this::processTrade
-        );
     }
 }

--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
@@ -1,5 +1,8 @@
 package com.verlumen.tradestream.ingestion;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+import com.google.common.collect.ImmutableList;
 import com.google.common.flogger.FluentLogger;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
@@ -88,8 +91,13 @@ final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
     }
 
     private void startMarketDataIngestion() {
+        ImmutableList<String> supportedSymbols = currencyPairSupply.get()
+            .symbols()
+            .stream()
+            .filter(exchangeClient::isSupportedCurrencyPair)
+            .collect(toImmutableList());
         exchangeClient.startStreaming(
-            currencyPairSupply.get().symbols(),
+            currencyPairSupply.get().symbols().stream(),
             this::processTrade
         );
     }

--- a/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
@@ -49,14 +49,36 @@ public class RealTimeDataIngestionImplTest {
 
     @Test
     public void start_initiatesStreaming() {
+        // Arrange
+        List<String> pairs = ImmutableList.of("BTC/USD", "ETH/USD");
+        when(mockCurrencyPairSupply.get())
+            .thenReturn(new CurrencyPairs(pairs));
+        when(mockExchangeClient.isSupportedCurrencyPair(anyString())).thenReturn(true);
+
         // Act
         realTimeDataIngestion.start();
 
         // Assert
-        verify(mockExchangeClient).startStreaming(
-            eq(TEST_CURRENCY_PAIRS),
-            any(Consumer.class)
-        );
+        verify(mockExchangeClient).startStreaming(pairs, realTimeDataIngestion);
+    }
+    
+    @Test
+    public void start_usesCorrectCurrencyPairs() {
+        // Arrange 
+        String supportedPair = "TEST1/USD";
+        String unsupportedPair = "TEST2/USD";
+        List<String> pairs = ImmutableList.of(supportedPair, unsupportedPair);
+        List<String> expected = ImmutableList.of(supportedPair);
+        when(mockCurrencyPairSupply.get()).thenReturn(new CurrencyPairs(pairs));
+
+        when(mockExchangeClient.isSupportedCurrencyPair(supportedPair)).thenReturn(true);
+        when(mockExchangeClient.isSupportedCurrencyPair(unsupportedPair)).thenReturn(false);
+
+        // Act
+        realTimeDataIngestion.start();
+
+        // Assert
+        verify(mockExchangeClient).startStreaming(expected, realTimeDataIngestion);
     }
 
     @Test

--- a/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
@@ -183,7 +183,7 @@ public class RealTimeDataIngestionImplTest {
         realTimeDataIngestion.start();
 
         // Assert
-        verify(mockExchangeClient).startStreaming(eq(pairs), any(Consumer.class));
+        verify(mockExchangeClient).startStreaming(eq(expected), any(Consumer.class));
     }
 
     @Test

--- a/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
@@ -61,7 +61,7 @@ public class RealTimeDataIngestionImplTest {
         // Assert
         verify(mockExchangeClient).startStreaming(pairs, realTimeDataIngestion);
     }
-    
+
     @Test
     public void start_startsThinMarketTimer() {
         // Act

--- a/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
@@ -183,7 +183,7 @@ public class RealTimeDataIngestionImplTest {
         realTimeDataIngestion.start();
 
         // Assert
-        verify(mockExchangeClient).startStreaming(expected, realTimeDataIngestion);
+        verify(mockExchangeClient).startStreaming(eq(pairs), any(Consumer.class));
     }
 
     @Test

--- a/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
@@ -63,25 +63,6 @@ public class RealTimeDataIngestionImplTest {
     }
     
     @Test
-    public void start_usesCorrectCurrencyPairs() {
-        // Arrange 
-        String supportedPair = "TEST1/USD";
-        String unsupportedPair = "TEST2/USD";
-        List<String> pairs = ImmutableList.of(supportedPair, unsupportedPair);
-        List<String> expected = ImmutableList.of(supportedPair);
-        when(mockCurrencyPairSupply.get()).thenReturn(new CurrencyPairs(pairs));
-
-        when(mockExchangeClient.isSupportedCurrencyPair(supportedPair)).thenReturn(true);
-        when(mockExchangeClient.isSupportedCurrencyPair(unsupportedPair)).thenReturn(false);
-
-        // Act
-        realTimeDataIngestion.start();
-
-        // Assert
-        verify(mockExchangeClient).startStreaming(expected, realTimeDataIngestion);
-    }
-
-    @Test
     public void start_startsThinMarketTimer() {
         // Act
         realTimeDataIngestion.start();
@@ -189,15 +170,21 @@ public class RealTimeDataIngestionImplTest {
 
     @Test
     public void start_usesCorrectCurrencyPairs() {
-        // Arrange
-        ImmutableList<String> expectedPairs = ImmutableList.of("TEST1/USD", "TEST2/USD");
-        when(mockCurrencyPairSupply.symbols()).thenReturn(expectedPairs);
+        // Arrange 
+        String supportedPair = "TEST1/USD";
+        String unsupportedPair = "TEST2/USD";
+        List<String> pairs = ImmutableList.of(supportedPair, unsupportedPair);
+        List<String> expected = ImmutableList.of(supportedPair);
+        when(mockCurrencyPairSupply.get()).thenReturn(new CurrencyPairs(pairs));
+
+        when(mockExchangeClient.isSupportedCurrencyPair(supportedPair)).thenReturn(true);
+        when(mockExchangeClient.isSupportedCurrencyPair(unsupportedPair)).thenReturn(false);
 
         // Act
         realTimeDataIngestion.start();
 
         // Assert
-        verify(mockExchangeClient).startStreaming(eq(expectedPairs), any());
+        verify(mockExchangeClient).startStreaming(expected, realTimeDataIngestion);
     }
 
     @Test

--- a/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
@@ -173,9 +173,9 @@ public class RealTimeDataIngestionImplTest {
         // Arrange 
         String supportedPair = "TEST1/USD";
         String unsupportedPair = "TEST2/USD";
-        List<String> pairs = ImmutableList.of(supportedPair, unsupportedPair);
-        List<String> expected = ImmutableList.of(supportedPair);
-        when(mockCurrencyPairSupply.get()).thenReturn(new CurrencyPairs(pairs));
+        ImmutableList<String> pairs = ImmutableList.of(supportedPair, unsupportedPair);
+        ImmutableList<String> expected = ImmutableList.of(supportedPair);
+        when(mockCurrencyPairSupply.symbols()).thenReturn(pairs);
 
         when(mockExchangeClient.isSupportedCurrencyPair(supportedPair)).thenReturn(true);
         when(mockExchangeClient.isSupportedCurrencyPair(unsupportedPair)).thenReturn(false);

--- a/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
@@ -50,9 +50,8 @@ public class RealTimeDataIngestionImplTest {
     @Test
     public void start_initiatesStreaming() {
         // Arrange
-        List<String> pairs = ImmutableList.of("BTC/USD", "ETH/USD");
-        when(mockCurrencyPairSupply.get())
-            .thenReturn(new CurrencyPairs(pairs));
+        ImmutableList<String> pairs = ImmutableList.of("BTC/USD", "ETH/USD");
+        when(mockCurrencyPairSupply.symbols()).thenReturn(pairs);
         when(mockExchangeClient.isSupportedCurrencyPair(anyString())).thenReturn(true);
 
         // Act

--- a/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
@@ -58,7 +58,7 @@ public class RealTimeDataIngestionImplTest {
         realTimeDataIngestion.start();
 
         // Assert
-        verify(mockExchangeClient).startStreaming(pairs, realTimeDataIngestion);
+        verify(mockExchangeClient).startStreaming(eq(pairs), any(Consumer.class));
     }
 
     @Test


### PR DESCRIPTION
- **New Method**: Introduced `supportedSymbols()` to filter symbols based on exchange support.  
- **Improved Start Logic**: `startMarketDataIngestion()` now ingests only supported symbols.  
- **Streamlined Flow**: Enhances compatibility checks and reduces runtime errors.  

Simplifies real-time ingestion by validating exchange compatibility upfront.