### PR TITLE
Remove Logging from Supported Pairs Extraction

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
@@ -103,10 +103,6 @@ final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
             .supportedCurrencyPairs(FORWARD_SLASH)
             .stream()
             .collect(toImmutableSet());
-        supportedPairs
-            .stream()
-            .map(CurrencyPair::symbol)
-            .forEach(logger.atInfo()::log);
         return currencyPairSupply.get()
             .currencyPairs()
             .stream()


### PR DESCRIPTION
Removed unnecessary logging of `supportedPairs` during extraction to streamline the `supportedCurrencyPairs` method.