### PR TITLE
Upgrade Protobuf Syntax to Edition 2023 and Add Dependency

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,7 @@
 bazel_dep(name = "aspect_bazel_lib", version = "2.8.1")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "container_structure_test", version = "1.16.0")
+bazel_dep(name = "protobuf", version = "29.1")
 bazel_dep(name = "rules_java", version = "8.3.1")
 bazel_dep(name = "rules_jvm_external", version = "6.5")
 bazel_dep(name = "rules_oci", version = "2.0.1")

--- a/protos/marketdata.proto
+++ b/protos/marketdata.proto
@@ -1,4 +1,4 @@
-syntax = "proto3";
+edition = "2023";
 
 package marketdata;
 

--- a/protos/strategies.proto
+++ b/protos/strategies.proto
@@ -1,4 +1,4 @@
-syntax = "proto3";
+edition = "2023";
 
 package strategies;
 


### PR DESCRIPTION
Updated Protobuf syntax to `edition = "2023"` in `marketdata.proto` and `strategies.proto` for compatibility with modern Protobuf features. Added the `protobuf` Bazel dependency (version 29.1) in `MODULE.bazel` to support the new Protobuf edition. This ensures consistency and readiness for advanced Protobuf capabilities in the project.