### PR TITLE
Simplify Currency Pair Validation

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/ExchangeStreamingClient.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/ExchangeStreamingClient.java
@@ -33,17 +33,6 @@ interface ExchangeStreamingClient {
     String getExchangeName();
 
     /**
-     * Checks if the given currency pair is supported by the exchange.
-     * Default implementation always returns true until further implementation.
-     *
-     * @param currencyPair The currency pair to check (e.g., "BTC/USD").
-     * @return true if the currency pair is supported, false otherwise.
-     */
-    default boolean isSupportedCurrencyPair(CurrencyPair currencyPair) {
-        return true;
-    }
-
-    /**
      * Fetches the list of supported currency pairs from the Coinbase API.
      * 
      * @return an immutable list of supported CurrencyPairs.

--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
@@ -110,9 +110,6 @@ final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
         return currencyPairSupply.get()
             .currencyPairs()
             .stream()
-            // .map(pair -> pair.symbolWithCustomDelimiter(FORWARD_SLASH))
-            // .map(CurrencyPair::fromSymbol)            
-            // .filter(supportedPairs::contains)
             .collect(toImmutableList());
     }
 }

--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
@@ -110,7 +110,6 @@ final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
         return currencyPairSupply.get()
             .currencyPairs()
             .stream()
-            .filter(exchangeClient::isSupportedCurrencyPair)
             // .map(pair -> pair.symbolWithCustomDelimiter(FORWARD_SLASH))
             // .map(CurrencyPair::fromSymbol)            
             // .filter(supportedPairs::contains)

--- a/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
@@ -65,7 +65,6 @@ public class RealTimeDataIngestionImplTest {
             .map(CurrencyPair::fromSymbol)
             .collect(toImmutableList());
         when(mockCurrencyPairSupply.currencyPairs()).thenReturn(pairs);
-        when(mockExchangeClient.isSupportedCurrencyPair(any(CurrencyPair.class))).thenReturn(true);
 
         // Act
         realTimeDataIngestion.start();
@@ -180,24 +179,21 @@ public class RealTimeDataIngestionImplTest {
         verify(mockCandlePublisher).close();
     }
 
-    @Test
-    public void start_usesCorrectCurrencyPairs() {
-        // Arrange 
-        CurrencyPair supportedPair = CurrencyPair.fromSymbol("TEST1/USD");
-        CurrencyPair unsupportedPair = CurrencyPair.fromSymbol("TEST2/USD");
-        ImmutableList<CurrencyPair> pairs = ImmutableList.of(supportedPair, unsupportedPair);
-        ImmutableList<CurrencyPair> expected = ImmutableList.of(supportedPair);
-        when(mockCurrencyPairSupply.currencyPairs()).thenReturn(pairs);
+    // @Test
+    // public void start_usesCorrectCurrencyPairs() {
+    //     // Arrange 
+    //     CurrencyPair supportedPair = CurrencyPair.fromSymbol("TEST1/USD");
+    //     CurrencyPair unsupportedPair = CurrencyPair.fromSymbol("TEST2/USD");
+    //     ImmutableList<CurrencyPair> pairs = ImmutableList.of(supportedPair, unsupportedPair);
+    //     ImmutableList<CurrencyPair> expected = ImmutableList.of(supportedPair);
+    //     when(mockCurrencyPairSupply.currencyPairs()).thenReturn(pairs);
 
-        when(mockExchangeClient.isSupportedCurrencyPair(supportedPair)).thenReturn(true);
-        when(mockExchangeClient.isSupportedCurrencyPair(unsupportedPair)).thenReturn(false);
+    //     // Act
+    //     realTimeDataIngestion.start();
 
-        // Act
-        realTimeDataIngestion.start();
-
-        // Assert
-        verify(mockExchangeClient).startStreaming(eq(expected), any(Consumer.class));
-    }
+    //     // Assert
+    //     verify(mockExchangeClient).startStreaming(eq(expected), any(Consumer.class));
+    // }
 
     @Test
     public void processTrade_handlesTradeProcessorException() {


### PR DESCRIPTION
1. Removed `isSupportedCurrencyPair` method from `ExchangeStreamingClient`.  
2. Deleted unused filtering logic in `RealTimeDataIngestionImpl`.  
3. Disabled outdated test cases related to unsupported currency pairs in `RealTimeDataIngestionImplTest`.