### PR TITLE
Add Backtesting Protobufs and Integration

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,7 @@
 bazel_dep(name = "aspect_bazel_lib", version = "2.8.1")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "container_structure_test", version = "1.16.0")
-bazel_dep(name = "protobuf", version = "29.1")
+bazel_dep(name = "protobuf", version = "29.1") 
 bazel_dep(name = "rules_java", version = "8.3.1")
 bazel_dep(name = "rules_jvm_external", version = "6.5")
 bazel_dep(name = "rules_oci", version = "2.0.1")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,7 @@
 bazel_dep(name = "aspect_bazel_lib", version = "2.8.1")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "container_structure_test", version = "1.16.0")
+bazel_dep(name = "protobuf", version = "29.1")
 bazel_dep(name = "rules_java", version = "8.3.1")
 bazel_dep(name = "rules_jvm_external", version = "6.5")
 bazel_dep(name = "rules_oci", version = "2.0.1")

--- a/protos/BUILD
+++ b/protos/BUILD
@@ -2,6 +2,7 @@ proto_library(
     name = "backtesting_proto",
     srcs = ["backtesting.proto"],
     deps = [
+        "@com_google_protobuf//:any_proto",
         ":marketdata_proto",
         ":strategies_proto",
     ],

--- a/protos/BUILD
+++ b/protos/BUILD
@@ -2,7 +2,7 @@ proto_library(
     name = "backtesting_proto",
     srcs = ["backtesting.proto"],
     deps = [
-        "@com_google_protobuf//:any_proto",
+        "@protobuf//:any_proto",
         ":marketdata_proto",
         ":strategies_proto",
     ],

--- a/protos/BUILD
+++ b/protos/BUILD
@@ -1,6 +1,10 @@
 proto_library(
     name = "backtesting_proto",
     srcs = ["backtesting.proto"],
+    deps = [
+        ":marketdata_proto",
+        ":strategies_proto",
+    ],
     visibility = ["//visibility:private"],
 )
 

--- a/protos/BUILD
+++ b/protos/BUILD
@@ -1,4 +1,16 @@
 proto_library(
+    name = "backtesting_proto",
+    srcs = ["backtesting.proto"],
+    visibility = ["//visibility:private"],
+)
+
+java_proto_library(
+    name = "backtesting_java_proto",
+    deps = [":backtesting_proto"],
+    visibility = ["//:__subpackages__"],
+)
+
+proto_library(
     name = "marketdata_proto",
     srcs = ["marketdata.proto"],
     visibility = ["//visibility:private"],

--- a/protos/backtesting.proto
+++ b/protos/backtesting.proto
@@ -11,12 +11,12 @@ import "strategies.proto";
 
 message BacktestRequest {
   repeated marketdata.Candle candles = 1;
-  StrategyType strategy_type = 2;
+  strategies.StrategyType strategy_type = 2;
 }
 
 message ParameterizedBacktestRequest {
   repeated marketdata.Candle candles = 1;
-  StrategyType strategy_type = 2;
+  strategies.StrategyType strategy_type = 2;
   google.protobuf.Any strategy_parameters = 3;
 }
 
@@ -37,7 +37,7 @@ message TimeframeResult {
 }
 
 message BacktestResult {
-  StrategyType strategy_type = 1;
+  strategies.StrategyType strategy_type = 1;
   repeated TimeframeResult timeframe_results = 2;
   double overall_score = 3;
 }

--- a/protos/backtesting.proto
+++ b/protos/backtesting.proto
@@ -1,0 +1,40 @@
+syntax = "proto3";
+
+package backtesting;
+
+import "google/protobuf/any.proto";
+import "marketdata.proto";
+import "strategies.proto";
+
+message BacktestRequest {
+  repeated marketdata.Candle candles = 1;
+  StrategyType strategy_type = 2;
+}
+
+message ParameterizedBacktestRequest {
+  repeated marketdata.Candle candles = 1;
+  StrategyType strategy_type = 2;
+  google.protobuf.Any strategy_parameters = 3;
+}
+
+message TimeframeResult {
+  string timeframe = 1;
+  double cumulative_return = 2;
+  double annualized_return = 3;
+  double sharpe_ratio = 4;
+  double sortino_ratio = 5;
+  double max_drawdown = 6;
+  double volatility = 7;
+  double win_rate = 8;
+  double profit_factor = 9;
+  int32 number_of_trades = 10;
+  double average_trade_duration = 11;
+  double alpha = 12;
+  double beta = 13;
+}
+
+message BacktestResult {
+  StrategyType strategy_type = 1;
+  repeated TimeframeResult timeframe_results = 2;
+  double overall_score = 3;
+}

--- a/protos/backtesting.proto
+++ b/protos/backtesting.proto
@@ -1,4 +1,4 @@
-syntax = "proto3";
+edition = "2023";
 
 package backtesting;
 

--- a/protos/backtesting.proto
+++ b/protos/backtesting.proto
@@ -6,8 +6,8 @@ option java_multiple_files = true;
 option java_package = "com.verlumen.tradestream.backtesting";
 
 import "google/protobuf/any.proto";
-import "marketdata.proto";
-import "strategies.proto";
+import "protos/marketdata.proto";
+import "protos/strategies.proto";
 
 message BacktestRequest {
   repeated marketdata.Candle candles = 1;

--- a/protos/backtesting.proto
+++ b/protos/backtesting.proto
@@ -2,6 +2,9 @@ syntax = "proto3";
 
 package backtesting;
 
+option java_multiple_files = true;
+option java_package = "com.verlumen.tradestream.backtesting";
+
 import "google/protobuf/any.proto";
 import "marketdata.proto";
 import "strategies.proto";


### PR DESCRIPTION
Introduced a new `backtesting.proto` file for defining messages related to strategy backtesting. Added dependencies on `marketdata.proto` and `strategies.proto`, as well as Google's `any.proto`. Key features include:

1. **New Messages**:
   - `BacktestRequest`: Standard backtest request with candles and a strategy type.
   - `ParameterizedBacktestRequest`: Adds support for strategy parameters using `google.protobuf.Any`.
   - `TimeframeResult`: Metrics for backtesting results over specific timeframes.
   - `BacktestResult`: Aggregates multiple `TimeframeResult` objects, providing an overall strategy evaluation.

2. **Bazel Integration**:
   - Added `backtesting_proto` and `backtesting_java_proto` targets in `protos/BUILD`.

These changes establish the foundation for implementing and evaluating trading strategies within the backtesting module.