### PR TITLE
Update Protobuf Java Dependency to Version 4.29.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -39,7 +39,7 @@ maven.install(
         "com.google.mug:mug:8.2",
         "com.google.mug:mug-guava:8.2",
         "com.google.mug:mug-protobuf:8.2",
-        "com.google.protobuf:protobuf-java:3.21.12",
+        "com.google.protobuf:protobuf-java:4.29.1",
         "com.ryanharter.auto.value:auto-value-gson:1.3.1",
         "com.ryanharter.auto.value:auto-value-gson-annotations:0.8.0",
         "com.ryanharter.auto.value:auto-value-gson-factory:1.3.1",


### PR DESCRIPTION
This PR updates the Protobuf Java dependency in `MODULE.bazel` to align with newer library versions and maintain compatibility with recent changes in protobuf tools.

- **Updated Dependency**:
  - `com.google.protobuf:protobuf-java` bumped from `3.21.12` to `4.29.1`.

This ensures the project benefits from the latest features, bug fixes, and performance improvements in the Protobuf library.