### PR TITLE
Add Kafka Bootstrap Server Argument in `values.yaml` for Helm Chart

### DIFF
--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -24,6 +24,7 @@ dataIngestion:
   args:
     - "--runMode=wet"
     - "--candlePublisherTopic=candles"
+    - "--kafka.bootstrap.servers={{ include \"tradestream.fullname\" . }}-kafka.{{ .Release.Namespace }}.svc.cluster.local:9092"
   replicaCount: 1
   image:
     repository: "tradestreamhq/tradestream-data-ingestion"


### PR DESCRIPTION
This update introduces the `--kafka.bootstrap.servers` argument under the `dataIngestion.args` in the Helm chart's `values.yaml` file.

### Key Changes:
1. **Kafka Bootstrap Server Argument**:
   - Added `--kafka.bootstrap.servers` with a dynamically generated service address.
   - Service address uses Helm templating:
     ```
     {{ include "tradestream.fullname" . }}-kafka.{{ .Release.Namespace }}.svc.cluster.local:9092
     ```
   - Ensures the Kafka service is correctly resolved in the cluster.

2. **Namespace Awareness**:
   - The argument dynamically resolves the namespace using `.Release.Namespace`, allowing the Helm chart to function across multiple namespaces without manual configuration.

3. **Default Kafka Port**:
   - Specifies `9092` as the default Kafka bootstrap server port.

### Benefits:
- **Dynamic and Scalable**:
  - Simplifies deployment configurations by dynamically adjusting to the release namespace and Helm-defined service names.
- **Improved Maintainability**:
  - Explicitly declares Kafka connection details, reducing potential configuration errors.
- **Cluster Compatibility**:
  - Ensures compatibility across Kubernetes clusters with dynamic namespace resolution.

This change enhances the data ingestion deployment's ability to integrate seamlessly with Kafka in a Kubernetes environment.