### PR TITLE
Add `StrategyManagerImpl` for Managing and Delegating Strategy Creation

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -89,6 +89,7 @@ java_library(
     deps = [
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_protobuf_protobuf_java",
+        "@maven//:org_ta4j_ta4j_core",
         ":strategy_factory",
     ],
 )
@@ -100,6 +101,7 @@ java_library(
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_inject_guice",
         "@maven//:com_google_protobuf_protobuf_java",
+        "@maven//:org_ta4j_ta4j_core",
         ":strategy_factory",
         ":strategy_manager",
     ],

--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -82,3 +82,21 @@ java_library(
         "//protos:strategies_java_proto",
     ],
 )
+
+java_library(
+    name = "strategy_manager",
+    srcs = ["StrategyManager.java"],
+    deps = [
+        ":strategy_factory",
+    ],
+)
+
+java_library(
+    name = "strategy_manager_impl",
+    srcs = ["StrategyManagerImpl.java"],
+    deps = [
+        ":strategy_factory",
+        ":strategy_manager",
+    ],
+)
+

--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -87,6 +87,7 @@ java_library(
     name = "strategy_manager",
     srcs = ["StrategyManager.java"],
     deps = [
+        "@maven//:com_google_protobuf_protobuf_java",
         ":strategy_factory",
     ],
 )
