### PR TITLE
Enhance `KafkaProperties` with `Mug` BiStream  

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -305,6 +305,7 @@ java_library(
     srcs = ["KafkaProperties.java"],
     deps = [
         "@maven//:com_google_inject_guice",
+        "@maven//:com_google_mug_mug",
         "@maven//:net_sourceforge_argparse4j_argparse4j",
     ],    
 )

--- a/src/main/java/com/verlumen/tradestream/ingestion/KafkaProperties.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/KafkaProperties.java
@@ -21,14 +21,14 @@ final class KafkaProperties implements Supplier<Properties> {
     Properties kafkaProperties = new Properties();
 
     // Iterate over the input properties
-    for (String key : namespace.getAttrs().keySet()) {
+    namespace.getAttrs().keySet().forEach(key -> {
       // Check if the key starts with the "kafka." prefix
       if (!key.startsWith("kafka.")) continue;
 
       // Remove the prefix and add the key-value pair to the new Properties object
       String newKey = key.substring("kafka.".length());
       kafkaProperties.setProperty(newKey, namespace.getString(key));
-    }
+    });
 
     return kafkaProperties;
   }

--- a/src/main/java/com/verlumen/tradestream/ingestion/KafkaProperties.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/KafkaProperties.java
@@ -21,14 +21,11 @@ final class KafkaProperties implements Supplier<Properties> {
     Properties kafkaProperties = new Properties();
 
     // Iterate over the input properties
-    namespace.getAttrs().keySet().forEach(key -> {
-      // Check if the key starts with the "kafka." prefix
-      if (!key.startsWith("kafka.")) continue;
-
-      // Remove the prefix and add the key-value pair to the new Properties object
-      String newKey = key.substring("kafka.".length());
-      kafkaProperties.setProperty(newKey, namespace.getString(key));
-    });
+    namespace.getAttrs().keySet()
+      .stream()
+      .filter(key -> key.startsWith("kafka."))
+      .map(key -> key.substring("kafka.".length()))
+      .forEach(key -> kafkaProperties.setProperty(key, namespace.getString(key)));
 
     return kafkaProperties;
   }

