### PR TITLE
Remove prerelease versioning from release workflow  

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
           namespace: "${{ steps.extract_branch.outputs.branch }}"
           major_pattern: "(MAJOR)"
           minor_pattern: "(MINOR)"
-          version_format: "${major}.${minor}.${patch}-prerelease${increment}"
+          version_format: "${major}.${minor}.${patch}-${increment}"
 
       - name: Set up Git
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
           namespace: "${{ steps.extract_branch.outputs.branch }}"
           major_pattern: "(MAJOR)"
           minor_pattern: "(MINOR)"
-          version_format: "${major}.${minor}.${patch}-${increment}"
+          version_format: "${major}.${minor}.${patch}"
 
       - name: Set up Git
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,6 @@ jobs:
           major_pattern: "(MAJOR)"
           minor_pattern: "(MINOR)"
           version_format: "${major}.${minor}.${patch}-prerelease${increment}"
-          enable_prerelease_mode: true
 
       - name: Set up Git
         run: |


### PR DESCRIPTION
This update modifies the GitHub Actions release workflow by removing prerelease versioning. Specifically:  
- Eliminates `enable_prerelease_mode: true`.  
- Updates `version_format` to exclude the `-prerelease${increment}` suffix.  

This ensures that all generated versions follow the standard `major.minor.patch` format without prerelease identifiers.  

#### Context  
This change is intended to streamline the versioning strategy and align with a stable release process. Let me know if further adjustments are needed!