### PR TITLE
Update release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,11 +46,6 @@ jobs:
           git tag ${{ steps.version.outputs.version_tag }}
           git push https://$GITHUB_ACTOR:${{ secrets.ACTIONS_TOKEN }}@github.com/${{ github.repository }} --tags
 
-      - name: Create image tag
-        shell: bash
-        run: echo "image_tag=${{ steps.version.outputs.version_tag }}-${{ steps.extract_branch.outputs.branch }}" >> $GITHUB_OUTPUT
-        id: create_image_tag
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -72,7 +67,7 @@ jobs:
             --verbose_failures \
             --sandbox_debug \
             -- \
-            --tag ${{ steps.create_image_tag.outputs.image_tag }}
+            --tag ${{ steps.version.outputs.version_tag }}
 
       - name: Install yq
         run: |


### PR DESCRIPTION
  - Removed the explicit `create_image_tag` step that concatenated version tags with branch names.
  - Updated the Docker image tag to use only the semantic version (`steps.version.outputs.version_tag`).
