### PR TITLE
Update Protobuf Dependency Naming and References

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,7 @@
 bazel_dep(name = "aspect_bazel_lib", version = "2.8.1")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "container_structure_test", version = "1.16.0")
-bazel_dep(name = "protobuf", version = "29.1")
+bazel_dep(name = "protobuf", repo_name = "com_google_protobuf", version = "29.1")
 bazel_dep(name = "rules_java", version = "8.3.1")
 bazel_dep(name = "rules_jvm_external", version = "6.5")
 bazel_dep(name = "rules_oci", version = "2.0.1")

--- a/protos/BUILD
+++ b/protos/BUILD
@@ -2,7 +2,7 @@ proto_library(
     name = "backtesting_proto",
     srcs = ["backtesting.proto"],
     deps = [
-        "@protobuf//:any_proto",
+        "@com_google_protobuf//:any_proto",
         ":marketdata_proto",
         ":strategies_proto",
     ],


### PR DESCRIPTION
Updated the `protobuf` Bazel dependency to use the repository name `com_google_protobuf` for better clarity and consistency. Key changes include:

1. **MODULE.bazel**:
   - Changed `protobuf` dependency to include `repo_name = "com_google_protobuf"`.

2. **Protobuf BUILD File**:
   - Updated `backtesting_proto` target to reference `@com_google_protobuf//:any_proto` instead of `@protobuf//:any_proto`.

This change ensures naming consistency across the project and aligns with standard Bazel practices for external dependencies.