### PR TITLE
Remove Unused Dependency on `org_knowm_xchange_xchange_core`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -158,7 +158,6 @@ java_library(
         "@maven//:com_google_code_gson_gson",
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_inject_guice",
-        "@maven//:org_knowm_xchange_xchange_core",
         ":coin_market_cap_config",
         ":currency_pair_metadata",
         ":currency_pair_supply",


### PR DESCRIPTION
- **Simplified Dependencies**: Removed `org_knowm_xchange_xchange_core` from the `BUILD` file.
- **Reason**: The project no longer relies on this library, ensuring cleaner and more efficient builds.
- **Impact**: Reduces overhead and potential confusion by maintaining only actively used dependencies.