### PR TITLE
Add gRPC Support for Backtesting Service

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,7 @@
 bazel_dep(name = "aspect_bazel_lib", version = "2.8.1")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "container_structure_test", version = "1.16.0")
+bazel_dep(name = "grpc-java", repo_name = "io_grpc_grpc_java", version = "1.70.0-SNAPSHOT")  # CURRENT_GRPC_VERSION
 bazel_dep(name = "protobuf", version = "29.1")
 bazel_dep(name = "rules_java", version = "8.3.1")
 bazel_dep(name = "rules_jvm_external", version = "6.5")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,7 @@
 bazel_dep(name = "aspect_bazel_lib", version = "2.8.1")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "container_structure_test", version = "1.16.0")
-bazel_dep(name = "grpc-java", repo_name = "io_grpc_grpc_java", version = "1.70.0-SNAPSHOT")  # CURRENT_GRPC_VERSION
+bazel_dep(name = "grpc-java", repo_name = "io_grpc_grpc_java", version = "1.68.1")
 bazel_dep(name = "protobuf", repo_name = "com_google_protobuf", version = "29.1")
 bazel_dep(name = "rules_java", version = "8.3.1")
 bazel_dep(name = "rules_jvm_external", version = "6.5")

--- a/protos/BUILD
+++ b/protos/BUILD
@@ -1,3 +1,5 @@
+load("@io_grpc_grpc_java//:java_grpc_library.bzl", "java_grpc_library")
+
 proto_library(
     name = "backtest_service_proto",
     srcs = ["backtest_service.proto"],

--- a/protos/BUILD
+++ b/protos/BUILD
@@ -14,6 +14,12 @@ java_proto_library(
     visibility = ["//:__subpackages__"],
 )
 
+java_grpc_library(
+    name = "backtest_service_java_grpc",
+    srcs = [":backtest_service_proto"],
+    deps = [":backtest_service_java_proto"],
+)
+
 proto_library(
     name = "backtesting_proto",
     srcs = ["backtesting.proto"],

--- a/protos/BUILD
+++ b/protos/BUILD
@@ -1,4 +1,18 @@
 proto_library(
+    name = "backtest_service_proto",
+    srcs = ["backtest_service.proto"],
+    deps = [
+        ":backtesting_proto",
+    ],
+)
+
+java_proto_library(
+    name = "backtest_service_java_proto",
+    deps = [":backtest_service_proto"],
+    visibility = ["//:__subpackages__"],
+)
+
+proto_library(
     name = "backtesting_proto",
     srcs = ["backtesting.proto"],
     deps = [

--- a/protos/backtest_service.proto
+++ b/protos/backtest_service.proto
@@ -2,8 +2,10 @@ edition = "2023";
 
 package backtesting;
 
+option java_multiple_files = true;
+option java_package = "com.verlumen.tradestream.backtesting";
+
 import "protos/backtesting.proto";
-option java_package = "com.verlumen.tradestream.marketdata";
 
 service BacktestService {
   rpc RunBacktest (BacktestRequest) returns (BacktestResult);

--- a/protos/backtest_service.proto
+++ b/protos/backtest_service.proto
@@ -1,0 +1,13 @@
+edition = "2023";
+
+package backtesting;
+
+import "protos/backtesting.proto";
+
+service BacktestService {
+  rpc RunBacktest (BacktestRequest) returns (BacktestResult);
+}
+
+service ParameterizedBacktestService {
+    rpc RunParameterizedBacktest (ParameterizedBacktestRequest) returns (BacktestResult);
+}

--- a/protos/backtest_service.proto
+++ b/protos/backtest_service.proto
@@ -3,6 +3,7 @@ edition = "2023";
 package backtesting;
 
 import "protos/backtesting.proto";
+option java_package = "com.verlumen.tradestream.marketdata";
 
 service BacktestService {
   rpc RunBacktest (BacktestRequest) returns (BacktestResult);


### PR DESCRIPTION
Introduced gRPC support for the backtesting module to enable remote invocation of backtest operations. Changes include:

1. **MODULE.bazel**:
   - Added `grpc-java` dependency with version `1.68.1`.

2. **Protobuf and BUILD Updates**:
   - Added `backtest_service.proto` to define the `BacktestService` and `ParameterizedBacktestService` gRPC services.
   - Updated `BUILD` file to include:
     - `proto_library` for `backtest_service.proto`.
     - `java_proto_library` and `java_grpc_library` for generating Java bindings.

These changes facilitate the integration of gRPC-based remote backtesting functionality in the application.