### PR TITLE
Add Image Push for Strategy Engine to Release Workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,8 @@ jobs:
     env:
       DATA_INGESTION_REPO: tradestreamhq/tradestream-data-ingestion
       DATA_INGESTION_SECTION_KEY: dataIngestion
+      STRATEGY_ENGINE_REPO: tradestreamhq/tradestream-strategy-engine
+      STRATEGY_ENGINE_SECTION_KEY: strategyEngine
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -69,6 +71,14 @@ jobs:
             -- \
             --tag ${{ steps.version.outputs.version_tag }}
 
+      - name: Push the Strategy Engine image
+        run: |
+          bazel run //src/main/java/com/verlumen/tradestream/strategies:push_image \
+            --verbose_failures \
+            --sandbox_debug \
+            -- \
+            --tag ${{ steps.version.outputs.version_tag }}
+
       - name: Install yq
         run: |
           sudo wget -O /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v4.35.1/yq_linux_amd64
@@ -79,7 +89,9 @@ jobs:
           yq eval-all '
             . as $item ireduce ({}; . * $item ) |
             .["${{ env.DATA_INGESTION_SECTION_KEY }}"].image.repository = "${{ env.DATA_INGESTION_REPO }}" |
-            .["${{ env.DATA_INGESTION_SECTION_KEY }}"].image.tag = "${{ steps.version.outputs.version_tag }}"
+            .["${{ env.DATA_INGESTION_SECTION_KEY }}"].image.tag = "${{ steps.version.outputs.version_tag }}" |
+            .["${{ env.STRATEGY_ENGINE_SECTION_KEY }}"].image.repository = "${{ env.STRATEGY_ENGINE_REPO }}" |
+            .["${{ env.STRATEGY_ENGINE_SECTION_KEY }}"].image.tag = "${{ steps.version.outputs.version_tag }}"
           ' charts/tradestream/values.yaml > charts/tradestream/values.yaml.tmp
           mv charts/tradestream/values.yaml.tmp charts/tradestream/values.yaml
 
@@ -88,6 +100,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
         run: |
           git add charts/tradestream/values.yaml
-          git commit -m "Update values.yaml: Set ${{ env.DATA_INGESTION_SECTION_KEY }} image to ${{ steps.version.outputs.version_tag }}" || echo "No changes to commit"
+          git commit -m "Update values.yaml: Set images to ${{ steps.version.outputs.version_tag }}" || echo "No changes to commit"
           git push https://$GITHUB_ACTOR:${{ secrets.ACTIONS_TOKEN }}@github.com/${{ github.repository }} HEAD:${{ github.ref }}
           

--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -1,7 +1,7 @@
 load("@aspect_bazel_lib//lib:tar.bzl", "tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("@rules_java//java:defs.bzl", "java_binary")
-load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index", "oci_push")
 load("//platforms:transition.bzl", "multi_arch")
 
 package(default_visibility = ["//visibility:public"])
@@ -64,4 +64,11 @@ oci_image_index(
 tar(
     name = "layer",
     srcs = [":app_deploy.jar"],
+)
+
+oci_push(
+    name = "push_image",
+    image = ":index",
+    remote_tags = ["latest"],
+    repository = "tradestreamhq/tradestream-strategy-engine",
 )


### PR DESCRIPTION
- **Release Workflow Updates**:
  - Added steps to **push the Strategy Engine image** to the container registry as part of the release workflow.
  - Extended `yq` processing to update the **strategy engine** image repository and tag in `values.yaml`.
  - Unified the commit message to reflect updates for multiple images.

- **Bazel Updates**:
  - Added an `oci_push` target in the `strategies/BUILD` file to push the Strategy Engine image to `tradestreamhq/tradestream-strategy-engine`.

#### **File Highlights**:
1. **`.github/workflows/release.yaml`**:
   - Introduced `STRATEGY_ENGINE_REPO` and `STRATEGY_ENGINE_SECTION_KEY`.
   - Added a step to **push the Strategy Engine image** using Bazel.
   - Modified `yq` script to update the `strategyEngine` section in `values.yaml` alongside `dataIngestion`.
   - Unified commit message to reflect updates to all image tags.

2. **`strategies/BUILD`**:
   - Added `oci_push` rule to push the Strategy Engine image to the registry.

#### **Purpose**:
- Ensures the **Strategy Engine** image is pushed during the release process.
- Updates Helm `values.yaml` with the correct repository and image tag for both components.

#### **Impact**:
- Automates the deployment process for the Strategy Engine.
- Keeps Helm chart configuration consistent with the latest release.

--- 

This PR improves release automation and supports multi-component versioning for TradeStream.