### PR TITLE
Add Branch Name to Git Tags in Release Workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,17 +33,17 @@ jobs:
           git config user.name "GitHub Action"
           git config user.email "action@github.com"
 
-      - name: Push Tag
-        env:
-          GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
-        run: |
-          git tag ${{ steps.version.outputs.version_tag }}
-          git push https://$GITHUB_ACTOR:${{ secrets.ACTIONS_TOKEN }}@github.com/${{ github.repository }} --tags
-
       - name: Extract branch name
         shell: bash
         run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
         id: extract_branch
+
+      - name: Push Tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+        run: |
+          git tag ${{ steps.version.outputs.version_tag }}-${{ steps.extract_branch.outputs.branch }}
+          git push https://$GITHUB_ACTOR:${{ secrets.ACTIONS_TOKEN }}@github.com/${{ github.repository }} --tags
 
       - name: Create image tag
         shell: bash


### PR DESCRIPTION
- **Key Changes**:
  - Appended the current branch name to the Git tag during release workflow.
  - Adjusted the tag creation step to include the extracted branch name using `${{ steps.extract_branch.outputs.branch }}`.

- **Purpose**:
  - Helps differentiate tags when releases are made from multiple branches.
  - Ensures clarity and traceability in version tags by explicitly including the branch name.

- **Workflow Update**:
  - Extracts branch name in an earlier step and uses it during the tag creation.
  - The final image tag also includes the branch name for consistency.

- **Example**:
  - Before: `v1.2.3`
  - After: `v1.2.3-main` (where `main` is the branch name).

This change simplifies tag management across branches and avoids potential conflicts between branch-based releases.