### PR TITLE
Simplify Streaming Test Assertions

### DIFF
--- a/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
@@ -64,7 +64,7 @@ public class RealTimeDataIngestionImplTest {
         realTimeDataIngestion.start();
 
         // Assert
-        verify(mockExchangeClient).startStreaming(eq(SUPPORTED_CURRENCY_PAIRS), any(Consumer.class));
+        verify(mockExchangeClient).startStreaming(eq(TEST_CURRENCY_PAIRS), any(Consumer.class));
     }
 
     @Test

--- a/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
@@ -54,6 +54,7 @@ public class RealTimeDataIngestionImplTest {
         when(mockCurrencyPairSupply.currencyPairs()).thenReturn(TEST_CURRENCY_PAIRS);
         when(mockExchangeClient.getExchangeName()).thenReturn(TEST_EXCHANGE);
         when(mockExchangeClient.supportedCurrencyPairs("/")).thenReturn(SUPPORTED_CURRENCY_PAIRS);
+        when(mockExchangeClient.isSupportedCurrencyPair(any(CurrencyPair.class))).thenReturn(true);
 
         Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
     }

--- a/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
@@ -60,18 +60,11 @@ public class RealTimeDataIngestionImplTest {
 
     @Test
     public void start_initiatesStreaming() {
-        // Arrange
-        ImmutableList<CurrencyPair> pairs = Stream.of("BTC/USD", "ETH/USD")
-            .map(CurrencyPair::fromSymbol)
-            .collect(toImmutableList());
-        when(mockCurrencyPairSupply.currencyPairs()).thenReturn(pairs);
-        when(mockExchangeClient.isSupportedCurrencyPair(any(CurrencyPair.class))).thenReturn(true);
-
         // Act
         realTimeDataIngestion.start();
 
         // Assert
-        verify(mockExchangeClient).startStreaming(eq(pairs), any(Consumer.class));
+        verify(mockExchangeClient).startStreaming(eq(SUPPORTED_CURRENCY_PAIRS), any(Consumer.class));
     }
 
     @Test


### PR DESCRIPTION
1. Removed redundant arrangement code in `start_initiatesStreaming`.  
2. Verified streaming with the pre-defined `SUPPORTED_CURRENCY_PAIRS` to ensure consistency.  