### PR TITLE
Refactor Protobuf Build Visibility and Default Configurations

### DIFF
--- a/protos/BUILD
+++ b/protos/BUILD
@@ -1,5 +1,9 @@
 load("@io_grpc_grpc_java//:java_grpc_library.bzl", "java_grpc_library")
 
+package(
+    default_visibility = ["//visibility:public"]
+)
+
 proto_library(
     name = "backtest_service_proto",
     srcs = ["backtest_service.proto"],
@@ -11,7 +15,6 @@ proto_library(
 java_proto_library(
     name = "backtest_service_java_proto",
     deps = [":backtest_service_proto"],
-    visibility = ["//:__subpackages__"],
 )
 
 java_grpc_library(
@@ -34,7 +37,6 @@ proto_library(
 java_proto_library(
     name = "backtesting_java_proto",
     deps = [":backtesting_proto"],
-    visibility = ["//:__subpackages__"],
 )
 
 proto_library(
@@ -46,7 +48,6 @@ proto_library(
 java_proto_library(
     name = "marketdata_java_proto",
     deps = [":marketdata_proto"],
-    visibility = ["//:__subpackages__"],
 )
 
 proto_library(
@@ -58,5 +59,4 @@ proto_library(
 java_proto_library(
     name = "strategies_java_proto",
     deps = [":strategies_proto"],
-    visibility = ["//:__subpackages__"],
 )


### PR DESCRIPTION
This PR refines the visibility and packaging configurations for protobuf targets to enhance reusability and standardization across modules.

1. **Set Default Visibility**:
   - Introduced `default_visibility = ["//visibility:public"]` for all protobuf-related targets.

2. **Simplified Visibility Declarations**:
   - Removed explicit `visibility = ["//:__subpackages__"]` from individual `java_proto_library` targets to rely on the default visibility.

These changes simplify the build configuration while maintaining flexibility for target reuse across projects.