### PR TITLE
Remove Kafka Bootstrap Servers Default and Update Tests

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/ConfigArguments.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/ConfigArguments.java
@@ -45,7 +45,6 @@ abstract class ConfigArguments implements Provider<Namespace> {
 
     // Kafka configuration
     parser.addArgument("--kafka.bootstrap.servers")
-      .setDefault("localhost:9092")
       .help("Kafka bootstrap servers");
 
     parser.addArgument("--kafka.acks")

--- a/src/main/java/com/verlumen/tradestream/ingestion/container-structure-test.yaml
+++ b/src/main/java/com/verlumen/tradestream/ingestion/container-structure-test.yaml
@@ -3,5 +3,9 @@ schemaVersion: 2.0.0
 commandTests:
   - name: test
     command: java
-    args: ['-jar', '/src/main/java/com/verlumen/tradestream/ingestion/app_deploy.jar', '--runMode=dry']
+    args:
+    - '-jar'
+    - '/src/main/java/com/verlumen/tradestream/ingestion/app_deploy.jar'
+    - '--kafka.bootstrap.servers=localhost:9092'
+    - '--runMode=dry'
     expectedError: ['.*Starting real-time data ingestion...']


### PR DESCRIPTION
1. **`ConfigArguments.java`**:
   - Removed default value for `--kafka.bootstrap.servers`.
2. **`container-structure-test.yaml`**:
   - Added explicit `--kafka.bootstrap.servers` argument with `localhost:9092` for tests.