### PR TITLE
Remove Default Value for `--runMode` Argument in `ConfigArguments`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/ConfigArguments.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/ConfigArguments.java
@@ -98,7 +98,6 @@ abstract class ConfigArguments implements Provider<Namespace> {
     // Run mode configuration
     parser.addArgument("--runMode")
       .choices("wet", "dry")
-      .setDefault("wet")
       .help("Run mode: wet or dry");
 
     return parser;


### PR DESCRIPTION
1. Removed `.setDefault("wet")` for the `--runMode` argument.
2. Requires explicit `"wet"` or `"dry"` configuration.