--- a/src/main/java/com/verlumen/tradestream/ingestion/KafkaProperties.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/KafkaProperties.java
@@ -27,6 +27,7 @@ final class KafkaProperties implements Supplier<Properties> {
       .filterKeys(key -> key.startsWith("kafka."))
       .mapKeys(key -> key.substring("kafka.".length()))
       .filterValues(Objects::nonNull)
+      .mapValues(Objects::toString)
       .forEach((key, value) -> kafkaProperties.setProperty(key, value));
 
     return kafkaProperties;

--- a/src/main/java/com/verlumen/tradestream/ingestion/KafkaProperties.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/KafkaProperties.java
@@ -25,9 +25,8 @@ final class KafkaProperties implements Supplier<Properties> {
     // Iterate over the input properties
     BiStream.from(namespace.getAttrs())
       .filterKeys(key -> key.startsWith("kafka."))
-      .mapValues(namespace::getString)
+      .mapKeys(key -> key.substring("kafka.".length()))
       .filterValues(Objects::nonNull)
-      .mapValues(key -> key.substring("kafka.".length()))
       .forEach((key, value) -> kafkaProperties.setProperty(key, value));
 
     return kafkaProperties;

--- a/src/main/java/com/verlumen/tradestream/ingestion/KafkaProperties.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/KafkaProperties.java
@@ -28,7 +28,7 @@ final class KafkaProperties implements Supplier<Properties> {
       .mapKeys(key -> key.substring("kafka.".length()))
       .filterValues(Objects::nonNull)
       .mapValues(Objects::toString)
-      .forEach((key, value) -> kafkaProperties.setProperty(key, value));
+      .forEach(kafkaProperties::setProperty);
 
     return kafkaProperties;
   }

--- a/src/main/java/com/verlumen/tradestream/ingestion/KafkaProperties.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/KafkaProperties.java
@@ -27,7 +27,7 @@ final class KafkaProperties implements Supplier<Properties> {
       .filterKeys(key -> key.startsWith("kafka."))
       .mapKeys(key -> key.substring("kafka.".length()))
       .filterValues(Objects::nonNull)
-      .forEach((key, value) -> kafkaProperties.setProperty(key, value));
+      .forEach(kafkaProperties::setProperty);
 
     return kafkaProperties;
   }

--- a/src/main/java/com/verlumen/tradestream/ingestion/KafkaProperties.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/KafkaProperties.java
@@ -2,10 +2,12 @@ package com.verlumen.tradestream.ingestion;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
+import com.google.mu.util.stream.BiStream;
 import net.sourceforge.argparse4j.inf.Namespace;
 
 import java.util.Properties;
 import java.util.function.Supplier;
+import java.util.Objects;
 
 final class KafkaProperties implements Supplier<Properties> {
   private final Namespace namespace;
@@ -21,11 +23,12 @@ final class KafkaProperties implements Supplier<Properties> {
     Properties kafkaProperties = new Properties();
 
     // Iterate over the input properties
-    namespace.getAttrs().keySet()
-      .stream()
-      .filter(key -> key.startsWith("kafka."))
-      .map(key -> key.substring("kafka.".length()))
-      .forEach(key -> kafkaProperties.setProperty(key, namespace.getString(key)));
+    BiStream.from(namespace.getAttrs().keySet())
+      .filterKeys(key -> key.startsWith("kafka."))
+      .mapValues(namespace::getString)
+      .filterValues(Objects::nonNull)
+      .mapValues(key -> key.substring("kafka.".length()))
+      .forEach((key, value) -> kafkaProperties.setProperty(key, value));
 
     return kafkaProperties;
   }

--- a/src/main/java/com/verlumen/tradestream/ingestion/KafkaProperties.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/KafkaProperties.java
@@ -27,7 +27,7 @@ final class KafkaProperties implements Supplier<Properties> {
       .filterKeys(key -> key.startsWith("kafka."))
       .mapKeys(key -> key.substring("kafka.".length()))
       .filterValues(Objects::nonNull)
-      .mapValues(Objects::toString)
+      .mapValues(Object::toString)
       .forEach(kafkaProperties::setProperty);
 
     return kafkaProperties;

--- a/src/main/java/com/verlumen/tradestream/ingestion/KafkaProperties.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/KafkaProperties.java
@@ -27,7 +27,7 @@ final class KafkaProperties implements Supplier<Properties> {
       .filterKeys(key -> key.startsWith("kafka."))
       .mapKeys(key -> key.substring("kafka.".length()))
       .filterValues(Objects::nonNull)
-      .forEach(kafkaProperties::setProperty);
+      .forEach((key, value) -> kafkaProperties.setProperty(key, value));
 
     return kafkaProperties;
   }

--- a/src/main/java/com/verlumen/tradestream/ingestion/KafkaProperties.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/KafkaProperties.java
@@ -23,7 +23,7 @@ final class KafkaProperties implements Supplier<Properties> {
     Properties kafkaProperties = new Properties();
 
     // Iterate over the input properties
-    BiStream.from(namespace.getAttrs().keySet())
+    BiStream.from(namespace.getAttrs())
       .filterKeys(key -> key.startsWith("kafka."))
       .mapValues(namespace::getString)
       .filterValues(Objects::nonNull)


### PR DESCRIPTION
1. Added `Mug` dependency (`@maven//:com_google_mug_mug`) to `KafkaProperties` in the Bazel `BUILD` file.  
2. Refactored the `KafkaProperties` implementation to leverage `Mug`’s `BiStream` for streamlined property transformation:  
   - Filtered keys with prefix `kafka.`.  
   - Removed the `kafka.` prefix from keys.  
   - Converted non-null values to strings and applied to `Properties`.  
3. Simplified code and improved readability using functional constructs from `Mug`.