### PR TITLE
Add Coinbase API Support for Fetching Supported Currency Pairs

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/CoinbaseStreamingClient.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CoinbaseStreamingClient.java
@@ -12,8 +12,11 @@ import com.google.inject.Inject;
 import com.verlumen.tradestream.instruments.CurrencyPair;
 import com.verlumen.tradestream.marketdata.Trade;
 
-import java.net.URI;
+import java.io.IOException;
 import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.URI;
 import java.net.http.WebSocket;
 import java.time.Instant;
 import java.util.ArrayList;

--- a/src/main/java/com/verlumen/tradestream/ingestion/CoinbaseStreamingClient.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CoinbaseStreamingClient.java
@@ -1,5 +1,6 @@
 package com.verlumen.tradestream.ingestion;
 
+import static com.google.common.collect.Streams.stream;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.common.collect.ImmutableList;
@@ -126,7 +127,7 @@ final class CoinbaseStreamingClient implements ExchangeStreamingClient {
             JsonArray productsArray = jsonElement.getAsJsonArray();
             
             // Convert JsonArray to Stream and map each product "id" to a CurrencyPair
-            ImmutableList<CurrencyPair> pairs = StreamSupport.stream(productsArray.spliterator(), false)
+            ImmutableList<CurrencyPair> pairs = stream(productsArray)
                 .filter(JsonElement::isJsonObject)
                 .map(JsonElement::getAsJsonObject)
                 .filter(obj -> obj.has("id"))

--- a/src/main/java/com/verlumen/tradestream/ingestion/CoinbaseStreamingClient.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CoinbaseStreamingClient.java
@@ -126,7 +126,6 @@ final class CoinbaseStreamingClient implements ExchangeStreamingClient {
             
             // Map each product "id" to a CurrencyPair
             ImmutableList<CurrencyPair> pairs = productsArray
-                .asList()
                 .stream()
                 .filter(JsonElement::isJsonObject)
                 .map(JsonElement::getAsJsonObject)

--- a/src/main/java/com/verlumen/tradestream/ingestion/CoinbaseStreamingClient.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CoinbaseStreamingClient.java
@@ -95,6 +95,7 @@ final class CoinbaseStreamingClient implements ExchangeStreamingClient {
      * 
      * @return an immutable list of supported CurrencyPairs.
      */
+    @Override
     public ImmutableList<CurrencyPair> supportedCurrencyPairs(String delimiter) {
         logger.atInfo().log("Fetching supported currency pairs from Coinbase");
         

--- a/src/main/java/com/verlumen/tradestream/ingestion/CoinbaseStreamingClient.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CoinbaseStreamingClient.java
@@ -124,9 +124,8 @@ final class CoinbaseStreamingClient implements ExchangeStreamingClient {
             
             JsonArray productsArray = jsonElement.getAsJsonArray();
             
-            // Map each product "id" to a CurrencyPair
-            ImmutableList<CurrencyPair> pairs = productsArray
-                .stream()
+            // Convert JsonArray to Stream and map each product "id" to a CurrencyPair
+            ImmutableList<CurrencyPair> pairs = StreamSupport.stream(productsArray.spliterator(), false)
                 .filter(JsonElement::isJsonObject)
                 .map(JsonElement::getAsJsonObject)
                 .filter(obj -> obj.has("id"))

--- a/src/main/java/com/verlumen/tradestream/ingestion/CoinbaseStreamingClient.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CoinbaseStreamingClient.java
@@ -28,7 +28,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
-import java.util.stream.StreamSupport;
 
 final class CoinbaseStreamingClient implements ExchangeStreamingClient {
     private static final FluentLogger logger = FluentLogger.forEnclosingClass();

--- a/src/main/java/com/verlumen/tradestream/ingestion/CoinbaseStreamingClient.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CoinbaseStreamingClient.java
@@ -27,6 +27,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
+import java.util.stream.StreamSupport;
 
 final class CoinbaseStreamingClient implements ExchangeStreamingClient {
     private static final FluentLogger logger = FluentLogger.forEnclosingClass();

--- a/src/main/java/com/verlumen/tradestream/ingestion/CoinbaseStreamingClient.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CoinbaseStreamingClient.java
@@ -94,7 +94,7 @@ final class CoinbaseStreamingClient implements ExchangeStreamingClient {
      * 
      * @return an immutable list of supported CurrencyPairs.
      */
-    public ImmutableList<CurrencyPair> supportedCurrencyPairs() {
+    public ImmutableList<CurrencyPair> supportedCurrencyPairs(String delimiter) {
         logger.atInfo().log("Fetching supported currency pairs from Coinbase");
         
         // Coinbase Exchange Products endpoint
@@ -132,6 +132,7 @@ final class CoinbaseStreamingClient implements ExchangeStreamingClient {
                 .map(JsonElement::getAsJsonObject)
                 .filter(obj -> obj.has("id"))
                 .map(obj -> obj.get("id").getAsString())
+                .map(productId -> productId.replace("-", delimiter))
                 .map(CurrencyPair::fromSymbol)
                 .collect(toImmutableList());
             

--- a/src/main/java/com/verlumen/tradestream/ingestion/ExchangeStreamingClient.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/ExchangeStreamingClient.java
@@ -44,6 +44,13 @@ interface ExchangeStreamingClient {
     }
 
     /**
+     * Fetches the list of supported currency pairs from the Coinbase API.
+     * 
+     * @return an immutable list of supported CurrencyPairs.
+     */
+    ImmutableList<CurrencyPair> supportedCurrencyPairs(String delimiter);
+
+    /**
      * Factory for creating exchange-specific streaming clients.
      */
     interface Factory {


### PR DESCRIPTION
1. **`CoinbaseStreamingClient.java`**:
   - Implemented `supportedCurrencyPairs` to fetch supported pairs from the Coinbase API.
   - Parses product IDs into `CurrencyPair` instances using a customizable delimiter.
   - Logs success and error states during API calls.
2. **`ExchangeStreamingClient.java`**:
   - Added `supportedCurrencyPairs` abstract method to fetch exchange-supported pairs.