### PR TITLE
Add Kafka Configuration Overrides

### DIFF
--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -4,6 +4,7 @@ kafka:
     enabled: true
     size: 10Gi
     accessModes:
+  configurationOverrides:
       - ReadWriteOnce
   auth:
     enabled: true
@@ -17,13 +18,19 @@ kafka:
     inter.broker.listener.name=PLAINTEXT
     controller.listener.names=CONTROLLER
     log.dirs=/var/lib/kafka/data
+  configurationOverrides:
     offset.storage=raft
     transaction.state.log.replication.factor=3
     transaction.state.log.min.isr=2
+
 dataIngestion:
   args:
     - "--runMode=wet"
     - "--candlePublisherTopic=candles"
+    - "--kafka.acks=all"
+    - "--kafka.retries=5"
+    - "--kafka.linger.ms=50"
+    # Note: Using only existing args from ConfigArguments.java
   replicaCount: 1
   image:
     repository: "tradestreamhq/tradestream-data-ingestion"

--- a/src/test/java/com/verlumen/tradestream/ingestion/KafkaPropertiesTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/KafkaPropertiesTest.java
@@ -86,4 +86,16 @@ public class KafkaPropertiesTest {
     // Assert
     assertThat(kafkaProperties.isEmpty()).isTrue();
   }
+
+  @Test
+  public void testKafkaProperties_includesRetriesAndLinger() {
+    INPUT_PROPERTIES.put("kafka.acks", "all");
+    INPUT_PROPERTIES.put("kafka.retries", "5");
+    INPUT_PROPERTIES.put("kafka.linger.ms", "50");
+
+    Properties kafkaProps = supplier.get();
+    assertThat(kafkaProps.getProperty("acks")).isEqualTo("all");
+    assertThat(kafkaProps.getProperty("retries")).isEqualTo("5");
+    assertThat(kafkaProps.getProperty("linger.ms")).isEqualTo("50");
+  }
 }


### PR DESCRIPTION
1. Introduced `configurationOverrides` to allow custom Kafka settings in Helm `values.yaml`.  
2. Updated `dataIngestion.args` to include `kafka.acks`, `kafka.retries`, and `kafka.linger.ms`.  
3. Added unit test in `KafkaPropertiesTest` to validate these Kafka properties.  