@@ -95,6 +96,7 @@ java_library(
     name = "strategy_manager_impl",
     srcs = ["StrategyManagerImpl.java"],
     deps = [
+        "@maven//:com_google_protobuf_protobuf_java",
         ":strategy_factory",
         ":strategy_manager",
     ],

--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -102,6 +102,8 @@ java_library(
         "@maven//:com_google_inject_guice",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:org_ta4j_ta4j_core",
+        "//:autovalue",
+        "//protos:strategies_java_proto",
         ":strategy_factory",
         ":strategy_manager",
     ],

--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -87,6 +87,7 @@ java_library(
     name = "strategy_manager",
     srcs = ["StrategyManager.java"],
     deps = [
+        "@maven//:com_google_guava_guava",
         "@maven//:com_google_protobuf_protobuf_java",
         ":strategy_factory",
     ],
@@ -96,6 +97,7 @@ java_library(
     name = "strategy_manager_impl",
     srcs = ["StrategyManagerImpl.java"],
     deps = [
+        "@maven//:com_google_guava_guava",
         "@maven//:com_google_inject_guice",
         "@maven//:com_google_protobuf_protobuf_java",
         ":strategy_factory",

--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -96,6 +96,7 @@ java_library(
     name = "strategy_manager_impl",
     srcs = ["StrategyManagerImpl.java"],
     deps = [
+        "@maven//:com_google_inject_guice",
         "@maven//:com_google_protobuf_protobuf_java",
         ":strategy_factory",
         ":strategy_manager",

--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -100,6 +100,7 @@ java_library(
     deps = [
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_inject_guice",
+        "@maven//:com_google_mug_mug",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:org_ta4j_ta4j_core",
         "//:autovalue",

--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -87,9 +87,9 @@ java_library(
     name = "strategy_manager",
     srcs = ["StrategyManager.java"],
     deps = [
-        "@maven//:com_google_guava_guava",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:org_ta4j_ta4j_core",
+        "//protos:strategies_java_proto",
         ":strategy_factory",
     ],
 )
@@ -106,4 +106,3 @@ java_library(
         ":strategy_manager",
     ],
 )
-

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManager.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManager.java
@@ -1,0 +1,18 @@
+package com.verlumen.tradestream.strategies;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.Any;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Message;
+import org.ta4j.core.Strategy;
+import java.util.Map;
+
+interface StrategyManager {
+  Strategy createStrategy(StrategyType strategyType, Any strategyParameters) throws InvalidProtocolBufferException;
+  
+  @AutoValue
+  abstract class Config {
+    abstract ImmutableMap<StrategyType, StrategyFactory> factoryMap();
+  }
+}

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManager.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManager.java
@@ -6,7 +6,6 @@ import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import org.ta4j.core.Strategy;
-import java.util.Map;
 
 interface StrategyManager {
   Strategy createStrategy(StrategyType strategyType, Any strategyParameters) throws InvalidProtocolBufferException;

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManager.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManager.java
@@ -3,8 +3,10 @@ package com.verlumen.tradestream.strategies;
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.verlumen.tradestream.strategies.StrategyType;
+import org.ta4j.core.BarSeries;
 import org.ta4j.core.Strategy;
 
 interface StrategyManager {
-  Strategy createStrategy(StrategyType strategyType, Any strategyParameters) throws InvalidProtocolBufferException;
+  Strategy createStrategy(BarSeries barSeries, StrategyType strategyType, Any strategyParameters)
+    throws InvalidProtocolBufferException;
 }

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManager.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManager.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
+import com.verlumen.tradestream.strategies.StrategyType;
 import org.ta4j.core.Strategy;
 
 interface StrategyManager {

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManager.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManager.java
@@ -1,5 +1,6 @@
 package com.verlumen.tradestream.strategies;
 
+import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.Any;

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManager.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManager.java
@@ -1,23 +1,10 @@
 package com.verlumen.tradestream.strategies;
 
-import com.google.auto.value.AutoValue;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.google.protobuf.Message;
 import com.verlumen.tradestream.strategies.StrategyType;
 import org.ta4j.core.Strategy;
 
 interface StrategyManager {
   Strategy createStrategy(StrategyType strategyType, Any strategyParameters) throws InvalidProtocolBufferException;
-  
-  @AutoValue
-  abstract class Config {
-    static Config create(ImmutableList<StrategyFactory> factories) {
-      return new AutoValue_Config();
-    }
-    
-    abstract ImmutableMap<StrategyType, StrategyFactory> factoryMap();
-  }
 }

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManager.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManager.java
@@ -13,6 +13,10 @@ interface StrategyManager {
   
   @AutoValue
   abstract class Config {
+    static Config create(ImmutableList<StrategyFactory> factories) {
+      return new AutoValue_Config();
+    }
+    
     abstract ImmutableMap<StrategyType, StrategyFactory> factoryMap();
   }
 }

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
@@ -23,23 +23,24 @@ final class StrategyManagerImpl implements StrategyManager {
   @Override
   public Strategy createStrategy(StrategyType strategyType, Any parameters)
       throws InvalidProtocolBufferException {
-    StrategyFactory<? extends Message> factory = config.factoryMap().get(strategyType);
+    StrategyFactory<?> factory = config.factoryMap().get(strategyType);
     if (factory == null) {
       throw new IllegalArgumentException("Unsupported strategy type: " + strategyType);
     }
 
-    return factory.createStrategy(parameters.unpack(factory.getParameterClass()));
+    Class<? extends Message> parameterClass = factory.getParameterClass();
+    return factory.createStrategy(parameters.unpack(parameterClass));
   }
 
   @AutoValue
   abstract static class Config {
-    static Config create(ImmutableList<StrategyFactory<? extends Message>> factories) {
-      ImmutableMap<StrategyType, StrategyFactory<? extends Message>> factoryMap =
+    static Config create(ImmutableList<StrategyFactory<?>> factories) {
+      ImmutableMap<StrategyType, StrategyFactory<?>> factoryMap =
           BiStream.from(factories, StrategyFactory::getStrategyType, identity())
               .collect(ImmutableMap::toImmutableMap);
       return new AutoValue_StrategyManagerImpl_Config(factoryMap);
     }
 
-    abstract ImmutableMap<StrategyType, StrategyFactory<? extends Message>> factoryMap();
+    abstract ImmutableMap<StrategyType, StrategyFactory<?>> factoryMap();
   }
 }

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
@@ -9,7 +9,6 @@ import com.google.inject.Inject;
 import com.google.mu.util.stream.BiStream;
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.google.protobuf.Message;
 import org.ta4j.core.Strategy;
 
 final class StrategyManagerImpl implements StrategyManager {
@@ -28,24 +27,8 @@ final class StrategyManagerImpl implements StrategyManager {
       throw new IllegalArgumentException("Unsupported strategy type: " + strategyType);
     }
   
-    // The factory returns a parameter class with a known Message subtype.
-    Class<? extends Message> parameterClass = factory.getParameterClass();
-  
-    // Cast the parameter class to Message, since we know it's safe from how we build the map.
-    @SuppressWarnings("unchecked")
-    Class<Message> castedParameterClass = (Class<Message>) parameterClass;
-  
-    // Unpack the parameters using the casted parameter class.
-    Message paramMessage = parameters.unpack(castedParameterClass);
-  
-    // Cast the factory to a StrategyFactory<Message> so createStrategy can accept paramMessage.
-    @SuppressWarnings("unchecked")
-    StrategyFactory<Message> castedFactory = (StrategyFactory<Message>) factory;
-  
-    // Now call createStrategy with the correctly typed message.
-    return castedFactory.createStrategy(paramMessage);
+    return castedFactory.createStrategy(parameters);
   }
-
 
   @AutoValue
   abstract static class Config {

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
@@ -1,0 +1,33 @@
+package com.verlumen.tradestream.strategies;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.Any;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Message;
+import org.ta4j.core.Strategy;
+import java.util.Map;
+
+public class StrategyManagerImpl {
+  private final ImmutableMap<StrategyType, StrategyFactory<?>> strategyFactories;
+
+  @Inject
+  StrategyManager(ImmutableList<StrategyFactory<? extends Message>> strategyFactories) {
+    ImmutableMap.Builder<StrategyType, StrategyFactory<?>> builder = ImmutableMap.builder();
+    for (StrategyFactory<?> factory : strategyFactories) {
+      builder.put(factory.getStrategyType(), factory);
+    }
+    this.strategyFactories = builder.build();
+  }
+
+
+   public  Strategy createStrategy(StrategyType strategyType, Any strategyParameters) throws InvalidProtocolBufferException {
+
+        StrategyFactory<?> factory = strategyFactories.get(strategyType);
+        if (factory == null) {
+            throw new IllegalArgumentException("Unsupported strategy type: " + strategyType);
+        }
+          Object params = strategyParameters.unpack(factory.getParameterClass());
+        return factory.createStrategy(params);
+    }
+}

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
@@ -6,6 +6,7 @@ import com.google.inject.Inject;
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
+import com.verlumen.tradestream.strategies.StrategyType;
 import org.ta4j.core.Strategy;
 
 final class StrategyManagerImpl {

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
@@ -1,9 +1,12 @@
 package com.verlumen.tradestream.strategies;
 
+import static java.util.function.Function.identity;
+
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
+import com.google.mu.util.stream.BiStream;
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
@@ -31,6 +34,10 @@ final class StrategyManagerImpl {
   @AutoValue
   abstract class Config {
     static Config create(ImmutableList<StrategyFactory> factories) {
+      ImmutableMap<StrategyType, StrategyFactory> factoryMap = 
+        ImmutableMap.copyOf(
+          BiStream.from(factories, StrategyFactory::getStrategyType, identity())
+          .toMap());
       return new AutoValue_StrategyManagerImpl_Config();
     }
     

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
@@ -36,7 +36,7 @@ final class StrategyManagerImpl implements StrategyManager {
     static Config create(ImmutableList<StrategyFactory<?>> factories) {
       ImmutableMap<StrategyType, StrategyFactory<?>> factoryMap = 
         BiStream.from(factories, StrategyFactory::getStrategyType, identity())
-          .collect(ImmutableMap.toImmutableMap());
+          .collect(ImmutableMap::toImmutableMap);
       return new AutoValue_StrategyManagerImpl_Config(factoryMap);
     }
     

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
@@ -1,7 +1,5 @@
 package com.verlumen.tradestream.strategies;
 
-import static java.util.function.Function.identity;
-
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -11,6 +9,7 @@ import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import com.verlumen.tradestream.strategies.StrategyType;
+import java.util.function.Function;
 import org.ta4j.core.Strategy;
 
 final class StrategyManagerImpl {
@@ -35,7 +34,7 @@ final class StrategyManagerImpl {
   abstract static class Config {
     static Config create(ImmutableList<StrategyFactory> factories) {
       ImmutableMap<StrategyType, StrategyFactory> factoryMap = 
-        BiStream.from(factories, StrategyFactory::getStrategyType, identity())
+        BiStream.from(factories, StrategyFactory::getStrategyType, Function::identity)
           .collect(ImmutableMap::toImmutableMap);
       return new AutoValue_StrategyManagerImpl_Config(factoryMap);
     }

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
@@ -38,7 +38,7 @@ final class StrategyManagerImpl {
         ImmutableMap.copyOf(
           BiStream.from(factories, StrategyFactory::getStrategyType, identity())
           .toMap());
-      return new AutoValue_StrategyManagerImpl_Config();
+      return new AutoValue_StrategyManagerImpl_Config(factoryMap);
     }
     
     abstract ImmutableMap<StrategyType, StrategyFactory> factoryMap();

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
@@ -17,18 +17,12 @@ public class StrategyManagerImpl {
   }
 
   @Override
-  public Strategy createStrategy(Any strategyParameters, StrategyType strategyType) throws InvalidProtocolBufferException {      
+  public Strategy createStrategy(Any parameters, StrategyType strategyType) throws InvalidProtocolBufferException {      
     StrategyFactory<?> factory = config.factoryMap().get(strategyType);
     if (factory == null) {
         throw new IllegalArgumentException("Unsupported strategy type: " + strategyType);
     }
 
-    Object params = strategyParameters.unpack(factory.getParameterClass());
-    return factory.createStrategy(params);
-  }
-
-  private <T extends Message> Strategy createStrategy(Any strategyParameters, StrategyFactory factory, Class<T> parameterClass) throws InvalidProtocolBufferException {
-    T params = strategyParameters.unpack(factory.getParameterClass());
-    return factory.createStrategy(params);
+    return factory.createStrategy(parameters.unpack(factory.getParameterClass()));
   }
 }

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
@@ -23,24 +23,23 @@ final class StrategyManagerImpl implements StrategyManager {
   @Override
   public Strategy createStrategy(StrategyType strategyType, Any parameters)
       throws InvalidProtocolBufferException {
-    StrategyFactory<?> factory = config.factoryMap().get(strategyType);
+    StrategyFactory<? extends Message> factory = config.factoryMap().get(strategyType);
     if (factory == null) {
       throw new IllegalArgumentException("Unsupported strategy type: " + strategyType);
     }
 
-    Class<? extends Message> parameterClass = (Class<? extends Message>)factory.getParameterClass();
-    return factory.createStrategy(parameters.unpack(parameterClass));
+    return factory.createStrategy(parameters.unpack(factory.getParameterClass()));
   }
 
   @AutoValue
   abstract static class Config {
-    static Config create(ImmutableList<StrategyFactory<?>> factories) {
-      ImmutableMap<StrategyType, StrategyFactory<?>> factoryMap =
+    static Config create(ImmutableList<StrategyFactory<? extends Message>> factories) {
+      ImmutableMap<StrategyType, StrategyFactory<? extends Message>> factoryMap =
           BiStream.from(factories, StrategyFactory::getStrategyType, identity())
               .collect(ImmutableMap::toImmutableMap);
       return new AutoValue_StrategyManagerImpl_Config(factoryMap);
     }
 
-    abstract ImmutableMap<StrategyType, StrategyFactory<?>> factoryMap();
+    abstract ImmutableMap<StrategyType, StrategyFactory<? extends Message>> factoryMap();
   }
 }

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
@@ -27,7 +27,7 @@ final class StrategyManagerImpl implements StrategyManager {
       throw new IllegalArgumentException("Unsupported strategy type: " + strategyType);
     }
   
-    return castedFactory.createStrategy(parameters);
+    return factory.createStrategy(parameters);
   }
 
   @AutoValue

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
@@ -1,5 +1,6 @@
 package com.verlumen.tradestream.strategies;
 
+import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
@@ -25,5 +26,14 @@ final class StrategyManagerImpl {
     }
 
     return factory.createStrategy(parameters.unpack(factory.getParameterClass()));
+  }
+
+  @AutoValue
+  abstract class Config {
+    static Config create(ImmutableList<StrategyFactory> factories) {
+      return new AutoValue_StrategyManagerImpl_Config();
+    }
+    
+    abstract ImmutableMap<StrategyType, StrategyFactory> factoryMap();
   }
 }

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
@@ -32,7 +32,7 @@ final class StrategyManagerImpl {
   }
 
   @AutoValue
-  abstract class Config {
+  abstract static class Config {
     static Config create(ImmutableList<StrategyFactory> factories) {
       ImmutableMap<StrategyType, StrategyFactory> factoryMap = 
         ImmutableMap.copyOf(

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
@@ -21,25 +21,26 @@ final class StrategyManagerImpl implements StrategyManager {
   }
 
   @Override
-  public Strategy createStrategy(StrategyType strategyType, Any parameters) 
-      throws InvalidProtocolBufferException {      
+  public Strategy createStrategy(StrategyType strategyType, Any parameters)
+      throws InvalidProtocolBufferException {
     StrategyFactory<?> factory = config.factoryMap().get(strategyType);
     if (factory == null) {
-        throw new IllegalArgumentException("Unsupported strategy type: " + strategyType);
+      throw new IllegalArgumentException("Unsupported strategy type: " + strategyType);
     }
 
-    return factory.createStrategy(parameters.unpack(factory.getParameterClass()));
+    Class<? extends Message> parameterClass = (Class<? extends Message>)factory.getParameterClass();
+    return factory.createStrategy(parameters.unpack(parameterClass));
   }
 
   @AutoValue
   abstract static class Config {
     static Config create(ImmutableList<StrategyFactory<?>> factories) {
-      ImmutableMap<StrategyType, StrategyFactory<?>> factoryMap = 
-        BiStream.from(factories, StrategyFactory::getStrategyType, identity())
-          .collect(ImmutableMap::toImmutableMap);
+      ImmutableMap<StrategyType, StrategyFactory<?>> factoryMap =
+          BiStream.from(factories, StrategyFactory::getStrategyType, identity())
+              .collect(ImmutableMap::toImmutableMap);
       return new AutoValue_StrategyManagerImpl_Config(factoryMap);
     }
-    
+
     abstract ImmutableMap<StrategyType, StrategyFactory<?>> factoryMap();
   }
 }

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
@@ -9,6 +9,7 @@ import com.google.inject.Inject;
 import com.google.mu.util.stream.BiStream;
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
+import org.ta4j.core.BarSeries;
 import org.ta4j.core.Strategy;
 
 final class StrategyManagerImpl implements StrategyManager {
@@ -20,14 +21,14 @@ final class StrategyManagerImpl implements StrategyManager {
   }
 
   @Override
-  public Strategy createStrategy(StrategyType strategyType, Any parameters)
+  public Strategy createStrategy(BarSeries barSeries, StrategyType strategyType, Any parameters)
       throws InvalidProtocolBufferException {
     StrategyFactory<?> factory = config.factoryMap().get(strategyType);
     if (factory == null) {
       throw new IllegalArgumentException("Unsupported strategy type: " + strategyType);
     }
   
-    return factory.createStrategy(parameters);
+    return factory.createStrategy(barSeries, parameters);
   }
 
   @AutoValue

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
@@ -8,7 +8,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import org.ta4j.core.Strategy;
 
-public class StrategyManagerImpl {
+final class StrategyManagerImpl {
   private final Config config;
 
   @Inject

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
@@ -10,10 +10,9 @@ import com.google.mu.util.stream.BiStream;
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
-import com.verlumen.tradestream.strategies.StrategyType;
 import org.ta4j.core.Strategy;
 
-final class StrategyManagerImpl {
+final class StrategyManagerImpl implements StrategyManager {
   private final Config config;
 
   @Inject
@@ -22,7 +21,8 @@ final class StrategyManagerImpl {
   }
 
   @Override
-  public Strategy createStrategy(Any parameters, StrategyType strategyType) throws InvalidProtocolBufferException {      
+  public Strategy createStrategy(StrategyType strategyType, Any parameters) 
+      throws InvalidProtocolBufferException {      
     StrategyFactory<?> factory = config.factoryMap().get(strategyType);
     if (factory == null) {
         throw new IllegalArgumentException("Unsupported strategy type: " + strategyType);
@@ -33,13 +33,13 @@ final class StrategyManagerImpl {
 
   @AutoValue
   abstract static class Config {
-    static Config create(ImmutableList<StrategyFactory> factories) {
-      ImmutableMap<StrategyType, StrategyFactory> factoryMap = 
+    static Config create(ImmutableList<StrategyFactory<?>> factories) {
+      ImmutableMap<StrategyType, StrategyFactory<?>> factoryMap = 
         BiStream.from(factories, StrategyFactory::getStrategyType, identity())
-          .collect(ImmutableMap::toImmutableMap);
+          .collect(ImmutableMap.toImmutableMap());
       return new AutoValue_StrategyManagerImpl_Config(factoryMap);
     }
     
-    abstract ImmutableMap<StrategyType, StrategyFactory> factoryMap();
+    abstract ImmutableMap<StrategyType, StrategyFactory<?>> factoryMap();
   }
 }

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
@@ -27,10 +27,25 @@ final class StrategyManagerImpl implements StrategyManager {
     if (factory == null) {
       throw new IllegalArgumentException("Unsupported strategy type: " + strategyType);
     }
-
+  
+    // The factory returns a parameter class with a known Message subtype.
     Class<? extends Message> parameterClass = factory.getParameterClass();
-    return factory.createStrategy(parameters.unpack(parameterClass));
+  
+    // Cast the parameter class to Message, since we know it's safe from how we build the map.
+    @SuppressWarnings("unchecked")
+    Class<Message> castedParameterClass = (Class<Message>) parameterClass;
+  
+    // Unpack the parameters using the casted parameter class.
+    Message paramMessage = parameters.unpack(castedParameterClass);
+  
+    // Cast the factory to a StrategyFactory<Message> so createStrategy can accept paramMessage.
+    @SuppressWarnings("unchecked")
+    StrategyFactory<Message> castedFactory = (StrategyFactory<Message>) factory;
+  
+    // Now call createStrategy with the correctly typed message.
+    return castedFactory.createStrategy(paramMessage);
   }
+
 
   @AutoValue
   abstract static class Config {

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
@@ -35,9 +35,8 @@ final class StrategyManagerImpl {
   abstract static class Config {
     static Config create(ImmutableList<StrategyFactory> factories) {
       ImmutableMap<StrategyType, StrategyFactory> factoryMap = 
-        ImmutableMap.copyOf(
-          BiStream.from(factories, StrategyFactory::getStrategyType, identity())
-          .toMap());
+        BiStream.from(factories, StrategyFactory::getStrategyType, identity())
+          .collect(ImmutableMap::toImmutableMap);
       return new AutoValue_StrategyManagerImpl_Config(factoryMap);
     }
     

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
@@ -1,5 +1,7 @@
 package com.verlumen.tradestream.strategies;
 
+import static java.util.function.Function.identity;
+
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -9,7 +11,6 @@ import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import com.verlumen.tradestream.strategies.StrategyType;
-import java.util.function.Function;
 import org.ta4j.core.Strategy;
 
 final class StrategyManagerImpl {
@@ -34,7 +35,7 @@ final class StrategyManagerImpl {
   abstract static class Config {
     static Config create(ImmutableList<StrategyFactory> factories) {
       ImmutableMap<StrategyType, StrategyFactory> factoryMap = 
-        BiStream.from(factories, StrategyFactory::getStrategyType, Function::identity)
+        BiStream.from(factories, StrategyFactory::getStrategyType, identity())
           .collect(ImmutableMap::toImmutableMap);
       return new AutoValue_StrategyManagerImpl_Config(factoryMap);
     }

--- a/src/test/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/test/java/com/verlumen/tradestream/strategies/BUILD
@@ -1,0 +1,24 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
+java_test(
+    name = "StrategyManagerImplTest",
+    srcs = ["StrategyManagerImplTest.java"],
+    deps = [
+        "@maven//:com_google_flogger_flogger",
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_inject_guice",
+        "@maven//:com_google_inject_extensions_guice_testlib",
+        "@maven//:com_google_protobuf_protobuf_java",
+        "@maven//:com_google_truth_truth",
+        "@maven//:junit_junit",
+        "@maven//:org_mockito_mockito_core",
+        "@maven//:org_ta4j_ta4j_core",
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/strategies:strategy_factory",
+        "//src/main/java/com/verlumen/tradestream/strategies:strategy_manager",
+        "//src/main/java/com/verlumen/tradestream/strategies:strategy_manager_impl",
+    ],
+    runtime_deps = [
+        "@maven//:com_google_flogger_flogger_system_backend",
+    ],
+)

--- a/src/test/java/com/verlumen/tradestream/strategies/StrategyManagerImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/StrategyManagerImplTest.java
@@ -1,0 +1,141 @@
+package com.verlumen.tradestream.strategies;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Guice;
+import com.google.inject.testing.fieldbinder.Bind;
+import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import com.google.protobuf.Any;
+import com.google.protobuf.InvalidProtocolBufferException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.ta4j.core.Strategy;
+
+@RunWith(JUnit4.class)
+public class StrategyManagerImplTest {
+
+    @Bind
+    @Mock
+    private StrategyFactory<SmaRsiParameters> mockSmaRsiFactory;
+
+    @Bind
+    @Mock 
+    private StrategyFactory<EmaMacdParameters> mockEmaMacdFactory;
+
+    private StrategyManagerImpl strategyManager;
+    private Strategy mockStrategy;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        // Configure mock factories
+        when(mockSmaRsiFactory.getStrategyType()).thenReturn(StrategyType.SMA_RSI);
+        when(mockEmaMacdFactory.getStrategyType()).thenReturn(StrategyType.EMA_MACD);
+
+        // Create config with mock factories
+        StrategyManagerImpl.Config config = StrategyManagerImpl.Config.create(
+            ImmutableList.of(mockSmaRsiFactory, mockEmaMacdFactory));
+
+        // Initialize strategy manager with mocked dependencies
+        strategyManager = Guice.createInjector(BoundFieldModule.of(this))
+            .getInstance(StrategyManagerImpl.class);
+
+        // Create mock strategy for testing
+        mockStrategy = mock(Strategy.class);
+    }
+
+    @Test
+    public void createStrategy_withValidSmaRsiParameters_returnsStrategy() 
+        throws InvalidProtocolBufferException {
+        // Arrange
+        SmaRsiParameters params = SmaRsiParameters.newBuilder()
+            .setMovingAveragePeriod(14)
+            .setRsiPeriod(14)
+            .setOverboughtThreshold(70)
+            .setOversoldThreshold(30)
+            .build();
+        Any packedParams = Any.pack(params);
+
+        when(mockSmaRsiFactory.createStrategy(packedParams)).thenReturn(mockStrategy);
+
+        // Act
+        Strategy result = strategyManager.createStrategy(StrategyType.SMA_RSI, packedParams);
+
+        // Assert
+        assertThat(result).isSameInstanceAs(mockStrategy);
+    }
+
+    @Test
+    public void createStrategy_withValidEmaMacdParameters_returnsStrategy() 
+        throws InvalidProtocolBufferException {
+        // Arrange
+        EmaMacdParameters params = EmaMacdParameters.newBuilder()
+            .setShortEmaPeriod(12)
+            .setLongEmaPeriod(26)
+            .setSignalPeriod(9)
+            .build();
+        Any packedParams = Any.pack(params);
+
+        when(mockEmaMacdFactory.createStrategy(packedParams)).thenReturn(mockStrategy);
+
+        // Act
+        Strategy result = strategyManager.createStrategy(StrategyType.EMA_MACD, packedParams);
+
+        // Assert
+        assertThat(result).isSameInstanceAs(mockStrategy);
+    }
+
+    @Test
+    public void createStrategy_withUnsupportedStrategyType_throwsIllegalArgumentException() {
+        // Arrange
+        SmaRsiParameters params = SmaRsiParameters.newBuilder()
+            .setMovingAveragePeriod(14)
+            .setRsiPeriod(14)
+            .setOverboughtThreshold(70)
+            .setOversoldThreshold(30)
+            .build();
+        Any packedParams = Any.pack(params);
+
+        // Act & Assert
+        IllegalArgumentException thrown = assertThrows(
+            IllegalArgumentException.class,
+            () -> strategyManager.createStrategy(StrategyType.ADX_STOCHASTIC, packedParams));
+        
+        assertThat(thrown).hasMessageThat()
+            .contains("Unsupported strategy type: ADX_STOCHASTIC");
+    }
+
+    @Test
+    public void createStrategy_whenFactoryThrowsException_propagatesException() 
+        throws InvalidProtocolBufferException {
+        // Arrange
+        SmaRsiParameters params = SmaRsiParameters.newBuilder()
+            .setMovingAveragePeriod(14)
+            .setRsiPeriod(14)
+            .setOverboughtThreshold(70)
+            .setOversoldThreshold(30)
+            .build();
+        Any packedParams = Any.pack(params);
+
+        InvalidProtocolBufferException expectedException = 
+            new InvalidProtocolBufferException("Test exception");
+        when(mockSmaRsiFactory.createStrategy(packedParams))
+            .thenThrow(expectedException);
+
+        // Act & Assert
+        InvalidProtocolBufferException thrown = assertThrows(
+            InvalidProtocolBufferException.class,
+            () -> strategyManager.createStrategy(StrategyType.SMA_RSI, packedParams));
+        
+        assertThat(thrown).isSameInstanceAs(expectedException);
+    }
+}


### PR DESCRIPTION
This PR introduces the `StrategyManagerImpl` class to centralize the management and delegation of strategy creation to specific `StrategyFactory` instances. It refines the architecture by providing a configurable `Config` object that maps `StrategyType` to their respective `StrategyFactory`.

### Key Changes
1. **Core Implementation**:
   - Added `StrategyManagerImpl` to implement the `StrategyManager` interface.
   - Included a nested `Config` class that uses `ImmutableMap` to associate `StrategyType` with their respective `StrategyFactory`.

2. **Interface Enhancements**:
   - Updated `StrategyManager` to include a `BarSeries` parameter for strategy creation.

3. **Testing**:
   - Created `StrategyManagerImplTest` to validate the behavior of `StrategyManagerImpl`.
   - Tests include successful strategy creation, unsupported strategy types, and exception propagation from factories.

4. **Build Configuration**:
   - Updated `BUILD` files to include the new classes and tests:
     - Added `strategy_manager_impl` as a `java_library`.
     - Added `StrategyManagerImplTest` as a `java_test`.

### Testing
- **Unit Tests**:
  - Verified strategy creation with valid parameters.
  - Ensured proper exception handling for unsupported types and invalid inputs.
- **Mocks and Dependencies**:
  - Used Mockito to simulate `StrategyFactory` behaviors.
  - Tested with mocked `BarSeries` and `Strategy` instances.

### Dependencies/Impact
- Requires updates to the strategy implementations to align with the new delegation model.
- Simplifies the addition of new strategy types by registering them in the `Config` class.

### Next Steps
- Integrate `StrategyManagerImpl` with existing modules.
- Extend test coverage for edge cases involving complex factory interactions.