### PR TITLE
Remove Unused `any_java_proto` Target from Protos BUILD

### DIFF
--- a/protos/BUILD
+++ b/protos/BUILD
@@ -4,11 +4,6 @@ package(
     default_visibility = ["//visibility:public"]
 )
 
-java_proto_library(
-    name = "any_java_proto",
-    deps = ["@com_google_protobuf//:any_proto"],
-)
-
 proto_library(
     name = "backtest_service_proto",
     srcs = ["backtest_service.proto"],


### PR DESCRIPTION
This PR removes the unused `any_java_proto` target from the `protos/BUILD` file. 

- **Removed**: 
  - The `java_proto_library` definition for `any_java_proto` was removed as it was not referenced elsewhere in the project.

- **Impact**:
  - Cleans up unnecessary targets from the build file to improve maintainability and clarity.

No functional changes were introduced with this update.