### PR TITLE
Add StrategyFactory Interface and Update Dependencies

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -52,6 +52,7 @@ maven.install(
         "org.knowm.xchange:xchange-stream-core:5.2.0",
         "org.knowm.xchange:xchange-stream-coinbasepro:5.2.0",
         "org.slf4j:slf4j-api:2.0.12",
+        "org.ta4j:ta4j-core:0.17",
 
         # Test Dependencies
         "com.google.inject.extensions:guice-testlib:7.0.0",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -39,7 +39,7 @@ maven.install(
         "com.google.mug:mug:8.2",
         "com.google.mug:mug-guava:8.2",
         "com.google.mug:mug-protobuf:8.2",
-        "com.google.protobuf:protobuf-java:3.21.12",
+        "com.google.protobuf:protobuf-java:4.29.1",
         "com.ryanharter.auto.value:auto-value-gson:1.3.1",
         "com.ryanharter.auto.value:auto-value-gson-annotations:0.8.0",
         "com.ryanharter.auto.value:auto-value-gson-factory:1.3.1",

--- a/protos/BUILD
+++ b/protos/BUILD
@@ -1,5 +1,5 @@
 load("@io_grpc_grpc_java//:java_grpc_library.bzl", "java_grpc_library")
-
+ 
 java_proto_library(
     name = "any_java_proto",
     deps = ["@com_google_protobuf//:any_proto"],

--- a/protos/BUILD
+++ b/protos/BUILD
@@ -1,5 +1,5 @@
 load("@io_grpc_grpc_java//:java_grpc_library.bzl", "java_grpc_library")
-
+ 
 proto_library(
     name = "backtest_service_proto",
     srcs = ["backtest_service.proto"],

--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -79,7 +79,7 @@ java_library(
     deps = [
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:org_ta4j_ta4j_core",
-        "//protos:any_java_proto",
+        # "//protos:any_java_proto",
         "//protos:strategies_java_proto",
     ],
 )

--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -78,6 +78,7 @@ java_library(
     srcs = ["StrategyFactory.java"],
     deps = [
         "@maven//:org_ta4j_ta4j_core",
+        "//protos:any_java_proto",
         "//protos:strategies_java_proto",
     ],
 )

--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -79,7 +79,6 @@ java_library(
     deps = [
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:org_ta4j_ta4j_core",
-        # "//protos:any_java_proto",
         "//protos:strategies_java_proto",
     ],
 )

--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -77,6 +77,7 @@ java_library(
     name = "strategy_factory",
     srcs = ["StrategyFactory.java"],
     deps = [
+        "@maven//:com_google_protobuf_protobuf",
         "@maven//:org_ta4j_ta4j_core",
         "//protos:any_java_proto",
         "//protos:strategies_java_proto",

--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -1,6 +1,6 @@
 load("@aspect_bazel_lib//lib:tar.bzl", "tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
-load("@rules_java//java:defs.bzl", "java_binary")
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index", "oci_push")
 load("//platforms:transition.bzl", "multi_arch")
 
@@ -71,4 +71,12 @@ oci_push(
     image = ":index",
     remote_tags = ["latest"],
     repository = "tradestreamhq/tradestream-strategy-engine",
+)
+
+java_library(
+    name = "strategy_factory",
+    srcs = ["StrategyFactory.java"],
+    deps = [
+        "@maven//:org_ta4j_ta4j_core",
+    ],
 )

--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -78,5 +78,6 @@ java_library(
     srcs = ["StrategyFactory.java"],
     deps = [
         "@maven//:org_ta4j_ta4j_core",
+        "//protos:strategies_java_proto",
     ],
 )

--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -77,7 +77,7 @@ java_library(
     name = "strategy_factory",
     srcs = ["StrategyFactory.java"],
     deps = [
-        "@maven//:com_google_protobuf_protobuf",
+        "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:org_ta4j_ta4j_core",
         "//protos:any_java_proto",
         "//protos:strategies_java_proto",

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
@@ -2,9 +2,9 @@ package com.verlumen.tradestream.strategies;
 
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
+import com.verlumen.tradestream.strategies.StrategyType;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Strategy;
-import com.verlumen.tradestream.strategies.StrategyType;
 
 interface StrategyFactory {
   /**

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
@@ -1,0 +1,35 @@
+package trading.backtesting;
+
+import com.google.protobuf.Any;
+import com.google.protobuf.InvalidProtocolBufferException;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Strategy;
+import trading.StrategyType;
+
+public interface StrategyFactory {
+
+  /**
+   * Creates a Ta4j Strategy object from the provided parameters
+   *
+   * @param strategyParameters the parameters for the strategy
+   * @param series bar series for the strategy
+   * @return Strategy object
+   * @throws InvalidProtocolBufferException If there is an error when unpacking the `Any` type
+   */
+  Strategy createStrategy(Any strategyParameters, BarSeries series)
+      throws InvalidProtocolBufferException;
+
+    /**
+     * Gets the `StrategyType` this factory handles.
+     *
+     * @return The StrategyType this factory handles.
+     */
+  StrategyType getStrategyType();
+
+    /**
+     * Returns the Class that this strategy unpacks the parameters into
+     *
+     * @return the Class that this factory unpacks `Any` into.
+     */
+  Class<?> getParameterClass();
+}

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
@@ -26,10 +26,15 @@ interface StrategyFactory<T extends Message> {
    */
   StrategyType getStrategyType();
 
-    /**
-     * Returns the Class that this strategy unpacks the parameters into
-     *
-     * @return the Class that this factory unpacks `Any` into.
-     */
-    Class<T> getParameterClass();
+  /**
+   * Returns the Class that this strategy unpacks the parameters into
+   *
+   * @return the Class that this factory unpacks `Any` into.
+   */
+  default Class<T> getParameterClass(){
+    Type genericSuperclass = getClass().getGenericInterfaces()[0];
+        ParameterizedType parameterizedType = (ParameterizedType) genericSuperclass;
+        Type actualTypeArgument = parameterizedType.getActualTypeArguments()[0];
+      return (Class<T>) actualTypeArgument;
+  }
 }

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
@@ -1,13 +1,12 @@
-package trading.backtesting;
+package com.verlumen.tradestream.strategies;
 
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Strategy;
-import trading.StrategyType;
+import com.verlumen.tradestream.strategies.StrategyType;
 
-public interface StrategyFactory {
-
+interface StrategyFactory {
   /**
    * Creates a Ta4j Strategy object from the provided parameters
    *
@@ -19,17 +18,10 @@ public interface StrategyFactory {
   Strategy createStrategy(Any strategyParameters, BarSeries series)
       throws InvalidProtocolBufferException;
 
-    /**
-     * Gets the `StrategyType` this factory handles.
-     *
-     * @return The StrategyType this factory handles.
-     */
+  /**
+   * Gets the `StrategyType` this factory handles.
+   *
+   * @return The StrategyType this factory handles.
+   */
   StrategyType getStrategyType();
-
-    /**
-     * Returns the Class that this strategy unpacks the parameters into
-     *
-     * @return the Class that this factory unpacks `Any` into.
-     */
-  Class<?> getParameterClass();
 }

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
@@ -2,11 +2,12 @@ package com.verlumen.tradestream.strategies;
 
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Message;
 import com.verlumen.tradestream.strategies.StrategyType;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Strategy;
 
-interface StrategyFactory {
+interface StrategyFactory<T extends Message> {
   /**
    * Creates a Ta4j Strategy object from the provided parameters
    *
@@ -24,4 +25,11 @@ interface StrategyFactory {
    * @return The StrategyType this factory handles.
    */
   StrategyType getStrategyType();
+
+    /**
+     * Returns the Class that this strategy unpacks the parameters into
+     *
+     * @return the Class that this factory unpacks `Any` into.
+     */
+    Class<T> getParameterClass();
 }

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
@@ -4,6 +4,8 @@ import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import com.verlumen.tradestream.strategies.StrategyType;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Strategy;
 


### PR DESCRIPTION
This PR introduces the `StrategyFactory` interface and updates dependencies to support the implementation.

- **New Class**: 
  - `StrategyFactory.java`: A generic interface to create Ta4j strategies based on protobuf `Any` parameters and `BarSeries`.

- **Dependency Updates**:
  - Added `org.ta4j:ta4j-core:0.17` for technical analysis and strategy implementation.
  - Updated Protobuf dependency to version `4.29.1`.

- **Build Changes**:
  - Added `strategy_factory` in `BUILD` for `StrategyFactory` with relevant dependencies.
  - Adjusted `MODULE.bazel` to include `ta4j-core`.

This enables dynamic strategy creation and parameter handling for backtesting and live trading scenarios.