### PR TITLE
Refactor StrategyFactory to Remove BarSeries Dependency

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
@@ -18,7 +18,7 @@ interface StrategyFactory<T extends Message> {
    * @return Strategy object
    * @throws InvalidProtocolBufferException If there is an error when unpacking the `Any` type
    */
-  Strategy createStrategy(Any strategyParameters, BarSeries series)
+  Strategy createStrategy(T strategyParameters, BarSeries series)
       throws InvalidProtocolBufferException;
 
   /**

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
@@ -13,12 +13,12 @@ interface StrategyFactory<T extends Message> {
   /**
    * Creates a Ta4j Strategy object from the provided parameters
    *
-   * @param strategyParameters the parameters for the strategy
+   * @param parameters the parameters for the strategy
    * @param series bar series for the strategy
    * @return Strategy object
    * @throws InvalidProtocolBufferException If there is an error when unpacking the `Any` type
    */
-  Strategy createStrategy(T strategyParameters, BarSeries series)
+  Strategy createStrategy(T parameters, BarSeries series)
       throws InvalidProtocolBufferException;
 
   /**

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
@@ -6,7 +6,6 @@ import com.google.protobuf.Message;
 import com.verlumen.tradestream.strategies.StrategyType;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import org.ta4j.core.BarSeries;
 import org.ta4j.core.Strategy;
 
 interface StrategyFactory<T extends Message> {
@@ -14,11 +13,10 @@ interface StrategyFactory<T extends Message> {
    * Creates a Ta4j Strategy object from the provided parameters
    *
    * @param parameters the parameters for the strategy
-   * @param series bar series for the strategy
    * @return Strategy object
    * @throws InvalidProtocolBufferException If there is an error when unpacking the `Any` type
    */
-  Strategy createStrategy(T parameters, BarSeries series)
+  Strategy createStrategy(T parameters)
       throws InvalidProtocolBufferException;
 
   /**


### PR DESCRIPTION
This PR refactors the `StrategyFactory` interface by simplifying the `createStrategy` method. 

- **Updated**:
  - The `createStrategy` method signature now accepts a single parameter of type `T` instead of both `Any` and `BarSeries`.
  - Removed the `BarSeries` dependency from the method parameters.

- **Impact**:
  - Improves the design by decoupling the `StrategyFactory` interface from `BarSeries`, enhancing flexibility and reusability.
  - Simplifies the interface for implementing classes, focusing purely on parameter unpacking.

No functional changes were introduced; this is a structural improvement.