### PR TITLE
Update Default Kafka Security Protocol to SASL_PLAINTEXT

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/ConfigArguments.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/ConfigArguments.java
@@ -82,7 +82,7 @@ abstract class ConfigArguments implements Provider<Namespace> {
 
     // SASL configuration
     parser.addArgument("--kafka.security.protocol")
-      .setDefault("PLAINTEXT")
+      .setDefault("SASL_PLAINTEXT")
       .help("Protocol used to communicate with brokers (e.g., PLAINTEXT, SASL_SSL)");
 
     parser.addArgument("--kafka.sasl.mechanism")


### PR DESCRIPTION
- **Default Protocol Change**:
  - Updated the default value of `--kafka.security.protocol` from `PLAINTEXT` to `SASL_PLAINTEXT`.
  
- **Purpose**:
  - Aligns with secure Kafka configurations, ensuring authentication is enabled by default while maintaining backward compatibility with plaintext setups.