### PR TITLE
Remove Delimiter from Supported Currency Pairs Method

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/CoinbaseStreamingClient.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CoinbaseStreamingClient.java
@@ -96,7 +96,7 @@ final class CoinbaseStreamingClient implements ExchangeStreamingClient {
      * @return an immutable list of supported CurrencyPairs.
      */
     @Override
-    public ImmutableList<CurrencyPair> supportedCurrencyPairs(String delimiter) {
+    public ImmutableList<CurrencyPair> supportedCurrencyPairs() {
         logger.atInfo().log("Fetching supported currency pairs from Coinbase");
         
         // Coinbase Exchange Products endpoint
@@ -132,7 +132,6 @@ final class CoinbaseStreamingClient implements ExchangeStreamingClient {
                 .map(JsonElement::getAsJsonObject)
                 .filter(obj -> obj.has("id"))
                 .map(obj -> obj.get("id").getAsString())
-                .map(productId -> productId.replace("-", delimiter))
                 .map(CurrencyPair::fromSymbol)
                 .collect(toImmutableList());
             

--- a/src/main/java/com/verlumen/tradestream/ingestion/ExchangeStreamingClient.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/ExchangeStreamingClient.java
@@ -37,7 +37,7 @@ interface ExchangeStreamingClient {
      * 
      * @return an immutable list of supported CurrencyPairs.
      */
-    ImmutableList<CurrencyPair> supportedCurrencyPairs(String delimiter);
+    ImmutableList<CurrencyPair> supportedCurrencyPairs();
 
     /**
      * Factory for creating exchange-specific streaming clients.

--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
@@ -104,7 +104,7 @@ final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
         ImmutableSet<CurrencyPair> supportedPairs = ImmutableSet.copyOf(
             exchangeClient.supportedCurrencyPairs());
         ImmutableSet<CurrencyPair> requestedPairs = ImmutableSet.copyOf(
-            currencyPairSupply.get());
+            currencyPairSupply.get().currencyPairs());
         difference(requestedPairs, supportedPairs)
             .forEach(unsupportedPair -> logger.atInfo().log(
                 "Pair with symbol %s is not supported.", unsupportedPair.symbol()));

--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
@@ -101,14 +101,10 @@ final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
     }
 
     private ImmutableList<CurrencyPair> supportedCurrencyPairs() {
-        ImmutableSet<CurrencyPair> supportedPairs = exchangeClient
-            .supportedCurrencyPairs(FORWARD_SLASH)
-            .stream()
-            .collect(toImmutableSet());
-        ImmutableSet<CurrencyPair> requestedPairs = currencyPairSupply.get()
-            .currencyPairs()
-            .stream()
-            .collect(toImmutableSet());
+        ImmutableSet<CurrencyPair> supportedPairs = ImmutableSet.copyOf(
+            exchangeClient.supportedCurrencyPairs());
+        ImmutableSet<CurrencyPair> requestedPairs = ImmutableSet.copyOf(
+            currencyPairSupply.get());
         difference(requestedPairs, supportedPairs)
             .forEach(unsupportedPair -> logger.atInfo().log(
                 "Pair with symbol %s is not supported.", unsupportedPair.symbol()));

--- a/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
@@ -58,7 +58,7 @@ public class RealTimeDataIngestionImplTest {
     public void setUp() {
         when(mockCurrencyPairSupply.currencyPairs()).thenReturn(TEST_CURRENCY_PAIRS);
         when(mockExchangeClient.getExchangeName()).thenReturn(TEST_EXCHANGE);
-        when(mockExchangeClient.supportedCurrencyPairs("/")).thenReturn(SUPPORTED_CURRENCY_PAIRS);
+        when(mockExchangeClient.supportedCurrencyPairs()).thenReturn(SUPPORTED_CURRENCY_PAIRS);
 
         Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
     }


### PR DESCRIPTION
- Removed the `delimiter` parameter from the `supportedCurrencyPairs` method in `ExchangeStreamingClient` and its implementation in `CoinbaseStreamingClient`.
- Updated `CoinbaseStreamingClient` to handle product ID mapping without custom delimiters.
- Adjusted `RealTimeDataIngestionImpl` to align with the updated `supportedCurrencyPairs` method signature.
- Simplified `supportedCurrencyPairs` logic by directly copying supported pairs as an `ImmutableSet`.
- Updated unit tests in `RealTimeDataIngestionImplTest` to reflect the method signature changes.