### PR TITLE
Add SASL Configuration Options for Kafka in ConfigArguments

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/ConfigArguments.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/ConfigArguments.java
@@ -77,8 +77,21 @@ abstract class ConfigArguments implements Provider<Namespace> {
       .help("Key serializer class");
 
     parser.addArgument("--kafka.value.serializer")
-      .setDefault("org.apache.kafka.common.serialization.StringSerializer")
+      .setDefault("org.apache.kafka.common.serialization.ByteArraySerializer")
       .help("Value serializer class");
+
+    // SASL configuration (added)
+    parser.addArgument("--kafka.security.protocol")
+      .setDefault("PLAINTEXT")
+      .help("Protocol used to communicate with brokers (e.g., PLAINTEXT, SASL_SSL)");
+
+    parser.addArgument("--kafka.sasl.mechanism")
+      .setDefault("")
+      .help("SASL mechanism used for authentication (e.g., PLAIN, SCRAM-SHA-256)");
+
+    parser.addArgument("--kafka.sasl.jaas.config")
+      .setDefault("")
+      .help("SASL JAAS configuration");
 
     // Exchange configuration
     parser.addArgument("--exchangeName")

--- a/src/main/java/com/verlumen/tradestream/ingestion/ConfigArguments.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/ConfigArguments.java
@@ -80,7 +80,7 @@ abstract class ConfigArguments implements Provider<Namespace> {
       .setDefault("org.apache.kafka.common.serialization.ByteArraySerializer")
       .help("Value serializer class");
 
-    // SASL configuration (added)
+    // SASL configuration
     parser.addArgument("--kafka.security.protocol")
       .setDefault("PLAINTEXT")
       .help("Protocol used to communicate with brokers (e.g., PLAINTEXT, SASL_SSL)");


### PR DESCRIPTION
- **Value Serializer Update**:
  - Changed the default Kafka value serializer from `StringSerializer` to `ByteArraySerializer` for enhanced flexibility in message handling.

- **New SASL Configuration**:
  - Introduced the following SASL-related arguments to support secure Kafka authentication:
    - `--kafka.security.protocol`: Defines the protocol used (e.g., `PLAINTEXT`, `SASL_SSL`).
    - `--kafka.sasl.mechanism`: Specifies the SASL mechanism (e.g., `PLAIN`, `SCRAM-SHA-256`).
    - `--kafka.sasl.jaas.config`: Allows providing the JAAS configuration string.

- **Purpose**:
  - These changes ensure compatibility with secure Kafka setups, enabling authentication and encryption using SASL mechanisms when required.