### PR TITLE
Remove Pull Policy from CI Workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,6 @@ jobs:
             --namespace tradestream-namespace \
             --set dataIngestion.image.repository=tradestream-app \
             --set dataIngestion.image.tag=latest \
-            --set dataIngestion.image.pullPolicy=IfNotPresent \
             --set 'dataIngestion.args[0]=--runMode=dry'
 
       - name: Wait for All Pods to be Ready


### PR DESCRIPTION
Removed the `pullPolicy` setting for `dataIngestion.image` in the CI workflow to rely on the default Kubernetes behavior.