### PR TITLE
Add Java Bindings for Protobuf Any Type

### DIFF
--- a/protos/BUILD
+++ b/protos/BUILD
@@ -1,5 +1,10 @@
 load("@io_grpc_grpc_java//:java_grpc_library.bzl", "java_grpc_library")
 
+java_proto_library(
+    name = "any_java_proto",
+    deps = ["@com_google_protobuf//:any_proto"],
+)
+
 proto_library(
     name = "backtest_service_proto",
     srcs = ["backtest_service.proto"],


### PR DESCRIPTION
Added support for generating Java bindings for the `google.protobuf.Any` type to enhance integration with existing protobuf services. Changes include:

1. **`BUILD` File Updates**:
   - Introduced a `java_proto_library` target named `any_java_proto` to generate Java bindings for the `google.protobuf.Any` type.

This update ensures compatibility with protobuf messages that use the `Any` type, streamlining development for services requiring dynamic message structures.