### PR TITLE
Update GitHub Actions Checkout Version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
           - 5000:5000
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Start minikube
         uses: medyagh/setup-minikube@latest


### PR DESCRIPTION
Upgraded `actions/checkout` from `v3` to `v4` for enhanced features and performance.