### PR TITLE
Remove Image Pull Policy from Helm Chart

### DIFF
--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -20,7 +20,6 @@ dataIngestion:
   replicaCount: 1
   image:
     repository: "tradestreamhq/tradestream-data-ingestion"
-    pullPolicy: IfNotPresent
     tag: "v0.0.338-develop"
   service:
     port: 8080


### PR DESCRIPTION
- **`values.yaml` Updates**:
  - Removed the `pullPolicy` field from the `dataIngestion.image` section in the Helm chart.

#### **Purpose**:
- Simplifies the Helm chart configuration by relying on Kubernetes' default pull policy:
  - `IfNotPresent` for locally built or cached images.
  - `Always` for images tagged with `latest` or `sha256` digests.

#### **Impact**:
- Ensures flexibility in image pulling behavior based on tag usage.
- Reduces unnecessary configuration overhead in the Helm chart.