### PR TITLE
Add `DoubleEmaCrossoverStrategyFactory` Implementation and Tests

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
@@ -50,7 +50,7 @@ public interface StrategyFactory<T extends Message> {
    * @param exitRule The {@link Rule} that signals an exit from a position.
    * @return The created {@link Strategy} object.
    */
-  default Strategy createStrategy(BarSeries series, Rule entryRule, Rule exitRule) {
+  default Strategy createStrategy(Rule entryRule, Rule exitRule) {
     return new BaseStrategy(getStrategyType().name(), entryRule, exitRule);
   }
   

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
@@ -42,14 +42,6 @@ public interface StrategyFactory<T extends Message> {
   default Strategy createStrategy(BarSeries series, Any parameters) throws InvalidProtocolBufferException {
     return createStrategy(series, parameters.unpack(getParameterClass()));
   }
-
-  default Strategy createStrategy(Rule entryRule, Rule exitRule) {
-    ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
-    EMAIndicator shortEma = new EMAIndicator(closePrice, params.getShortEmaPeriod());
-    EMAIndicator longEma = new EMAIndicator(closePrice, params.getLongEmaPeriod());
-
-    return new BaseStrategy(getStrategyType().name(), entryRule, exitRule);
-  }
   
   /**
    * Creates a Ta4j Strategy object from the provided {@link Rule} and {@link Rule}.

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
@@ -48,9 +48,10 @@ public interface StrategyFactory<T extends Message> {
    *
    * @param entryRule     The {@link Rule} that signals an entry into a position.
    * @param exitRule The {@link Rule} that signals an exit from a position.
+   * @param unstableBars strategy will ignore possible signals at {@code index < unstableBars}
    * @return The created {@link Strategy} object.
    */
-  default Strategy createStrategy(Rule entryRule, Rule exitRule) {
+  default Strategy createStrategy(Rule entryRule, Rule exitRule, int unstableBars) {
     return new BaseStrategy(getStrategyType().name(), entryRule, exitRule);
   }
   

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
@@ -42,7 +42,7 @@ public interface StrategyFactory<T extends Message> {
   default Strategy createStrategy(BarSeries series, Any parameters) throws InvalidProtocolBufferException {
     return createStrategy(series, parameters.unpack(getParameterClass()));
   }
-  
+
   /**
    * Creates a Ta4j Strategy object from the provided {@link Rule} and {@link Rule}.
    *

--- a/src/main/java/com/verlumen/tradestream/strategies/movingaverages/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/movingaverages/BUILD
@@ -6,6 +6,7 @@ java_library(
     name = "movingaverages_lib",
     srcs = glob(["*.java"]),
     deps = [
+        "@maven//:com_google_guava_guava",
         "@maven//:com_google_inject_guice",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:org_ta4j_ta4j_core",

--- a/src/main/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactory.java
@@ -34,26 +34,24 @@ public class DoubleEmaCrossoverStrategyFactory implements StrategyFactory<Double
 
         // Entry rule: Short EMA crosses above Long EMA
         Rule entryRule = new CrossedUpIndicatorRule(shortEma, longEma);
-        
+
         // Exit rule: Short EMA crosses below Long EMA
         Rule exitRule = new CrossedDownIndicatorRule(shortEma, longEma);
 
-        // Important: Set name to help with debugging
-        BaseStrategy strategy = new BaseStrategy(
-            String.format("%s (%d, %d)",
-                getStrategyType().name(),
-                params.getShortEmaPeriod(), 
-                params.getLongEmaPeriod()),
-            entryRule,
-            exitRule);
-            
         // Since we need stable EMAs for our calculation, we must wait for enough bars
         // to let both EMAs stabilize. While Ta4j docs suggest setting unstable period
         // to the longest indicator period, for EMAs we actually need more bars due to
         // their exponential nature.
         int unstablePeriod = Math.min(4, params.getLongEmaPeriod() - 1);
-        strategy.setUnstablePeriod(unstablePeriod);
-        
+
+        return new BaseStrategy(
+            String.format("%s (%d, %d)",
+                getStrategyType().name(),
+                params.getShortEmaPeriod(), 
+                params.getLongEmaPeriod()),
+            entryRule,
+            exitRule,
+            unstablePeriod);
         return strategy;
     }
 

--- a/src/main/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactory.java
@@ -46,7 +46,7 @@ public class DoubleEmaCrossoverStrategyFactory implements StrategyFactory<Double
                 params.getLongEmaPeriod()),
             entryRule,
             exitRule,
-            params.getLongEmaPeriod() - 1);  // Subtract 1 since we need N-1 bars before Nth bar is ready
+            params.getLongEmaPeriod());
     }
 
     @Override

--- a/src/main/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactory.java
@@ -4,9 +4,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.inject.Inject;
 import com.google.protobuf.InvalidProtocolBufferException;
+import com.verlumen.tradestream.strategies.DoubleEmaCrossoverParameters;
 import com.verlumen.tradestream.strategies.StrategyFactory;
 import com.verlumen.tradestream.strategies.StrategyType;
-import com.verlumen.tradestream.strategies.DoubleEmaCrossoverParameters;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseStrategy;
 import org.ta4j.core.Strategy;
@@ -25,7 +25,7 @@ public class DoubleEmaCrossoverStrategyFactory implements StrategyFactory<Double
     checkArgument(params.getShortEmaPeriod() > 0);
     checkArgument(params.getLongEmaPeriod() > 0);
     checkArgument(params.getLongEmaPeriod() > params.getShortEmaPeriod());
-    
+
     ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
     EMAIndicator shortEma = new EMAIndicator(closePrice, params.getShortEmaPeriod());
     EMAIndicator longEma = new EMAIndicator(closePrice, params.getLongEmaPeriod());

--- a/src/main/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactory.java
@@ -8,7 +8,6 @@ import com.verlumen.tradestream.strategies.DoubleEmaCrossoverParameters;
 import com.verlumen.tradestream.strategies.StrategyFactory;
 import com.verlumen.tradestream.strategies.StrategyType;
 import org.ta4j.core.BarSeries;
-import org.ta4j.core.BaseStrategy;
 import org.ta4j.core.Strategy;
 import org.ta4j.core.indicators.EMAIndicator;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
@@ -33,11 +32,11 @@ public class DoubleEmaCrossoverStrategyFactory implements StrategyFactory<Double
     EMAIndicator shortEma = new EMAIndicator(closePrice, params.getShortEmaPeriod());
     EMAIndicator longEma = new EMAIndicator(closePrice, params.getLongEmaPeriod());
 
-    // Entry rule: Short EMA crosses above Long EMA AND Short EMA > Long EMA
+    // Entry rule: Short EMA crosses above Long EMA AND stays above
     CrossedUpIndicatorRule crossedUpRule = new CrossedUpIndicatorRule(shortEma, longEma);
     OverIndicatorRule overRule = new OverIndicatorRule(shortEma, longEma);
     
-    // Exit rule: Short EMA crosses below Long EMA AND Short EMA < Long EMA  
+    // Exit rule: Short EMA crosses below Long EMA AND stays below
     CrossedDownIndicatorRule crossedDownRule = new CrossedDownIndicatorRule(shortEma, longEma);
     UnderIndicatorRule underRule = new UnderIndicatorRule(shortEma, longEma);
 

--- a/src/main/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactory.java
@@ -38,12 +38,6 @@ public class DoubleEmaCrossoverStrategyFactory implements StrategyFactory<Double
         // Exit rule: Short EMA crosses below Long EMA
         Rule exitRule = new CrossedDownIndicatorRule(shortEma, longEma);
 
-        // Since we need stable EMAs for our calculation, we must wait for enough bars
-        // to let both EMAs stabilize. While Ta4j docs suggest setting unstable period
-        // to the longest indicator period, for EMAs we actually need more bars due to
-        // their exponential nature.
-        int unstablePeriod = Math.min(4, params.getLongEmaPeriod() - 1);
-
         return new BaseStrategy(
             String.format("%s (%d, %d)",
                 getStrategyType().name(),
@@ -51,8 +45,7 @@ public class DoubleEmaCrossoverStrategyFactory implements StrategyFactory<Double
                 params.getLongEmaPeriod()),
             entryRule,
             exitRule,
-            unstablePeriod);
-        return strategy;
+            params.getLongEmaPeriod());
     }
 
     @Override

--- a/src/main/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactory.java
@@ -38,14 +38,15 @@ public class DoubleEmaCrossoverStrategyFactory implements StrategyFactory<Double
         // Exit rule: Short EMA crosses below Long EMA
         Rule exitRule = new CrossedDownIndicatorRule(shortEma, longEma);
 
+        // Create strategy using the constructor that takes unstable period directly
         return new BaseStrategy(
             String.format("%s (%d, %d)",
                 getStrategyType().name(),
-                params.getShortEmaPeriod(), 
+                params.getShortEmaPeriod(),
                 params.getLongEmaPeriod()),
             entryRule,
             exitRule,
-            params.getLongEmaPeriod());
+            params.getLongEmaPeriod() - 1);  // Subtract 1 since we need N-1 bars before Nth bar is ready
     }
 
     @Override

--- a/src/main/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactory.java
@@ -1,5 +1,7 @@
 package com.verlumen.tradestream.strategies.movingaverages;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.google.inject.Inject;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.verlumen.tradestream.strategies.StrategyFactory;
@@ -20,13 +22,19 @@ public class DoubleEmaCrossoverStrategyFactory implements StrategyFactory<Double
   @Override
   public Strategy createStrategy(BarSeries series, DoubleEmaCrossoverParameters params)
       throws InvalidProtocolBufferException {
+    checkArgument(params.getShortEmaPeriod() > 0);
+    checkArgument(params.getLongEmaPeriod() > 0);
+    checkArgument(params.getLongEmaPeriod() > params.getShortEmaPeriod());
+    
     ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
     EMAIndicator shortEma = new EMAIndicator(closePrice, params.getShortEmaPeriod());
     EMAIndicator longEma = new EMAIndicator(closePrice, params.getLongEmaPeriod());
 
     return createStrategy(
         new CrossedUpIndicatorRule(shortEma, longEma),
-        new CrossedDownIndicatorRule(shortEma, longEma));
+        new CrossedDownIndicatorRule(shortEma, longEma),
+        params.getLongEmaPeriod()
+    );
   }
 
   @Override

--- a/src/main/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactory.java
@@ -14,6 +14,8 @@ import org.ta4j.core.indicators.EMAIndicator;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.rules.CrossedDownIndicatorRule;
 import org.ta4j.core.rules.CrossedUpIndicatorRule;
+import org.ta4j.core.rules.OverIndicatorRule;
+import org.ta4j.core.rules.UnderIndicatorRule;
 
 public class DoubleEmaCrossoverStrategyFactory implements StrategyFactory<DoubleEmaCrossoverParameters> {
   @Inject
@@ -22,17 +24,26 @@ public class DoubleEmaCrossoverStrategyFactory implements StrategyFactory<Double
   @Override
   public Strategy createStrategy(BarSeries series, DoubleEmaCrossoverParameters params)
       throws InvalidProtocolBufferException {
-    checkArgument(params.getShortEmaPeriod() > 0);
-    checkArgument(params.getLongEmaPeriod() > 0);
-    checkArgument(params.getLongEmaPeriod() > params.getShortEmaPeriod());
+    checkArgument(params.getShortEmaPeriod() > 0, "Short EMA period must be positive");
+    checkArgument(params.getLongEmaPeriod() > 0, "Long EMA period must be positive");
+    checkArgument(params.getLongEmaPeriod() > params.getShortEmaPeriod(),
+        "Long EMA period must be greater than short EMA period");
 
     ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
     EMAIndicator shortEma = new EMAIndicator(closePrice, params.getShortEmaPeriod());
     EMAIndicator longEma = new EMAIndicator(closePrice, params.getLongEmaPeriod());
 
+    // Entry rule: Short EMA crosses above Long EMA AND Short EMA > Long EMA
+    CrossedUpIndicatorRule crossedUpRule = new CrossedUpIndicatorRule(shortEma, longEma);
+    OverIndicatorRule overRule = new OverIndicatorRule(shortEma, longEma);
+    
+    // Exit rule: Short EMA crosses below Long EMA AND Short EMA < Long EMA  
+    CrossedDownIndicatorRule crossedDownRule = new CrossedDownIndicatorRule(shortEma, longEma);
+    UnderIndicatorRule underRule = new UnderIndicatorRule(shortEma, longEma);
+
     return createStrategy(
-        new CrossedUpIndicatorRule(shortEma, longEma),
-        new CrossedDownIndicatorRule(shortEma, longEma),
+        crossedUpRule.and(overRule),
+        crossedDownRule.and(underRule),
         params.getLongEmaPeriod()
     );
   }

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/BUILD
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/BUILD
@@ -4,6 +4,7 @@ java_test(
     name = "DoubleEmaCrossoverStrategyFactoryTest",
     srcs = ["DoubleEmaCrossoverStrategyFactoryTest.java"],
     deps = [
+        "@maven//:com_google_flogger_flogger",
         "@maven//:com_google_inject_guice",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:com_google_truth_truth",

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/BUILD
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/BUILD
@@ -5,6 +5,7 @@ java_test(
     srcs = ["DoubleEmaCrossoverStrategyFactoryTest.java"],
     deps = [
         "@maven//:com_google_flogger_flogger",
+        "@maven//:com_google_guava_guava",
         "@maven//:com_google_inject_guice",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:com_google_truth_truth",

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -131,12 +131,12 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
    */
   private BarSeries createCrossUpSeries() {
     logger.atInfo().log("Creating bar series to test short EMA crossing up...");
+
     BarSeries series = new BaseBarSeries();
     ZonedDateTime now = ZonedDateTime.now();
 
-    // 1) Warm-up bars so the short (3) & long (7) EMAs are valid.
-    //    10 bars at 10.0 to "prime" the EMAs.
-    for (int i = 0; i < 10; i++) {
+    // Warm-up: 7 bars at 10.0 for a smaller EMA warm-up period
+    for (int i = 0; i < 7; i++) {
       series.addBar(
           new BaseBar(
               Duration.ofMinutes(1),
@@ -145,25 +145,20 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
               100.0));
     }
 
-    // 2) Gradually increase price so shortEma eventually crosses above longEma.
-    series.addBar(
-        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(10), 12.0, 12.0, 12.0, 12.0, 100.0));
-    series.addBar(
-        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(11), 14.0, 14.0, 14.0, 14.0, 100.0));
-    series.addBar(
-        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(12), 18.0, 18.0, 18.0, 18.0, 100.0));
-    series.addBar(
-        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(13), 20.0, 20.0, 20.0, 20.0, 100.0));
+    // Move up: enough to push short EMA > long EMA quickly
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(7), 12.0, 12.0, 12.0, 12.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(8), 14.0, 14.0, 14.0, 14.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(9), 18.0, 18.0, 18.0, 18.0, 100.0));
+ 
+    // Extra trailing bars so the cross is recognized
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(10), 18.0, 18.0, 18.0, 18.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(11), 18.0, 18.0, 18.0, 18.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(12), 18.0, 18.0, 18.0, 18.0, 100.0));
 
-    // 3) Add extra bars so TA4J can “finalize” the cross.
-    series.addBar(
-        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(14), 20.0, 20.0, 20.0, 20.0, 100.0));
-    series.addBar(
-        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(15), 20.0, 20.0, 20.0, 20.0, 100.0));
-
-    logger.atInfo().log("createCrossUpSeries - Completed building bar series for cross-up scenario.");
+    logger.atInfo().log("createCrossUpSeries - Done with smaller EMAs + more trailing bars.");
     return series;
   }
+
 
   /**
    * Creates a bar series designed to produce a short-EMA cross DOWN below the long-EMA.

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -67,28 +67,31 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
     assertThat(position.getEntry().getIndex()).isLessThan(position.getExit().getIndex());
   }
 
-  private BarSeries createCrossDownSeries() {
+private BarSeries createCrossDownSeries() {
       BarSeries series = new BaseBarSeries();
       ZonedDateTime now = ZonedDateTime.now();
 
-      // Establish a baseline with steady low price
-      for (int i = 0; i < 5; i++) {
+      // Start with low baseline to establish EMAs
+      for (int i = 0; i < 10; i++) {
           series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(i), 10.0, 10.0, 10.0, 10.0, 100.0));
       }
 
-      // Sharp upward movement to trigger short EMA crossing above long EMA
-      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(5), 20.0, 20.0, 20.0, 20.0, 100.0));
-      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(6), 25.0, 25.0, 25.0, 25.0, 100.0));
-      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(7), 30.0, 30.0, 30.0, 30.0, 100.0));
+      // Gradual rise to create upward trend and EMA cross
+      for (int i = 10; i < 15; i++) {
+          double price = 10.0 + (i - 10) * 5.0;
+          series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(i), price, price, price, price, 100.0));
+      }
       
-      // Hold at higher level briefly
-      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(8), 30.0, 30.0, 30.0, 30.0, 100.0));
-      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(9), 30.0, 30.0, 30.0, 30.0, 100.0));
+      // Maintain high level briefly
+      for (int i = 15; i < 20; i++) {
+          series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(i), 30.0, 30.0, 30.0, 30.0, 100.0));
+      }
 
-      // Sharp decline to trigger short EMA crossing below long EMA
-      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(10), 15.0, 15.0, 15.0, 15.0, 100.0));
-      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(11), 10.0, 10.0, 10.0, 10.0, 100.0));
-      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(12), 5.0, 5.0, 5.0, 5.0, 100.0));
+      // Gradual decline to trigger crossover down
+      for (int i = 20; i < 25; i++) {
+          double price = 30.0 - (i - 20) * 5.0;
+          series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(i), price, price, price, price, 100.0));
+      }
 
       return series;
   }
@@ -97,15 +100,16 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
     BarSeries series = new BaseBarSeries();
     ZonedDateTime now = ZonedDateTime.now();
 
-    // Start with steady prices to establish baseline EMAs
-    for (int i = 0; i < 5; i++) {
+    // Start with steady low prices to establish baseline EMAs
+    for (int i = 0; i < 10; i++) {
         series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(i), 10.0, 10.0, 10.0, 10.0, 100.0));
     }
 
-    // Sharp upward movement to trigger cross up
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(5), 15.0, 15.0, 15.0, 15.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(6), 20.0, 20.0, 20.0, 20.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(7), 25.0, 25.0, 25.0, 25.0, 100.0));
+    // Gradual upward movement to ensure clear EMA crossover
+    for (int i = 10; i < 20; i++) {
+        double price = 10.0 + (i - 10) * 2.0;
+        series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(i), price, price, price, price, 100.0));
+    }
 
     return series;
   }

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -15,21 +15,21 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BarSeriesManager;
 import org.ta4j.core.BaseBar;
 import org.ta4j.core.BaseBarSeries;
+import org.ta4j.core.Position;
 import org.ta4j.core.Strategy;
+import org.ta4j.core.TradingRecord;
 import org.ta4j.core.indicators.EMAIndicator;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.rules.CrossedDownIndicatorRule;
 import org.ta4j.core.rules.CrossedUpIndicatorRule;
-import org.ta4j.core.BarSeriesManager;
-import org.ta4j.core.TradingRecord;
 
 @RunWith(JUnit4.class)
 public class DoubleEmaCrossoverStrategyFactoryTest {
 
-  @Inject
-  private DoubleEmaCrossoverStrategyFactory factory;
+  @Inject private DoubleEmaCrossoverStrategyFactory factory;
 
   @Before
   public void setUp() {
@@ -49,10 +49,8 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
   public void createStrategy_entryRule_isCrossedUpIndicatorRule()
       throws InvalidProtocolBufferException {
     // Arrange
-    DoubleEmaCrossoverParameters params = DoubleEmaCrossoverParameters.newBuilder()
-        .setShortEmaPeriod(5)
-        .setLongEmaPeriod(20)
-        .build();
+    DoubleEmaCrossoverParameters params =
+        DoubleEmaCrossoverParameters.newBuilder().setShortEmaPeriod(5).setLongEmaPeriod(20).build();
     BarSeries series = createTestBarSeries();
 
     // Act
@@ -67,10 +65,8 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
   public void createStrategy_exitRule_isCrossedDownIndicatorRule()
       throws InvalidProtocolBufferException {
     // Arrange
-    DoubleEmaCrossoverParameters params = DoubleEmaCrossoverParameters.newBuilder()
-        .setShortEmaPeriod(5)
-        .setLongEmaPeriod(20)
-        .build();
+    DoubleEmaCrossoverParameters params =
+        DoubleEmaCrossoverParameters.newBuilder().setShortEmaPeriod(5).setLongEmaPeriod(20).build();
     BarSeries series = createTestBarSeries();
 
     // Act
@@ -84,22 +80,23 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
    * A more functional test verifying that the entry rule is satisfied at the correct index after
    * short EMA crosses above long EMA.
    *
-   * Note: This requires creating a BarSeries that actually triggers a cross-up if shortEmaPeriod <
+   * <p>Note: This requires creating a BarSeries that actually triggers a cross-up if shortEmaPeriod <
    * longEmaPeriod.
    */
   @Test
   public void createStrategy_entryRule_triggersOnShortEmaCrossUp()
       throws InvalidProtocolBufferException {
     // Arrange
-     DoubleEmaCrossoverParameters params = DoubleEmaCrossoverParameters.newBuilder()
-         // Use smaller periods so the crossover can happen quickly
-         .setShortEmaPeriod(2)
-         .setLongEmaPeriod(3)
-         .build();
+    DoubleEmaCrossoverParameters params =
+        DoubleEmaCrossoverParameters.newBuilder()
+            // Use smaller periods so the crossover can happen quickly
+            .setShortEmaPeriod(2)
+            .setLongEmaPeriod(3)
+            .build();
 
-     // This series (below) is engineered so that around the last bar,
-     // the short EMA (2) crosses above the long EMA (3) at index 3.
-     BarSeries series = createCrossUpSeries();
+    // This series (below) is engineered so that around the last bar,
+    // the short EMA (2) crosses above the long EMA (3) at index 3.
+    BarSeries series = createCrossUpSeries();
     Strategy strategy = factory.createStrategy(series, params);
 
     // Act & Assert
@@ -120,25 +117,24 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
    * EMA crosses below long EMA.
    */
   @Test
-  public void createStrategy_exitRule_triggersOnShortEmaCrossDown() throws InvalidProtocolBufferException {
-      // Arrange
-      DoubleEmaCrossoverParameters params = DoubleEmaCrossoverParameters.newBuilder()
-          .setShortEmaPeriod(2)
-          .setLongEmaPeriod(3)
-          .build();
-      BarSeries series = createCrossDownSeries();
+  public void createStrategy_exitRule_triggersOnShortEmaCrossDown()
+      throws InvalidProtocolBufferException {
+    // Arrange
+    DoubleEmaCrossoverParameters params =
+        DoubleEmaCrossoverParameters.newBuilder().setShortEmaPeriod(2).setLongEmaPeriod(3).build();
+    BarSeries series = createCrossDownSeries();
 
-      // Act
-      Strategy strategy = factory.createStrategy(series, params);
-      BarSeriesManager manager = new BarSeriesManager(series);
-      TradingRecord tradingRecord = manager.run(strategy);
+    // Act
+    Strategy strategy = factory.createStrategy(series, params);
+    BarSeriesManager manager = new BarSeriesManager(series);
+    TradingRecord tradingRecord = manager.run(strategy);
 
-      // Assert
-      // Should enter position when short EMA crosses above long EMA
-      // and exit when it crosses below
-      assertThat(tradingRecord.getPositionCount()).isEqualTo(1);
-      Position position = tradingRecord.getPositions().get(0);
-      assertThat(position.getEntry().getIndex()).isLessThan(position.getExit().getIndex());
+    // Assert
+    // Should enter position when short EMA crosses above long EMA
+    // and exit when it crosses below
+    assertThat(tradingRecord.getPositionCount()).isEqualTo(1);
+    Position position = tradingRecord.getPositions().get(0);
+    assertThat(position.getEntry().getIndex()).isLessThan(position.getExit().getIndex());
   }
 
   private BarSeries createTestBarSeries() {
@@ -147,10 +143,10 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
 
     // With newer TA4j, we must supply (Duration, endTime, open, high, low, close, volume)
     // Below is just an example with arbitrary values
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(1),
-        10.0, 12.0, 8.0, 11.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(2),
-        11.0, 13.0, 9.0, 12.0, 120.0));
+    series.addBar(
+        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(1), 10.0, 12.0, 8.0, 11.0, 100.0));
+    series.addBar(
+        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(2), 11.0, 13.0, 9.0, 12.0, 120.0));
 
     return series;
   }
@@ -159,7 +155,7 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
    * Series designed so that short EMA crosses up the long EMA. The short period is 2, and the long
    * is 3, so around the last bar the short EMA rises above the long.
    *
-   * Crossover is expected at index 3.
+   * <p>Crossover is expected at index 3.
    */
   private BarSeries createCrossUpSeries() {
     BarSeries series = new BaseBarSeries();
@@ -168,33 +164,38 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
 
     // For the first few bars, keep the close price steady or slightly decreasing
     // Then spike upward so that short EMA crosses above the long EMA
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(1),
-        10.0, 10.0, 10.0, 10.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(2),
-        10.0, 10.0, 10.0, 10.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(3),
-        9.5,  9.5,  9.0,  9.0,  100.0));
+    series.addBar(
+        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(1), 10.0, 10.0, 10.0, 10.0, 100.0));
+    series.addBar(
+        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(2), 10.0, 10.0, 10.0, 10.0, 100.0));
+    series.addBar(
+        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(3), 9.5, 9.5, 9.0, 9.0, 100.0));
     // Big jump
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(4),
-        10.0, 15.0, 10.0, 15.0, 100.0));
+    series.addBar(
+        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(4), 10.0, 15.0, 10.0, 15.0, 100.0));
 
     return series;
   }
 
   private BarSeries createCrossDownSeries() {
-      BarSeries series = new BaseBarSeries();
-      ZonedDateTime now = ZonedDateTime.now();
+    BarSeries series = new BaseBarSeries();
+    ZonedDateTime now = ZonedDateTime.now();
 
-      // Initial price movement to get short EMA above long EMA
-      series.addBar(new BaseBar(Duration.ofMinutes(1), now, 10.0, 10.0, 10.0, 10.0, 100.0));
-      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(1), 15.0, 15.0, 15.0, 15.0, 100.0));
-      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(2), 20.0, 20.0, 20.0, 20.0, 100.0));
+    // Initial price movement to get short EMA above long EMA
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now, 10.0, 10.0, 10.0, 10.0, 100.0));
+    series.addBar(
+        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(1), 15.0, 15.0, 15.0, 15.0, 100.0));
+    series.addBar(
+        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(2), 20.0, 20.0, 20.0, 20.0, 100.0));
 
-      // Price decline to trigger short EMA crossing below long EMA
-      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(3), 15.0, 15.0, 15.0, 15.0, 100.0));
-      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(4), 10.0, 10.0, 10.0, 10.0, 100.0));
-      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(5), 5.0, 5.0, 5.0, 5.0, 100.0));
+    // Price decline to trigger short EMA crossing below long EMA
+    series.addBar(
+        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(3), 15.0, 15.0, 15.0, 15.0, 100.0));
+    series.addBar(
+        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(4), 10.0, 10.0, 10.0, 10.0, 100.0));
+    series.addBar(
+        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(5), 5.0, 5.0, 5.0, 5.0, 100.0));
 
-      return series;
+    return series;
   }
 }

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -119,44 +119,36 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
    */
   @Test
   public void createStrategy_exitRule_triggersOnShortEmaCrossDown()
-          throws InvalidProtocolBufferException {
-      // Arrange
-      DoubleEmaCrossoverParameters params = DoubleEmaCrossoverParameters.newBuilder()
-              .setShortEmaPeriod(2)
-              .setLongEmaPeriod(3)
-              .build();
-  
-      BarSeries series = createCrossDownSeries();
-      Strategy strategy = factory.createStrategy(series, params);
-  
-      // Debugging Output:
-      ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
-      EMAIndicator shortEma = new EMAIndicator(closePrice, params.getShortEmaPeriod());
-      EMAIndicator longEma = new EMAIndicator(closePrice, params.getLongEmaPeriod());
-  
-      int lastBarIndex = series.getEndIndex();
-  
-      System.out.println("----- DEBUG INFO -----");
-      System.out.println("Last Bar Index: " + lastBarIndex);
-      for (int i = 0; i <= lastBarIndex; i++) {
-          System.out.println("Index: " + i +
-                ", Short EMA: " + shortEma.getValue(i) +
-                ", Long EMA: " + longEma.getValue(i) +
-                ", Close Price: " + series.getBar(i).getClosePrice());
-      }
-  
-  
-      // Act & Assert
-      // We'll test that the exit rule becomes true at some bar
-      boolean anyExitSatisfied = false;
-      for (int i = series.getBeginIndex(); i <= series.getEndIndex(); i++) {
-        if (strategy.getExitRule().isSatisfied(i)) {
-          anyExitSatisfied = true;
-          break;
-        }
-      }
+      throws InvalidProtocolBufferException {
+    // Arrange
+    DoubleEmaCrossoverParameters params = DoubleEmaCrossoverParameters.newBuilder()
+        .setShortEmaPeriod(2)
+        .setLongEmaPeriod(3)
+        .build();
 
-      assertThat(anyExitSatisfied).isTrue();
+    BarSeries series = createCrossDownSeries();
+    Strategy strategy = factory.createStrategy(series, params);
+
+    // Act & Assert
+    // We'll test that the exit rule becomes true at some bar
+    boolean anyExitSatisfied = false;
+    for (int i = series.getBeginIndex(); i <= series.getEndIndex(); i++) {
+      if (strategy.getExitRule().isSatisfied(i)) {
+        anyExitSatisfied = true;
+        break;
+      }
+    }
+
+    // Debugging Output:
+    ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
+    EMAIndicator shortEma = new EMAIndicator(closePrice, params.getShortEmaPeriod());
+    EMAIndicator longEma = new EMAIndicator(closePrice, params.getLongEmaPeriod());
+    for (int i = 0; i <= series.getEndIndex(); i++) {
+      System.out.println(
+          "Index: " + i + ", Short EMA: " + shortEma.getValue(i) + ", Long EMA: " + longEma.getValue(i));
+    }
+
+    assertThat(anyExitSatisfied).isTrue();
   }
 
   private BarSeries createTestBarSeries() {
@@ -199,18 +191,18 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
   private BarSeries createCrossDownSeries() {
     BarSeries series = new BaseBarSeries();
     ZonedDateTime now = ZonedDateTime.now();
-  
+
     // 1) Start with some higher values to ensure short EMA > long EMA initially.
     series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(1), 18.0, 18.0, 18.0, 18.0, 100.0));
     series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(2), 17.0, 17.0, 17.0, 17.0, 100.0));
-  
+
     // 2) Gradually decrease further, so short EMA crosses below.
     series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(3), 16.0, 16.0, 16.0, 16.0, 100.0));
     series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(4), 14.0, 14.0, 14.0, 14.0, 100.0));
     series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(5), 12.0, 12.0, 12.0, 12.0, 100.0));
     series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(6), 10.0, 10.0, 10.0, 10.0, 100.0));
     series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(7), 8.0, 8.0, 8.0, 8.0, 100.0));
-  
+
     return series;
   }
 }

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -81,7 +81,6 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
       throws InvalidProtocolBufferException {
     logger.info("Executing createStrategy_exitRule_triggersOnShortEmaCrossDown test...");
     DoubleEmaCrossoverParameters params =
-    DoubleEmaCrossoverParameters params =
         DoubleEmaCrossoverParameters
           .newBuilder()
           .setShortEmaPeriod(SHORT_EMA)

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -182,23 +182,17 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
   private BarSeries createCrossDownSeries() {
       BarSeries series = new BaseBarSeries();
       ZonedDateTime now = ZonedDateTime.now();
-  
-      // Start with very high values to ensure short EMA starts above long EMA
-      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(1), 
-          25.0, 25.0, 25.0, 25.0, 100.0));
-      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(2), 
-          24.0, 24.0, 24.0, 24.0, 100.0));
-          
-      // Then sharp decline to force crossover
-      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(3), 
-          15.0, 15.0, 15.0, 15.0, 100.0));
-      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(4), 
-          10.0, 10.0, 10.0, 10.0, 100.0));
-      
-      // Continue lower to maintain short EMA below long EMA
-      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(5), 
-          8.0, 8.0, 8.0, 8.0, 100.0));
-  
+
+      // Initial price movement to get short EMA above long EMA
+      series.addBar(new BaseBar(Duration.ofMinutes(1), now, 10.0, 10.0, 10.0, 10.0, 100.0));
+      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(1), 15.0, 15.0, 15.0, 15.0, 100.0));
+      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(2), 20.0, 20.0, 20.0, 20.0, 100.0));
+
+      // Price decline to trigger short EMA crossing below long EMA
+      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(3), 15.0, 15.0, 15.0, 15.0, 100.0));
+      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(4), 10.0, 10.0, 10.0, 10.0, 100.0));
+      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(5), 5.0, 5.0, 5.0, 5.0, 100.0));
+
       return series;
   }
 }

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -178,24 +178,25 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
   }
 
   private BarSeries createCrossDownSeries() {
-    BarSeries series = new BaseBarSeries();
-    ZonedDateTime now = ZonedDateTime.now();
+      BarSeries series = new BaseBarSeries();
+      ZonedDateTime now = ZonedDateTime.now();
 
-    // Initial price movement to get short EMA above long EMA
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now, 10.0, 10.0, 10.0, 10.0, 100.0));
-    series.addBar(
-        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(1), 15.0, 15.0, 15.0, 15.0, 100.0));
-    series.addBar(
-        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(2), 20.0, 20.0, 20.0, 20.0, 100.0));
+      // Initial steady price to establish baseline EMAs (3+ bars for stability)
+      series.addBar(new BaseBar(Duration.ofMinutes(1), now, 10.0, 10.0, 10.0, 10.0, 100.0));
+      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(1), 10.0, 10.0, 10.0, 10.0, 100.0));
+      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(2), 10.0, 10.0, 10.0, 10.0, 100.0));
+      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(3), 10.0, 10.0, 10.0, 10.0, 100.0));
 
-    // Price decline to trigger short EMA crossing below long EMA
-    series.addBar(
-        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(3), 15.0, 15.0, 15.0, 15.0, 100.0));
-    series.addBar(
-        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(4), 10.0, 10.0, 10.0, 10.0, 100.0));
-    series.addBar(
-        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(5), 5.0, 5.0, 5.0, 5.0, 100.0));
+      // Strong upward movement to get short EMA above long EMA
+      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(4), 20.0, 20.0, 20.0, 20.0, 100.0));
+      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(5), 25.0, 25.0, 25.0, 25.0, 100.0));
+      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(6), 30.0, 30.0, 30.0, 30.0, 100.0));
 
-    return series;
+      // Sharp decline to trigger short EMA crossing below long EMA
+      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(7), 15.0, 15.0, 15.0, 15.0, 100.0));
+      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(8), 10.0, 10.0, 10.0, 10.0, 100.0));
+      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(9), 5.0, 5.0, 5.0, 5.0, 100.0));
+
+      return series;
   }
 }

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -42,7 +42,8 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
   }
 
   @Test
-  public void createStrategy_entryRule_isCrossedUpIndicatorRule() throws InvalidProtocolBufferException {
+  public void createStrategy_entryRule_isCrossedUpIndicatorRule()
+      throws InvalidProtocolBufferException {
     // Arrange
     DoubleEmaCrossoverParameters params = DoubleEmaCrossoverParameters.newBuilder()
         .setShortEmaPeriod(5)
@@ -59,7 +60,8 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
   }
 
   @Test
-  public void createStrategy_exitRule_isCrossedDownIndicatorRule() throws InvalidProtocolBufferException {
+  public void createStrategy_exitRule_isCrossedDownIndicatorRule()
+      throws InvalidProtocolBufferException {
     // Arrange
     DoubleEmaCrossoverParameters params = DoubleEmaCrossoverParameters.newBuilder()
         .setShortEmaPeriod(5)
@@ -75,14 +77,15 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
   }
 
   /**
-   * A more functional test verifying that the entry rule is satisfied
-   * at the correct index after short EMA crosses above long EMA.
+   * A more functional test verifying that the entry rule is satisfied at the correct index after
+   * short EMA crosses above long EMA.
    *
-   * Note: This requires creating a BarSeries that actually triggers
-   * a cross-up if shortEmaPeriod < longEmaPeriod.
+   * Note: This requires creating a BarSeries that actually triggers a cross-up if shortEmaPeriod <
+   * longEmaPeriod.
    */
   @Test
-  public void createStrategy_entryRule_triggersOnShortEmaCrossUp() throws InvalidProtocolBufferException {
+  public void createStrategy_entryRule_triggersOnShortEmaCrossUp()
+      throws InvalidProtocolBufferException {
     // Arrange
     DoubleEmaCrossoverParameters params = DoubleEmaCrossoverParameters.newBuilder()
         // Use smaller periods so the crossover can happen quickly
@@ -109,11 +112,12 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
   }
 
   /**
-   * A more functional test verifying that the exit rule is satisfied
-   * at the correct index after short EMA crosses below long EMA.
+   * A more functional test verifying that the exit rule is satisfied at the correct index after short
+   * EMA crosses below long EMA.
    */
   @Test
-  public void createStrategy_exitRule_triggersOnShortEmaCrossDown() throws InvalidProtocolBufferException {
+  public void createStrategy_exitRule_triggersOnShortEmaCrossDown()
+      throws InvalidProtocolBufferException {
     // Arrange
     DoubleEmaCrossoverParameters params = DoubleEmaCrossoverParameters.newBuilder()
         .setShortEmaPeriod(2)
@@ -126,14 +130,10 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
     Strategy strategy = factory.createStrategy(series, params);
 
     // Act & Assert
-    boolean anyExitSatisfied = false;
-    for (int i = series.getBeginIndex(); i <= series.getEndIndex(); i++) {
-      if (strategy.getExitRule().isSatisfied(i)) {
-        anyExitSatisfied = true;
-        break;
-      }
-    }
-    assertThat(anyExitSatisfied).isTrue();
+    // We'll test that the exit rule becomes true at the last bar
+    int lastBarIndex = series.getEndIndex();
+    boolean lastBarExitSatisfied = strategy.getExitRule().isSatisfied(lastBarIndex);
+    assertThat(lastBarExitSatisfied).isTrue();
   }
 
   private BarSeries createTestBarSeries() {
@@ -151,9 +151,8 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
   }
 
   /**
-   * Series designed so that short EMA crosses up the long EMA.
-   * The short period is 2, and the long is 3, so around the last bar
-   * the short EMA rises above the long.
+   * Series designed so that short EMA crosses up the long EMA. The short period is 2, and the long
+   * is 3, so around the last bar the short EMA rises above the long.
    */
   private BarSeries createCrossUpSeries() {
     BarSeries series = new BaseBarSeries();
@@ -175,9 +174,8 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
   }
 
   /**
-   * Series designed so that short EMA starts above the long EMA
-   * and then crosses down. The last bar is a big drop in price
-   * forcing short EMA < long EMA.
+   * Series designed so that short EMA starts above the long EMA and then crosses down. The last bar
+   * is a big drop in price forcing short EMA < long EMA.
    */
     private BarSeries createCrossDownSeries() {
         BarSeries series = new BaseBarSeries();

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -173,23 +173,24 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
     return series;
   }
 
-  /**
-   * Series designed so that short EMA starts above the long EMA and then crosses down. The last bar
-   * is a big drop in price forcing short EMA < long EMA.
-   */
-    private BarSeries createCrossDownSeries() {
-        BarSeries series = new BaseBarSeries();
-        ZonedDateTime now = ZonedDateTime.now();
-
-        // Start high and keep falling
-        series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(1),
-            15.0, 15.0, 14.0, 14.0, 100.0));
-         series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(2),
-            14.0, 14.0, 13.0, 13.0, 100.0));
-        // Now plunge
-        series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(3),
-            10.0, 10.0,  9.0,  9.0, 100.0));
-
-        return series;
-    }
+  private BarSeries createCrossDownSeries() {
+    BarSeries series = new BaseBarSeries();
+    ZonedDateTime now = ZonedDateTime.now();
+  
+    // First two bars at 16 to keep short EMA above the long EMA.
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(1),
+        16.0, 16.0, 16.0, 16.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(2),
+        16.0, 16.0, 16.0, 16.0, 100.0));
+  
+    // One bar slightly lower, but short EMA should still be above the long EMA here.
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(3),
+        15.0, 15.0, 15.0, 15.0, 100.0));
+  
+    // Now a big drop to force short EMA < long EMA.
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(4),
+        9.0,  9.0,  9.0,  9.0, 100.0));
+  
+    return series;
+  }
 }

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -177,18 +177,12 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
     BarSeries series = new BaseBarSeries();
     ZonedDateTime now = ZonedDateTime.now();
   
-    // Keep price high for the first few bars so short EMA stays above the long EMA.
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(1),
-        16.0, 16.0, 16.0, 16.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(2),
-        16.0, 16.0, 16.0, 16.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(3),
-        15.0, 15.0, 15.0, 15.0, 100.0));
-  
-    // Final bar: a big drop that forces short EMA below the long EMA.
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(4),
-        9.0, 9.0, 9.0, 9.0, 100.0));
-  
+    // Gradually decrease the price over several bars
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(4), 14.0, 14.0, 14.0, 14.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(5), 12.0, 12.0, 12.0, 12.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(6), 10.0, 10.0, 10.0, 10.0, 100.0)); // Still above
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(7), 8.0, 8.0, 8.0, 8.0, 100.0)); // Now likely below
+
     return series;
   }
 }

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -188,21 +188,21 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
     return series;
   }
 
-private BarSeries createCrossDownSeries() {
-  BarSeries series = new BaseBarSeries();
-  ZonedDateTime now = ZonedDateTime.now();
-
-  // Keep price high for the first few bars so short EMA stays above the long EMA.
-  series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(1), 16.0, 16.0, 16.0, 16.0, 100.0));
-  series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(2), 16.0, 16.0, 16.0, 16.0, 100.0));
-  series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(3), 15.0, 15.0, 15.0, 15.0, 100.0));
-
-  // Gradually decrease the price over several bars to ensure the short EMA crosses down.
-  series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(4), 14.0, 14.0, 14.0, 14.0, 100.0));
-  series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(5), 12.0, 12.0, 12.0, 12.0, 100.0));
-  series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(6), 10.0, 10.0, 10.0, 10.0, 100.0));
-  series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(7), 8.0, 8.0, 8.0, 8.0, 100.0));
-
-  return series;
-}
+  private BarSeries createCrossDownSeries() {
+    BarSeries series = new BaseBarSeries();
+    ZonedDateTime now = ZonedDateTime.now();
+  
+    // 1) Start with some higher values to ensure short EMA > long EMA initially.
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(1), 18.0, 18.0, 18.0, 18.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(2), 17.0, 17.0, 17.0, 17.0, 100.0));
+  
+    // 2) Gradually decrease further, so short EMA crosses below.
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(3), 16.0, 16.0, 16.0, 16.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(4), 14.0, 14.0, 14.0, 14.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(5), 12.0, 12.0, 12.0, 12.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(6), 10.0, 10.0, 10.0, 10.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(7), 8.0, 8.0, 8.0, 8.0, 100.0));
+  
+    return series;
+  }
 }

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -22,6 +22,8 @@ import org.ta4j.core.indicators.EMAIndicator;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.rules.CrossedDownIndicatorRule;
 import org.ta4j.core.rules.CrossedUpIndicatorRule;
+import org.ta4j.core.BarSeriesManager;
+import org.ta4j.core.TradingRecord;
 
 @RunWith(JUnit4.class)
 public class DoubleEmaCrossoverStrategyFactoryTest {

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -67,49 +67,45 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
     assertThat(position.getEntry().getIndex()).isLessThan(position.getExit().getIndex());
   }
 
-private BarSeries createCrossDownSeries() {
-      BarSeries series = new BaseBarSeries();
-      ZonedDateTime now = ZonedDateTime.now();
+  private BarSeries createCrossDownSeries() {
+    BarSeries series = new BaseBarSeries();
+    ZonedDateTime now = ZonedDateTime.now();
 
-      // Start with low baseline to establish EMAs
-      for (int i = 0; i < 10; i++) {
-          series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(i), 10.0, 10.0, 10.0, 10.0, 100.0));
-      }
+    // Establish a baseline with steady low price
+    for (int i = 0; i < 5; i++) {
+      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(i), 10.0, 10.0, 10.0, 10.0, 100.0));
+    }
 
-      // Gradual rise to create upward trend and EMA cross
-      for (int i = 10; i < 15; i++) {
-          double price = 10.0 + (i - 10) * 5.0;
-          series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(i), price, price, price, price, 100.0));
-      }
-      
-      // Maintain high level briefly
-      for (int i = 15; i < 20; i++) {
-          series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(i), 30.0, 30.0, 30.0, 30.0, 100.0));
-      }
+    // Sharp upward movement to trigger short EMA crossing above long EMA
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(5), 20.0, 20.0, 20.0, 20.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(6), 25.0, 25.0, 25.0, 25.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(7), 30.0, 30.0, 30.0, 30.0, 100.0));
 
-      // Gradual decline to trigger crossover down
-      for (int i = 20; i < 25; i++) {
-          double price = 30.0 - (i - 20) * 5.0;
-          series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(i), price, price, price, price, 100.0));
-      }
+    // Hold at higher level briefly
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(8), 30.0, 30.0, 30.0, 30.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(9), 30.0, 30.0, 30.0, 30.0, 100.0));
 
-      return series;
+    // Sharp decline to trigger short EMA crossing below long EMA
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(10), 15.0, 15.0, 15.0, 15.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(11), 10.0, 10.0, 10.0, 10.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(12), 5.0, 5.0, 5.0, 5.0, 100.0));
+
+    return series;
   }
 
   private BarSeries createCrossUpSeries() {
     BarSeries series = new BaseBarSeries();
     ZonedDateTime now = ZonedDateTime.now();
 
-    // Start with steady low prices to establish baseline EMAs
-    for (int i = 0; i < 10; i++) {
+    // Start with steady prices to establish baseline EMAs
+    for (int i = 0; i < 5; i++) {
         series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(i), 10.0, 10.0, 10.0, 10.0, 100.0));
     }
 
-    // Gradual upward movement to ensure clear EMA crossover
-    for (int i = 10; i < 20; i++) {
-        double price = 10.0 + (i - 10) * 2.0;
-        series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(i), price, price, price, price, 100.0));
-    }
+    // Sharp upward movement to trigger cross up
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(5), 15.0, 15.0, 15.0, 15.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(6), 20.0, 20.0, 20.0, 20.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(7), 25.0, 25.0, 25.0, 25.0, 100.0));
 
     return series;
   }

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -177,19 +177,17 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
     BarSeries series = new BaseBarSeries();
     ZonedDateTime now = ZonedDateTime.now();
   
-    // First two bars at 16 to keep short EMA above the long EMA.
+    // Keep price high for the first few bars so short EMA stays above the long EMA.
     series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(1),
         16.0, 16.0, 16.0, 16.0, 100.0));
     series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(2),
         16.0, 16.0, 16.0, 16.0, 100.0));
-  
-    // One bar slightly lower, but short EMA should still be above the long EMA here.
     series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(3),
         15.0, 15.0, 15.0, 15.0, 100.0));
   
-    // Now a big drop to force short EMA < long EMA.
+    // Final bar: a big drop that forces short EMA below the long EMA.
     series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(4),
-        9.0,  9.0,  9.0,  9.0, 100.0));
+        9.0, 9.0, 9.0, 9.0, 100.0));
   
     return series;
   }

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -37,7 +37,7 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
 
     @Before
     public void setUp() throws InvalidProtocolBufferException {
-        // If you do NOT have a Guice module, just instantiate the factory directly:
+        // Instantiate factory directly (unless you have a Guice Module)
         factory = new DoubleEmaCrossoverStrategyFactory();
 
         // Create standard parameters
@@ -83,7 +83,7 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
 
     @Test
     public void entryRule_shouldTrigger_whenShortEmaCrossesAboveLongEma() {
-        // Log EMA values around expected crossover point
+        // Log EMA values around the expected crossover
         for (int i = 6; i <= 9; i++) {
             System.out.printf("Bar %d - Price: %.2f, Short EMA: %.2f, Long EMA: %.2f%n",
                 i,
@@ -98,16 +98,16 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
             strategy.getEntryRule().isSatisfied(6)
         );
 
-        // Should detect entry when short EMA crosses above long EMA
+        // CrossUp occurs between bar 6 and bar 7, so the rule triggers at bar 7
         assertTrue(
             "Entry rule should trigger when short EMA crosses above long EMA",
-            strategy.getEntryRule().isSatisfied(8)
+            strategy.getEntryRule().isSatisfied(7)
         );
     }
 
     @Test
     public void exitRule_shouldTrigger_whenShortEmaCrossesBelowLongEma() {
-        // Log EMA values around expected crossover point
+        // Log EMA values around the expected crossover
         for (int i = 10; i <= 13; i++) {
             System.out.printf("Bar %d - Price: %.2f, Short EMA: %.2f, Long EMA: %.2f%n",
                 i,
@@ -122,10 +122,10 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
             strategy.getExitRule().isSatisfied(10)
         );
 
-        // Should detect exit when short EMA crosses below long EMA
+        // CrossDown occurs between bar 10 and bar 11, so the rule triggers at bar 11
         assertTrue(
             "Exit rule should trigger when short EMA crosses below long EMA",
-            strategy.getExitRule().isSatisfied(12)
+            strategy.getExitRule().isSatisfied(11)
         );
     }
 

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -90,7 +90,7 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
         .setLongEmaPeriod(3)
         .build();
 
-    // This series (below) is engineered so that around the last bar, 
+    // This series (below) is engineered so that around the last bar,
     // short EMA (2) crosses above long EMA (3)
     BarSeries series = createCrossUpSeries();
     Strategy strategy = factory.createStrategy(series, params);
@@ -179,19 +179,19 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
    * and then crosses down. The last bar is a big drop in price
    * forcing short EMA < long EMA.
    */
-  private BarSeries createCrossDownSeries() {
-    BarSeries series = new BaseBarSeries();
-    ZonedDateTime now = ZonedDateTime.now();
+    private BarSeries createCrossDownSeries() {
+        BarSeries series = new BaseBarSeries();
+        ZonedDateTime now = ZonedDateTime.now();
 
-    // Start high, so short EMA is quickly above
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(1),
-        15.0, 15.0, 15.0, 15.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(2),
-        15.0, 15.0, 15.0, 15.0, 100.0));
-    // Now plunge
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(3),
-        10.0, 10.0,  9.0,  9.0, 100.0));
+        // Start high and keep falling
+        series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(1),
+            15.0, 15.0, 14.0, 14.0, 100.0));
+         series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(2),
+            14.0, 14.0, 13.0, 13.0, 100.0));
+        // Now plunge
+        series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(3),
+            10.0, 10.0,  9.0,  9.0, 100.0));
 
-    return series;
-  }
+        return series;
+    }
 }

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -4,8 +4,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import com.google.inject.Guice;
-import com.google.inject.Inject;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.verlumen.tradestream.strategies.DoubleEmaCrossoverParameters;
 import com.verlumen.tradestream.strategies.StrategyType;
@@ -25,23 +23,23 @@ import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 public class DoubleEmaCrossoverStrategyFactoryTest {
     private static final int SHORT_EMA = 3;
     private static final int LONG_EMA = 7;
-    
-    // For debugging EMA calculations
-    private EMAIndicator shortEma;
-    private EMAIndicator longEma;
-    private ClosePriceIndicator closePrice;
 
-    @Inject 
     private DoubleEmaCrossoverStrategyFactory factory;
 
     private DoubleEmaCrossoverParameters params;
     private BaseBarSeries series;
     private Strategy strategy;
 
+    // For debugging EMA calculations
+    private EMAIndicator shortEma;
+    private EMAIndicator longEma;
+    private ClosePriceIndicator closePrice;
+
     @Before
     public void setUp() throws InvalidProtocolBufferException {
-        Guice.createInjector().injectMembers(this);
-        
+        // If you do NOT have a Guice module, just instantiate the factory directly:
+        factory = new DoubleEmaCrossoverStrategyFactory();
+
         // Create standard parameters
         params = DoubleEmaCrossoverParameters.newBuilder()
             .setShortEmaPeriod(SHORT_EMA)
@@ -57,13 +55,13 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
         for (int i = 0; i < 7; i++) {
             series.addBar(createBar(now.plusMinutes(i), 50.0));
         }
-        
+
         // Create stronger upward movement to force crossover
         series.addBar(createBar(now.plusMinutes(7), 65.0));   // Sharper rise
         series.addBar(createBar(now.plusMinutes(8), 80.0));   // Continues up strongly
         series.addBar(createBar(now.plusMinutes(9), 85.0));   // Maintains high level
         series.addBar(createBar(now.plusMinutes(10), 90.0));  // Still high
-        
+
         // Create stronger downward movement
         series.addBar(createBar(now.plusMinutes(11), 40.0));  // Sharp drop
         series.addBar(createBar(now.plusMinutes(12), 30.0));  // Continues down strongly
@@ -74,6 +72,7 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
         shortEma = new EMAIndicator(closePrice, SHORT_EMA);
         longEma = new EMAIndicator(closePrice, LONG_EMA);
 
+        // Create strategy
         strategy = factory.createStrategy(series, params);
     }
 
@@ -94,12 +93,16 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
         }
 
         // No entry signal during baseline period
-        assertFalse("Should not trigger entry during baseline",
-            strategy.getEntryRule().isSatisfied(6));
-        
+        assertFalse(
+            "Should not trigger entry during baseline",
+            strategy.getEntryRule().isSatisfied(6)
+        );
+
         // Should detect entry when short EMA crosses above long EMA
-        assertTrue("Entry rule should trigger when short EMA crosses above long EMA",
-            strategy.getEntryRule().isSatisfied(8));
+        assertTrue(
+            "Entry rule should trigger when short EMA crosses above long EMA",
+            strategy.getEntryRule().isSatisfied(8)
+        );
     }
 
     @Test
@@ -114,12 +117,16 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
         }
 
         // No exit signal during uptrend
-        assertFalse("Should not trigger exit during uptrend",
-            strategy.getExitRule().isSatisfied(10));
-        
+        assertFalse(
+            "Should not trigger exit during uptrend",
+            strategy.getExitRule().isSatisfied(10)
+        );
+
         // Should detect exit when short EMA crosses below long EMA
-        assertTrue("Exit rule should trigger when short EMA crosses below long EMA",
-            strategy.getExitRule().isSatisfied(12));
+        assertTrue(
+            "Exit rule should trigger when short EMA crosses below long EMA",
+            strategy.getExitRule().isSatisfied(12)
+        );
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -30,8 +30,8 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
   // Use Flogger:
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
-  private static final int SHORT_EMA = 3;
-  private static final int LONG_EMA = 7;
+  private static final int SHORT_EMA = 2;
+  private static final int LONG_EMA = 5;
 
   @Inject private DoubleEmaCrossoverStrategyFactory factory;
 

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -148,7 +148,6 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
   
       // Act & Assert
       // We'll test that the exit rule becomes true at some bar
-      assertThat(lastBarExitSatisfied).isTrue();
       boolean anyExitSatisfied = false;
       for (int i = series.getBeginIndex(); i <= series.getEndIndex(); i++) {
         if (strategy.getExitRule().isSatisfied(i)) {

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -2,6 +2,7 @@ package com.verlumen.tradestream.strategies.movingaverages;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.common.flogger.FluentLogger;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -9,8 +10,6 @@ import com.verlumen.tradestream.strategies.DoubleEmaCrossoverParameters;
 import com.verlumen.tradestream.strategies.StrategyType;
 import java.time.Duration;
 import java.time.ZonedDateTime;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,11 +22,13 @@ import org.ta4j.core.Position;
 import org.ta4j.core.Strategy;
 import org.ta4j.core.TradingRecord;
 import org.ta4j.core.backtest.BarSeriesManager;
+import org.ta4j.core.indicators.EMAIndicator;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 
 @RunWith(JUnit4.class)
 public class DoubleEmaCrossoverStrategyFactoryTest {
-  private static final Logger logger =
-      Logger.getLogger(DoubleEmaCrossoverStrategyFactoryTest.class.getName());
+  // Use Flogger:
+  private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
   private static final int SHORT_EMA = 3;
   private static final int LONG_EMA = 7;
@@ -36,84 +37,103 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
 
   @Before
   public void setUp() {
-    logger.info("Setting up test dependencies via Guice injector...");
+    logger.atInfo().log("Setting up test dependencies via Guice injector...");
     Guice.createInjector().injectMembers(this);
   }
 
   @Test
   public void getStrategyType_returnsCorrectType() {
-    logger.info("Executing getStrategyType_returnsCorrectType test...");
+    logger.atInfo().log("Executing getStrategyType_returnsCorrectType test...");
     StrategyType strategyType = factory.getStrategyType();
-    logger.log(Level.FINE, "StrategyType obtained: {0}", strategyType);
+    logger.atInfo().log("StrategyType obtained: %s", strategyType);
 
     assertThat(strategyType).isEqualTo(StrategyType.DOUBLE_EMA_CROSSOVER);
-    logger.info("getStrategyType_returnsCorrectType test passed.");
+    logger.atInfo().log("getStrategyType_returnsCorrectType test passed.");
   }
 
   @Test
   public void createStrategy_entryRule_triggersOnShortEmaCrossUp()
       throws InvalidProtocolBufferException {
-    logger.info("Executing createStrategy_entryRule_triggersOnShortEmaCrossUp test...");
+    logger.atInfo().log("Executing createStrategy_entryRule_triggersOnShortEmaCrossUp test...");
     DoubleEmaCrossoverParameters params =
-        DoubleEmaCrossoverParameters
-          .newBuilder()
-          .setShortEmaPeriod(SHORT_EMA)
-          .setLongEmaPeriod(LONG_EMA)
-          .build();
-    logger.log(Level.FINE, "Parameters for short/long EMA: {0}", params);
+        DoubleEmaCrossoverParameters.newBuilder()
+            .setShortEmaPeriod(SHORT_EMA)
+            .setLongEmaPeriod(LONG_EMA)
+            .build();
+    logger.atInfo().log("Parameters for short/long EMA: %s", params);
 
     BarSeries series = createCrossUpSeries();
+
+    // We'll create an EMAIndicator in the test, just to log how the EMA values progress.
+    ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
+    EMAIndicator shortEmaInd = new EMAIndicator(closePrice, SHORT_EMA);
+    EMAIndicator longEmaInd = new EMAIndicator(closePrice, LONG_EMA);
+
+    // Log bars/EMA
+    logBarSeriesWithEma(series, shortEmaInd, longEmaInd);
+
     Strategy strategy = factory.createStrategy(series, params);
     BarSeriesManager manager = new BarSeriesManager(series);
     TradingRecord tradingRecord = manager.run(strategy);
 
-    logger.log(
-        Level.FINE,
-        "Finished running strategy. Position count: {0}",
+    // Log final trading record
+    logTradingRecord(tradingRecord, series);
+
+    logger.atInfo().log("Finished running strategy. Final position count: %d",
         tradingRecord.getPositionCount());
     assertThat(tradingRecord.getPositionCount()).isGreaterThan(0);
 
-    logger.info("createStrategy_entryRule_triggersOnShortEmaCrossUp test passed.");
+    logger.atInfo().log("createStrategy_entryRule_triggersOnShortEmaCrossUp test passed.");
   }
 
   @Test
   public void createStrategy_exitRule_triggersOnShortEmaCrossDown()
       throws InvalidProtocolBufferException {
-    logger.info("Executing createStrategy_exitRule_triggersOnShortEmaCrossDown test...");
+    logger.atInfo().log("Executing createStrategy_exitRule_triggersOnShortEmaCrossDown test...");
     DoubleEmaCrossoverParameters params =
-        DoubleEmaCrossoverParameters
-          .newBuilder()
-          .setShortEmaPeriod(SHORT_EMA)
-          .setLongEmaPeriod(LONG_EMA)
-          .build();
-    logger.log(Level.FINE, "Parameters for short/long EMA: {0}", params);
+        DoubleEmaCrossoverParameters.newBuilder()
+            .setShortEmaPeriod(SHORT_EMA)
+            .setLongEmaPeriod(LONG_EMA)
+            .build();
+    logger.atInfo().log("Parameters for short/long EMA: %s", params);
 
     BarSeries series = createCrossDownSeries();
+
+    // Again, create local EMA indicators to observe values per bar
+    ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
+    EMAIndicator shortEmaInd = new EMAIndicator(closePrice, SHORT_EMA);
+    EMAIndicator longEmaInd = new EMAIndicator(closePrice, LONG_EMA);
+
+    logBarSeriesWithEma(series, shortEmaInd, longEmaInd);
+
     Strategy strategy = factory.createStrategy(series, params);
     BarSeriesManager manager = new BarSeriesManager(series);
     TradingRecord tradingRecord = manager.run(strategy);
 
-    logger.log(
-        Level.FINE,
-        "Finished running strategy. Position count: {0}",
+    logTradingRecord(tradingRecord, series);
+
+    logger.atInfo().log("Finished running strategy. Final position count: %d",
         tradingRecord.getPositionCount());
     assertThat(tradingRecord.getPositionCount()).isEqualTo(1);
 
     Position position = tradingRecord.getPositions().get(0);
-    logger.log(
-        Level.FINE,
-        "Validating that entry index ({0}) < exit index ({1})",
-        new Object[] {position.getEntry().getIndex(), position.getExit().getIndex()});
+    logger.atInfo().log(
+        "Validating that entry index (%d) < exit index (%d)",
+        position.getEntry().getIndex(),
+        position.getExit().getIndex());
     assertThat(position.getEntry().getIndex()).isLessThan(position.getExit().getIndex());
 
-    logger.info("createStrategy_exitRule_triggersOnShortEmaCrossDown test passed.");
+    logger.atInfo().log("createStrategy_exitRule_triggersOnShortEmaCrossDown test passed.");
   }
 
+  /**
+   * Creates a bar series designed to produce a short-EMA cross UP over the long-EMA.
+   */
   private BarSeries createCrossUpSeries() {
-    logger.fine("Creating bar series to test short EMA crossing up...");
+    logger.atInfo().log("Creating bar series to test short EMA crossing up...");
     BarSeries series = new BaseBarSeries();
     ZonedDateTime now = ZonedDateTime.now();
-  
+
     // 1) Warm-up bars so the short (3) & long (7) EMAs are valid.
     //    10 bars at 10.0 to "prime" the EMAs.
     for (int i = 0; i < 10; i++) {
@@ -126,24 +146,34 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
     }
 
     // 2) Gradually increase price so shortEma eventually crosses above longEma.
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(10), 12.0, 12.0, 12.0, 12.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(11), 14.0, 14.0, 14.0, 14.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(12), 18.0, 18.0, 18.0, 18.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(13), 20.0, 20.0, 20.0, 20.0, 100.0));
+    series.addBar(
+        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(10), 12.0, 12.0, 12.0, 12.0, 100.0));
+    series.addBar(
+        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(11), 14.0, 14.0, 14.0, 14.0, 100.0));
+    series.addBar(
+        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(12), 18.0, 18.0, 18.0, 18.0, 100.0));
+    series.addBar(
+        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(13), 20.0, 20.0, 20.0, 20.0, 100.0));
 
-    // 3) Add 1–2 extra bars so TA4J can “finalize” the cross.
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(14), 20.0, 20.0, 20.0, 20.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(15), 20.0, 20.0, 20.0, 20.0, 100.0));
+    // 3) Add extra bars so TA4J can “finalize” the cross.
+    series.addBar(
+        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(14), 20.0, 20.0, 20.0, 20.0, 100.0));
+    series.addBar(
+        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(15), 20.0, 20.0, 20.0, 20.0, 100.0));
 
+    logger.atInfo().log("createCrossUpSeries - Completed building bar series for cross-up scenario.");
     return series;
   }
-  
+
+  /**
+   * Creates a bar series designed to produce a short-EMA cross DOWN below the long-EMA.
+   */
   private BarSeries createCrossDownSeries() {
-    logger.fine("Creating bar series to test short EMA crossing down...");
+    logger.atInfo().log("Creating bar series to test short EMA crossing down...");
     BarSeries series = new BaseBarSeries();
     ZonedDateTime now = ZonedDateTime.now();
 
-    // 1) Again, warm-up bars to let the longEma(7) & shortEma(3) initialize.
+    // 1) Warm-up bars
     for (int i = 0; i < 10; i++) {
       series.addBar(
           new BaseBar(
@@ -153,21 +183,79 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
               100.0));
     }
 
-    // 2) Move up first, ensuring shortEma > longEma
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(10), 15.0, 15.0, 15.0, 15.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(11), 20.0, 20.0, 20.0, 20.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(12), 25.0, 25.0, 25.0, 25.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(13), 25.0, 25.0, 25.0, 25.0, 100.0));
+    // 2) Move up first (shortEma > longEma)
+    series.addBar(
+        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(10), 15.0, 15.0, 15.0, 15.0, 100.0));
+    series.addBar(
+        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(11), 20.0, 20.0, 20.0, 20.0, 100.0));
+    series.addBar(
+        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(12), 25.0, 25.0, 25.0, 25.0, 100.0));
+    series.addBar(
+        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(13), 25.0, 25.0, 25.0, 25.0, 100.0));
 
-    // 3) Then a sharp drop to cross below
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(14), 15.0, 15.0, 15.0, 15.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(15), 10.0, 10.0, 10.0, 10.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(16), 5.0, 5.0, 5.0, 5.0, 100.0));
+    // 3) Then drop so shortEma < longEma
+    series.addBar(
+        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(14), 15.0, 15.0, 15.0, 15.0, 100.0));
+    series.addBar(
+        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(15), 10.0, 10.0, 10.0, 10.0, 100.0));
+    series.addBar(
+        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(16), 5.0, 5.0, 5.0, 5.0, 100.0));
 
-    // 4) Extra trailing bars to finalize the cross event
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(17), 5.0, 5.0, 5.0, 5.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(18), 5.0, 5.0, 5.0, 5.0, 100.0));
+    // 4) Extra trailing bars for final cross detection
+    series.addBar(
+        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(17), 5.0, 5.0, 5.0, 5.0, 100.0));
+    series.addBar(
+        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(18), 5.0, 5.0, 5.0, 5.0, 100.0));
 
+    logger.atInfo().log(
+        "createCrossDownSeries - Completed building bar series for cross-down scenario.");
     return series;
+  }
+
+  /**
+   * Logs each bar’s open/high/low/close plus short and long EMA values for debugging.
+   */
+  private void logBarSeriesWithEma(
+      BarSeries series, EMAIndicator shortEmaInd, EMAIndicator longEmaInd) {
+    logger.atInfo().log("Logging bar data + short/long EMA values for debugging:");
+    for (int i = 0; i < series.getBarCount(); i++) {
+      Bar bar = series.getBar(i);
+      double shortVal = shortEmaInd.getValue(i).doubleValue();
+      double longVal = longEmaInd.getValue(i).doubleValue();
+      logger.atInfo().log(
+          "Bar[%d] time=%s O=%.4f,H=%.4f,L=%.4f,C=%.4f shortEma=%.4f longEma=%.4f",
+          i,
+          bar.getEndTime(),
+          bar.getOpenPrice().doubleValue(),
+          bar.getHighPrice().doubleValue(),
+          bar.getLowPrice().doubleValue(),
+          bar.getClosePrice().doubleValue(),
+          shortVal,
+          longVal);
+    }
+  }
+
+  /**
+   * Logs the trading record: final position count, positions with entry/exit bar indexes.
+   */
+  private void logTradingRecord(TradingRecord tradingRecord, BarSeries series) {
+    int count = tradingRecord.getPositionCount();
+    logger.atInfo().log("Logging TradingRecord details... Position count=%d", count);
+
+    if (count == 0) {
+      logger.atInfo().log("-- No positions in this trading record. Possibly no crosses detected. --");
+      return;
+    }
+
+    for (int p = 0; p < count; p++) {
+      Position pos = tradingRecord.getPositions().get(p);
+      logger.atInfo().log("Position #%d: entry=%s exit=%s", p, pos.getEntry(), pos.getExit());
+      logger.atInfo().log(
+          "Entry bar idx=%d closePrice=%.4f; Exit bar idx=%d closePrice=%.4f",
+          pos.getEntry().getIndex(),
+          series.getBar(pos.getEntry().getIndex()).getClosePrice().doubleValue(),
+          pos.getExit().getIndex(),
+          series.getBar(pos.getExit().getIndex()).getClosePrice().doubleValue());
+    }
   }
 }

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -15,12 +15,12 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
-import org.ta4j.core.BarSeriesManager;
 import org.ta4j.core.BaseBar;
 import org.ta4j.core.BaseBarSeries;
 import org.ta4j.core.Position;
 import org.ta4j.core.Strategy;
 import org.ta4j.core.TradingRecord;
+import org.ta4j.core.backtest.BarSeriesManager
 import org.ta4j.core.indicators.EMAIndicator;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.rules.CrossedDownIndicatorRule;

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -165,11 +165,12 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
    */
   private BarSeries createCrossDownSeries() {
     logger.atInfo().log("Creating bar series to test short EMA crossing down...");
+
     BarSeries series = new BaseBarSeries();
     ZonedDateTime now = ZonedDateTime.now();
 
-    // 1) Warm-up bars
-    for (int i = 0; i < 10; i++) {
+    // Warm-up: 7 bars at 10.0
+    for (int i = 0; i < 7; i++) {
       series.addBar(
           new BaseBar(
               Duration.ofMinutes(1),
@@ -178,32 +179,19 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
               100.0));
     }
 
-    // 2) Move up first (shortEma > longEma)
-    series.addBar(
-        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(10), 15.0, 15.0, 15.0, 15.0, 100.0));
-    series.addBar(
-        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(11), 20.0, 20.0, 20.0, 20.0, 100.0));
-    series.addBar(
-        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(12), 25.0, 25.0, 25.0, 25.0, 100.0));
-    series.addBar(
-        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(13), 25.0, 25.0, 25.0, 25.0, 100.0));
+    // First push short Ema above long Ema
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(7), 20.0, 20.0, 20.0, 20.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(8), 25.0, 25.0, 25.0, 25.0, 100.0));
 
-    // 3) Then drop so shortEma < longEma
-    series.addBar(
-        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(14), 15.0, 15.0, 15.0, 15.0, 100.0));
-    series.addBar(
-        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(15), 10.0, 10.0, 10.0, 10.0, 100.0));
-    series.addBar(
-        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(16), 5.0, 5.0, 5.0, 5.0, 100.0));
+    // Then drop so short < long
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(9), 10.0, 10.0, 10.0, 10.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(10), 5.0, 5.0, 5.0, 5.0, 100.0));
 
-    // 4) Extra trailing bars for final cross detection
-    series.addBar(
-        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(17), 5.0, 5.0, 5.0, 5.0, 100.0));
-    series.addBar(
-        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(18), 5.0, 5.0, 5.0, 5.0, 100.0));
+    // Trailing bars so TA4J sees the cross
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(11), 5.0, 5.0, 5.0, 5.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(12), 5.0, 5.0, 5.0, 5.0, 100.0));
 
-    logger.atInfo().log(
-        "createCrossDownSeries - Completed building bar series for cross-down scenario.");
+    logger.atInfo().log("createCrossDownSeries - Done with smaller EMAs + more trailing bars.");
     return series;
   }
 

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -173,16 +173,21 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
     return series;
   }
 
-  private BarSeries createCrossDownSeries() {
-    BarSeries series = new BaseBarSeries();
-    ZonedDateTime now = ZonedDateTime.now();
-  
-    // Gradually decrease the price over several bars
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(4), 14.0, 14.0, 14.0, 14.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(5), 12.0, 12.0, 12.0, 12.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(6), 10.0, 10.0, 10.0, 10.0, 100.0)); // Still above
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(7), 8.0, 8.0, 8.0, 8.0, 100.0)); // Now likely below
+private BarSeries createCrossDownSeries() {
+  BarSeries series = new BaseBarSeries();
+  ZonedDateTime now = ZonedDateTime.now();
 
-    return series;
-  }
+  // Keep price high for the first few bars so short EMA stays above the long EMA.
+  series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(1), 16.0, 16.0, 16.0, 16.0, 100.0));
+  series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(2), 16.0, 16.0, 16.0, 16.0, 100.0));
+  series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(3), 15.0, 15.0, 15.0, 15.0, 100.0));
+
+  // Gradually decrease the price over several bars to ensure the short EMA crosses down.
+  series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(4), 14.0, 14.0, 14.0, 14.0, 100.0));
+  series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(5), 12.0, 12.0, 12.0, 12.0, 100.0));
+  series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(6), 10.0, 10.0, 10.0, 10.0, 100.0));
+  series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(7), 8.0, 8.0, 8.0, 8.0, 100.0));
+
+  return series;
+}
 }

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -86,9 +86,9 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
     logger.atInfo().log("createStrategy_entryRule_triggersOnShortEmaCrossUp test passed.");
   }
 
-  @Test
-  public void createStrategy_exitRule_triggersOnShortEmaCrossDown()
-      throws InvalidProtocolBufferException {
+@Test
+public void createStrategy_exitRule_triggersOnShortEmaCrossDown()
+    throws InvalidProtocolBufferException {
     logger.atInfo().log("Executing createStrategy_exitRule_triggersOnShortEmaCrossDown test...");
     DoubleEmaCrossoverParameters params =
         DoubleEmaCrossoverParameters.newBuilder()
@@ -99,7 +99,7 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
 
     BarSeries series = createCrossDownSeries();
 
-    // Again, create local EMA indicators to observe values per bar
+    // Create local EMA indicators to observe values per bar
     ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
     EMAIndicator shortEmaInd = new EMAIndicator(closePrice, SHORT_EMA);
     EMAIndicator longEmaInd = new EMAIndicator(closePrice, LONG_EMA);
@@ -112,18 +112,20 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
 
     logTradingRecord(tradingRecord, series);
 
-    logger.atInfo().log("Finished running strategy. Final position count: %d",
-        tradingRecord.getPositionCount());
+    // First verify we have exactly 1 completed position
     assertThat(tradingRecord.getPositionCount()).isEqualTo(1);
 
     Position position = tradingRecord.getPositions().get(0);
-    logger.atInfo().log(
-        "Validating that entry index (%d) < exit index (%d)",
-        position.getEntry().getIndex(),
-        position.getExit().getIndex());
-    assertThat(position.getEntry().getIndex()).isLessThan(position.getExit().getIndex());
-
-    logger.atInfo().log("createStrategy_exitRule_triggersOnShortEmaCrossDown test passed.");
+  
+    // Entry should happen around bar 7-8 where short EMA is above long EMA
+    assertThat(position.getEntry().getIndex()).isIn(Range.closed(7, 8));
+  
+    // Exit should happen around bar 9-10 where short EMA crosses below long EMA  
+    assertThat(position.getExit().getIndex()).isIn(Range.closed(9, 10));
+  
+    // Entry must come before exit
+    assertThat(position.getEntry().getIndex())
+        .isLessThan(position.getExit().getIndex());
   }
 
   /**

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -1,12 +1,11 @@
 package com.verlumen.tradestream.strategies.movingaverages;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import com.google.common.collect.Range;
-import com.google.common.flogger.FluentLogger;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
-import com.google.protobuf.InvalidProtocolBufferException;
 import com.verlumen.tradestream.strategies.DoubleEmaCrossoverParameters;
 import com.verlumen.tradestream.strategies.StrategyType;
 import java.time.Duration;
@@ -15,224 +14,114 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.ta4j.core.Bar;
-import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseBar;
 import org.ta4j.core.BaseBarSeries;
-import org.ta4j.core.Position;
 import org.ta4j.core.Strategy;
-import org.ta4j.core.TradingRecord;
-import org.ta4j.core.backtest.BarSeriesManager;
-import org.ta4j.core.indicators.EMAIndicator;
-import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 
 @RunWith(JUnit4.class)
 public class DoubleEmaCrossoverStrategyFactoryTest {
-  private static final FluentLogger logger = FluentLogger.forEnclosingClass();
+    private static final int SHORT_EMA = 3;
+    private static final int LONG_EMA = 7;
 
-  private static final int SHORT_EMA = 3;
-  private static final int LONG_EMA = 7;
+    @Inject 
+    private DoubleEmaCrossoverStrategyFactory factory;
 
-  @Inject private DoubleEmaCrossoverStrategyFactory factory;
+    private DoubleEmaCrossoverParameters params;
+    private BaseBarSeries series;
+    private Strategy strategy;
 
-  @Before
-  public void setUp() {
-    logger.atInfo().log("Setting up test dependencies via Guice injector...");
-    Guice.createInjector().injectMembers(this);
-  }
-
-  @Test
-  public void getStrategyType_returnsCorrectType() {
-    logger.atInfo().log("Executing getStrategyType_returnsCorrectType test...");
-    StrategyType strategyType = factory.getStrategyType();
-    logger.atInfo().log("StrategyType obtained: %s", strategyType);
-
-    assertThat(strategyType).isEqualTo(StrategyType.DOUBLE_EMA_CROSSOVER);
-    logger.atInfo().log("getStrategyType_returnsCorrectType test passed.");
-  }
-
-  @Test
-  public void createStrategy_entryRule_triggersOnShortEmaCrossUp()
-      throws InvalidProtocolBufferException {
-    logger.atInfo().log("Executing createStrategy_entryRule_triggersOnShortEmaCrossUp test...");
-    DoubleEmaCrossoverParameters params =
-        DoubleEmaCrossoverParameters.newBuilder()
+    @Before
+    public void setUp() {
+        Guice.createInjector().injectMembers(this);
+        
+        // Create standard parameters
+        params = DoubleEmaCrossoverParameters.newBuilder()
             .setShortEmaPeriod(SHORT_EMA)
             .setLongEmaPeriod(LONG_EMA)
             .build();
-    logger.atInfo().log("Parameters for short/long EMA: %s", params);
 
-    BarSeries series = createCrossUpSeries();
+        // Initialize series
+        series = new BaseBarSeries();
+        ZonedDateTime now = ZonedDateTime.now();
 
-    // Create indicators for logging
-    ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
-    EMAIndicator shortEmaInd = new EMAIndicator(closePrice, SHORT_EMA);
-    EMAIndicator longEmaInd = new EMAIndicator(closePrice, LONG_EMA);
+        // Add bars that will create a clear crossover pattern
+        // First establish baseline with steady prices
+        for (int i = 0; i < 7; i++) {
+            series.addBar(createBar(now.plusMinutes(i), 50.0));
+        }
+        
+        // Create crossover scenario
+        series.addBar(createBar(now.plusMinutes(7), 60.0));  // Price starts rising
+        series.addBar(createBar(now.plusMinutes(8), 70.0));  // Continues up
+        series.addBar(createBar(now.plusMinutes(9), 75.0));  // Peaks
+        series.addBar(createBar(now.plusMinutes(10), 45.0)); // Sharp drop
+        series.addBar(createBar(now.plusMinutes(11), 40.0)); // Continues down
+        series.addBar(createBar(now.plusMinutes(12), 35.0)); // Establishes downtrend
 
-    // Log values for debugging
-    logBarSeriesWithEma(series, shortEmaInd, longEmaInd);
+        strategy = factory.createStrategy(series, params);
+    }
 
-    Strategy strategy = factory.createStrategy(series, params);
-    BarSeriesManager manager = new BarSeriesManager(series);
-    TradingRecord tradingRecord = manager.run(strategy);
+    @Test
+    public void getStrategyType_returnsDoubleEmaCrossover() {
+        assertThat(factory.getStrategyType()).isEqualTo(StrategyType.DOUBLE_EMA_CROSSOVER);
+    }
 
-    logTradingRecord(tradingRecord, series);
+    @Test
+    public void entryRule_shouldTrigger_whenShortEmaCrossesAboveLongEma() {
+        // No entry signal during baseline period
+        assertFalse(strategy.getEntryRule().isSatisfied(6));
+        
+        // Should detect entry around when short EMA crosses above long EMA
+        assertTrue("Entry rule should trigger when short EMA crosses above long EMA",
+            strategy.getEntryRule().isSatisfied(8));
+    }
 
-    logger.atInfo().log("Finished running strategy. Final position count: %d", 
-        tradingRecord.getPositionCount());
-    assertThat(tradingRecord.getPositionCount()).isGreaterThan(0);
-  }
+    @Test
+    public void exitRule_shouldTrigger_whenShortEmaCrossesBelowLongEma() {
+        // No exit signal during uptrend
+        assertFalse(strategy.getExitRule().isSatisfied(9));
+        
+        // Should detect exit around when short EMA crosses below long EMA
+        assertTrue("Exit rule should trigger when short EMA crosses below long EMA",
+            strategy.getExitRule().isSatisfied(11));
+    }
 
-  @Test
-  public void createStrategy_exitRule_triggersOnShortEmaCrossDown()
-      throws InvalidProtocolBufferException {
-    logger.atInfo().log("Executing createStrategy_exitRule_triggersOnShortEmaCrossDown test...");
-    DoubleEmaCrossoverParameters params =
-        DoubleEmaCrossoverParameters.newBuilder()
-            .setShortEmaPeriod(SHORT_EMA)
+    @Test(expected = IllegalArgumentException.class)
+    public void constructor_shouldThrowException_whenShortEmaPeriodIsNegative() {
+        params = DoubleEmaCrossoverParameters.newBuilder()
+            .setShortEmaPeriod(-1)
             .setLongEmaPeriod(LONG_EMA)
             .build();
-    logger.atInfo().log("Parameters for short/long EMA: %s", params);
-
-    BarSeries series = createCrossDownSeries();
-
-    // Create local EMA indicators to observe values
-    ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
-    EMAIndicator shortEmaInd = new EMAIndicator(closePrice, SHORT_EMA);
-    EMAIndicator longEmaInd = new EMAIndicator(closePrice, LONG_EMA);
-
-    logBarSeriesWithEma(series, shortEmaInd, longEmaInd);
-
-    Strategy strategy = factory.createStrategy(series, params);
-    BarSeriesManager manager = new BarSeriesManager(series);
-    TradingRecord tradingRecord = manager.run(strategy);
-
-    logTradingRecord(tradingRecord, series);
-
-    // Verify exactly one completed position
-    assertThat(tradingRecord.getPositionCount()).isEqualTo(1);
-
-    Position position = tradingRecord.getPositions().get(0);
-  
-    // Entry should happen around when short EMA rises above long EMA (bars 7-8)
-    assertThat(position.getEntry().getIndex()).isIn(Range.closed(7, 8));
-  
-    // Exit should happen around when short EMA drops below long EMA (bars 10-11)
-    assertThat(position.getExit().getIndex()).isIn(Range.closed(10, 11));
-  
-    // Entry must come before exit
-    assertThat(position.getEntry().getIndex())
-        .isLessThan(position.getExit().getIndex());
-  }
-
-  private BarSeries createCrossUpSeries() {
-    logger.atInfo().log("Creating bar series to test short EMA crossing up...");
-    BarSeries series = new BaseBarSeries();
-    ZonedDateTime now = ZonedDateTime.now();
-
-    // Warm-up: 7 bars steady price to establish baseline EMAs
-    for (int i = 0; i < 7; i++) {
-        series.addBar(
-            new BaseBar(
-                Duration.ofMinutes(1),
-                now.plusMinutes(i),
-                50.0, 50.0, 50.0, 50.0,
-                100.0));
+        factory.createStrategy(series, params);
     }
 
-    // Sharp rise to trigger short EMA crossing above long EMA
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(7), 60.0, 60.0, 60.0, 60.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(8), 70.0, 70.0, 70.0, 70.0, 100.0));
-    
-    // Maintain higher levels to establish uptrend
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(9), 75.0, 75.0, 75.0, 75.0, 100.0));
-
-    // Sharp drop to trigger short EMA crossing below long EMA
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(10), 45.0, 45.0, 45.0, 45.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(11), 40.0, 40.0, 40.0, 40.0, 100.0));
-
-    logger.atInfo().log("createCrossUpSeries - Done creating series with dramatic price movements");
-    return series;
-  }
-
-  private BarSeries createCrossDownSeries() {
-    logger.atInfo().log("Creating bar series to test short EMA crossing down...");
-    BarSeries series = new BaseBarSeries();
-    ZonedDateTime now = ZonedDateTime.now();
-
-    // Same pattern as crossUpSeries to first establish a position
-    // Warm-up: 7 bars steady price to establish baseline EMAs
-    for (int i = 0; i < 7; i++) {
-        series.addBar(
-            new BaseBar(
-                Duration.ofMinutes(1),
-                now.plusMinutes(i),
-                50.0, 50.0, 50.0, 50.0,
-                100.0));
+    @Test(expected = IllegalArgumentException.class)
+    public void constructor_shouldThrowException_whenLongEmaPeriodIsNegative() {
+        params = DoubleEmaCrossoverParameters.newBuilder()
+            .setShortEmaPeriod(SHORT_EMA)
+            .setLongEmaPeriod(-1)
+            .build();
+        factory.createStrategy(series, params);
     }
 
-    // Sharp rise to trigger short EMA crossing above long EMA
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(7), 60.0, 60.0, 60.0, 60.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(8), 70.0, 70.0, 70.0, 70.0, 100.0));
-    
-    // Maintain higher levels briefly
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(9), 75.0, 75.0, 75.0, 75.0, 100.0));
-
-    // Sharp drop to trigger short EMA crossing below long EMA
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(10), 45.0, 45.0, 45.0, 45.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(11), 40.0, 40.0, 40.0, 40.0, 100.0));
-    
-    // Keep low to establish downtrend
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(12), 35.0, 35.0, 35.0, 35.0, 100.0));
-
-    logger.atInfo().log("createCrossDownSeries - Done creating series with dramatic price movements");
-    return series;
-  }
-
-  /**
-   * Logs each bar’s open/high/low/close plus short and long EMA values for debugging.
-   */
-  private void logBarSeriesWithEma(
-      BarSeries series, EMAIndicator shortEmaInd, EMAIndicator longEmaInd) {
-    logger.atInfo().log("Logging bar data + short/long EMA values for debugging:");
-    for (int i = 0; i < series.getBarCount(); i++) {
-      Bar bar = series.getBar(i);
-      double shortVal = shortEmaInd.getValue(i).doubleValue();
-      double longVal = longEmaInd.getValue(i).doubleValue();
-      logger.atInfo().log(
-          "Bar[%d] time=%s O=%.4f,H=%.4f,L=%.4f,C=%.4f shortEma=%.4f longEma=%.4f",
-          i,
-          bar.getEndTime(),
-          bar.getOpenPrice().doubleValue(),
-          bar.getHighPrice().doubleValue(),
-          bar.getLowPrice().doubleValue(),
-          bar.getClosePrice().doubleValue(),
-          shortVal,
-          longVal);
-    }
-  }
-
-  /**
-   * Logs the trading record: final position count, positions with entry/exit bar indexes.
-   */
-  private void logTradingRecord(TradingRecord tradingRecord, BarSeries series) {
-    int count = tradingRecord.getPositionCount();
-    logger.atInfo().log("Logging TradingRecord details... Position count=%d", count);
-
-    if (count == 0) {
-      logger.atInfo().log("-- No positions in this trading record. Possibly no crosses detected. --");
-      return;
+    @Test(expected = IllegalArgumentException.class)
+    public void constructor_shouldThrowException_whenLongEmaPeriodLessThanShortPeriod() {
+        params = DoubleEmaCrossoverParameters.newBuilder()
+            .setShortEmaPeriod(LONG_EMA)
+            .setLongEmaPeriod(SHORT_EMA)
+            .build();
+        factory.createStrategy(series, params);
     }
 
-    for (int p = 0; p < count; p++) {
-      Position pos = tradingRecord.getPositions().get(p);
-      logger.atInfo().log("Position #%d: entry=%s exit=%s", p, pos.getEntry(), pos.getExit());
-      logger.atInfo().log(
-          "Entry bar idx=%d closePrice=%.4f; Exit bar idx=%d closePrice=%.4f",
-          pos.getEntry().getIndex(),
-          series.getBar(pos.getEntry().getIndex()).getClosePrice().doubleValue(),
-          pos.getExit().getIndex(),
-          series.getBar(pos.getExit().getIndex()).getClosePrice().doubleValue());
+    private BaseBar createBar(ZonedDateTime time, double price) {
+        return new BaseBar(
+            Duration.ofMinutes(1),
+            time,
+            price, // Open
+            price, // High
+            price, // Low
+            price, // Close
+            100.0  // Volume
+        );
     }
-  }
 }

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertTrue;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.verlumen.tradestream.strategies.DoubleEmaCrossoverParameters;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.verlumen.tradestream.strategies.StrategyType;
 import java.time.Duration;
 import java.time.ZonedDateTime;
@@ -31,7 +32,7 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
     private Strategy strategy;
 
     @Before
-    public void setUp() {
+    public void setUp() throws InvalidProtocolBufferException {
         Guice.createInjector().injectMembers(this);
         
         // Create standard parameters
@@ -87,7 +88,7 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void constructor_shouldThrowException_whenShortEmaPeriodIsNegative() {
+    public void constructor_shouldThrowException_whenShortEmaPeriodIsNegative() throws InvalidProtocolBufferException {
         params = DoubleEmaCrossoverParameters.newBuilder()
             .setShortEmaPeriod(-1)
             .setLongEmaPeriod(LONG_EMA)
@@ -96,7 +97,7 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void constructor_shouldThrowException_whenLongEmaPeriodIsNegative() {
+    public void constructor_shouldThrowException_whenLongEmaPeriodIsNegative() throws InvalidProtocolBufferException {
         params = DoubleEmaCrossoverParameters.newBuilder()
             .setShortEmaPeriod(SHORT_EMA)
             .setLongEmaPeriod(-1)
@@ -105,7 +106,7 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void constructor_shouldThrowException_whenLongEmaPeriodLessThanShortPeriod() {
+    public void constructor_shouldThrowException_whenLongEmaPeriodLessThanShortPeriod() throws InvalidProtocolBufferException {
         params = DoubleEmaCrossoverParameters.newBuilder()
             .setShortEmaPeriod(LONG_EMA)
             .setLongEmaPeriod(SHORT_EMA)

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -109,63 +109,65 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
     logger.info("createStrategy_exitRule_triggersOnShortEmaCrossDown test passed.");
   }
 
-  private BarSeries createCrossDownSeries() {
-    logger.fine("Creating bar series to test short EMA crossing down...");
-    BarSeries series = new BaseBarSeries();
-    ZonedDateTime now = ZonedDateTime.now();
-
-    // 5 bars at 10 to establish a baseline
-    for (int i = 0; i < 5; i++) {
-      Bar bar = new BaseBar(
-          Duration.ofMinutes(1),
-          now.plusMinutes(i),
-          10.0, 10.0, 10.0, 10.0,
-          100.0);
-      series.addBar(bar);
-    }
-  
-    // Move up first, letting short EMA go above the long EMA
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(5), 15.0, 15.0, 15.0, 15.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(6), 20.0, 20.0, 20.0, 20.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(7), 25.0, 25.0, 25.0, 25.0, 100.0));
-  
-    // Stabilize a bit
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(8), 25.0, 25.0, 25.0, 25.0, 100.0));
-  
-    // Then a sharp drop—enough bars to ensure the cross down is recognized
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(9), 15.0, 15.0, 15.0, 15.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(10), 10.0, 10.0, 10.0, 10.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(11), 5.0, 5.0, 5.0, 5.0, 100.0));
-  
-    // One extra bar so TA4J sees the cross from the previous bar
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(12), 5.0, 5.0, 5.0, 5.0, 100.0));
-  
-    return series;
-  }
-
   private BarSeries createCrossUpSeries() {
     logger.fine("Creating bar series to test short EMA crossing up...");
     BarSeries series = new BaseBarSeries();
     ZonedDateTime now = ZonedDateTime.now();
   
-    // 5 bars at 10 to establish baseline
-    for (int i = 0; i < 5; i++) {
-      Bar bar = new BaseBar(
-          Duration.ofMinutes(1),
-          now.plusMinutes(i),
-          10.0, 10.0, 10.0, 10.0,
-          100.0);
-      series.addBar(bar);
+    // 1) Warm-up bars so the short (3) & long (7) EMAs are valid.
+    //    10 bars at 10.0 to "prime" the EMAs.
+    for (int i = 0; i < 10; i++) {
+      series.addBar(
+          new BaseBar(
+              Duration.ofMinutes(1),
+              now.plusMinutes(i),
+              10.0, 10.0, 10.0, 10.0,
+              100.0));
     }
+
+    // 2) Gradually increase price so shortEma eventually crosses above longEma.
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(10), 12.0, 12.0, 12.0, 12.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(11), 14.0, 14.0, 14.0, 14.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(12), 18.0, 18.0, 18.0, 18.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(13), 20.0, 20.0, 20.0, 20.0, 100.0));
+
+    // 3) Add 1–2 extra bars so TA4J can “finalize” the cross.
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(14), 20.0, 20.0, 20.0, 20.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(15), 20.0, 20.0, 20.0, 20.0, 100.0));
+
+    return series;
+  }
   
-    // Gradually move upward to let short EMA inch above long EMA
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(5), 12.0, 12.0, 12.0, 12.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(6), 14.0, 14.0, 14.0, 14.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(7), 18.0, 18.0, 18.0, 18.0, 100.0));
-  
-    // IMPORTANT: One extra bar to confirm short > long *on the next bar*
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(8), 20.0, 20.0, 20.0, 20.0, 100.0));
-  
+  private BarSeries createCrossDownSeries() {
+    logger.fine("Creating bar series to test short EMA crossing down...");
+    BarSeries series = new BaseBarSeries();
+    ZonedDateTime now = ZonedDateTime.now();
+
+    // 1) Again, warm-up bars to let the longEma(7) & shortEma(3) initialize.
+    for (int i = 0; i < 10; i++) {
+      series.addBar(
+          new BaseBar(
+              Duration.ofMinutes(1),
+              now.plusMinutes(i),
+              10.0, 10.0, 10.0, 10.0,
+              100.0));
+    }
+
+    // 2) Move up first, ensuring shortEma > longEma
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(10), 15.0, 15.0, 15.0, 15.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(11), 20.0, 20.0, 20.0, 20.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(12), 25.0, 25.0, 25.0, 25.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(13), 25.0, 25.0, 25.0, 25.0, 100.0));
+
+    // 3) Then a sharp drop to cross below
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(14), 15.0, 15.0, 15.0, 15.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(15), 10.0, 10.0, 10.0, 10.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(16), 5.0, 5.0, 5.0, 5.0, 100.0));
+
+    // 4) Extra trailing bars to finalize the cross event
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(17), 5.0, 5.0, 5.0, 5.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(18), 5.0, 5.0, 5.0, 5.0, 100.0));
+
     return series;
   }
 }

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -89,28 +89,28 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
   public void createStrategy_entryRule_triggersOnShortEmaCrossUp()
       throws InvalidProtocolBufferException {
     // Arrange
-    DoubleEmaCrossoverParameters params = DoubleEmaCrossoverParameters.newBuilder()
-        // Use smaller periods so the crossover can happen quickly
-        .setShortEmaPeriod(2)
-        .setLongEmaPeriod(3)
-        .build();
+     DoubleEmaCrossoverParameters params = DoubleEmaCrossoverParameters.newBuilder()
+         // Use smaller periods so the crossover can happen quickly
+         .setShortEmaPeriod(2)
+         .setLongEmaPeriod(3)
+         .build();
 
-    // This series (below) is engineered so that around the last bar,
-    // short EMA (2) crosses above long EMA (3)
-    BarSeries series = createCrossUpSeries();
+     // This series (below) is engineered so that around the last bar,
+     // the short EMA (2) crosses above the long EMA (3) at index 3.
+     BarSeries series = createCrossUpSeries();
     Strategy strategy = factory.createStrategy(series, params);
 
     // Act & Assert
     // We'll test that the entry rule becomes true at some bar
-    boolean anyEntrySatisfied = false;
+    boolean entrySatisfiedAtIndex = false;
     for (int i = series.getBeginIndex(); i <= series.getEndIndex(); i++) {
       if (strategy.getEntryRule().isSatisfied(i)) {
-        anyEntrySatisfied = true;
+        entrySatisfiedAtIndex = true;
         break;
       }
     }
     // Because we've engineered the data to cross, we expect at least one bar to trigger
-    assertThat(anyEntrySatisfied).isTrue();
+    assertThat(entrySatisfiedAtIndex).isTrue();
   }
 
   /**
@@ -131,10 +131,10 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
 
     // Act & Assert
     // We'll test that the exit rule becomes true at some bar
-    boolean anyExitSatisfied = false;
+    boolean exitSatisfiedAtIndex = false;
     for (int i = series.getBeginIndex(); i <= series.getEndIndex(); i++) {
       if (strategy.getExitRule().isSatisfied(i)) {
-        anyExitSatisfied = true;
+        exitSatisfiedAtIndex = true;
         break;
       }
     }
@@ -148,7 +148,7 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
           "Index: " + i + ", Short EMA: " + shortEma.getValue(i) + ", Long EMA: " + longEma.getValue(i));
     }
 
-    assertThat(anyExitSatisfied).isTrue();
+    assertThat(exitSatisfiedAtIndex).isTrue();
   }
 
   private BarSeries createTestBarSeries() {
@@ -168,9 +168,12 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
   /**
    * Series designed so that short EMA crosses up the long EMA. The short period is 2, and the long
    * is 3, so around the last bar the short EMA rises above the long.
+   *
+   * Crossover is expected at index 3.
    */
   private BarSeries createCrossUpSeries() {
     BarSeries series = new BaseBarSeries();
+
     ZonedDateTime now = ZonedDateTime.now();
 
     // For the first few bars, keep the close price steady or slightly decreasing
@@ -190,6 +193,7 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
 
   private BarSeries createCrossDownSeries() {
     BarSeries series = new BaseBarSeries();
+    // The crossover is expected at index 6.
     ZonedDateTime now = ZonedDateTime.now();
 
     // 1) Start with some higher values to ensure short EMA > long EMA initially.

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -117,23 +117,36 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
    */
   @Test
   public void createStrategy_exitRule_triggersOnShortEmaCrossDown()
-      throws InvalidProtocolBufferException {
-    // Arrange
-    DoubleEmaCrossoverParameters params = DoubleEmaCrossoverParameters.newBuilder()
-        .setShortEmaPeriod(2)
-        .setLongEmaPeriod(3)
-        .build();
-
-    // This series is engineered so that short EMA is initially above,
-    // then crosses down (the last bar has a big drop).
-    BarSeries series = createCrossDownSeries();
-    Strategy strategy = factory.createStrategy(series, params);
-
-    // Act & Assert
-    // We'll test that the exit rule becomes true at the last bar
-    int lastBarIndex = series.getEndIndex();
-    boolean lastBarExitSatisfied = strategy.getExitRule().isSatisfied(lastBarIndex);
-    assertThat(lastBarExitSatisfied).isTrue();
+          throws InvalidProtocolBufferException {
+      // Arrange
+      DoubleEmaCrossoverParameters params = DoubleEmaCrossoverParameters.newBuilder()
+              .setShortEmaPeriod(2)
+              .setLongEmaPeriod(3)
+              .build();
+  
+      BarSeries series = createCrossDownSeries();
+      Strategy strategy = factory.createStrategy(series, params);
+  
+      // Debugging Output:
+      ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
+      EMAIndicator shortEma = new EMAIndicator(closePrice, params.getShortEmaPeriod());
+      EMAIndicator longEma = new EMAIndicator(closePrice, params.getLongEmaPeriod());
+  
+      int lastBarIndex = series.getEndIndex();
+  
+      System.out.println("----- DEBUG INFO -----");
+      System.out.println("Last Bar Index: " + lastBarIndex);
+      for (int i = 0; i <= lastBarIndex; i++) {
+          System.out.println("Index: " + i +
+                ", Short EMA: " + shortEma.getValue(i) +
+                ", Long EMA: " + longEma.getValue(i) +
+                ", Close Price: " + series.getBar(i).getClosePrice());
+      }
+  
+  
+      // Act & Assert
+      boolean lastBarExitSatisfied = strategy.getExitRule().isSatisfied(lastBarIndex);
+      assertThat(lastBarExitSatisfied).isTrue();
   }
 
   private BarSeries createTestBarSeries() {

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -104,92 +104,32 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
     BarSeries series = new BaseBarSeries();
     ZonedDateTime now = ZonedDateTime.now();
 
-    // Establish a baseline with steady low price
+    // 5 bars at 10 to establish a baseline
     for (int i = 0; i < 5; i++) {
-      Bar bar =
-          new BaseBar(
-              Duration.ofMinutes(1), now.plusMinutes(i), 10.0, 10.0, 10.0, 10.0, 100.0);
+      Bar bar = new BaseBar(
+          Duration.ofMinutes(1),
+          now.plusMinutes(i),
+          10.0, 10.0, 10.0, 10.0,
+          100.0);
       series.addBar(bar);
     }
-
-    // Sharp upward movement to trigger short EMA crossing above long EMA
-    series.addBar(
-        new BaseBar(
-            Duration.ofMinutes(1),
-            now.plusMinutes(5),
-            20.0,
-            20.0,
-            20.0,
-            20.0,
-            100.0));
-    series.addBar(
-        new BaseBar(
-            Duration.ofMinutes(1),
-            now.plusMinutes(6),
-            25.0,
-            25.0,
-            25.0,
-            25.0,
-            100.0));
-    series.addBar(
-        new BaseBar(
-            Duration.ofMinutes(1),
-            now.plusMinutes(7),
-            30.0,
-            30.0,
-            30.0,
-            30.0,
-            100.0));
-
-    // Hold at higher level briefly
-    series.addBar(
-        new BaseBar(
-            Duration.ofMinutes(1),
-            now.plusMinutes(8),
-            30.0,
-            30.0,
-            30.0,
-            30.0,
-            100.0));
-    series.addBar(
-        new BaseBar(
-            Duration.ofMinutes(1),
-            now.plusMinutes(9),
-            30.0,
-            30.0,
-            30.0,
-            30.0,
-            100.0));
-
-    // Sharp decline to trigger short EMA crossing below long EMA
-    series.addBar(
-        new BaseBar(
-            Duration.ofMinutes(1),
-            now.plusMinutes(10),
-            15.0,
-            15.0,
-            15.0,
-            15.0,
-            100.0));
-    series.addBar(
-        new BaseBar(
-            Duration.ofMinutes(1),
-            now.plusMinutes(11),
-            10.0,
-            10.0,
-            10.0,
-            10.0,
-            100.0));
-    series.addBar(
-        new BaseBar(
-            Duration.ofMinutes(1),
-            now.plusMinutes(12),
-            5.0,
-            5.0,
-            5.0,
-            5.0,
-            100.0));
-
+  
+    // Move up first, letting short EMA go above the long EMA
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(5), 15.0, 15.0, 15.0, 15.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(6), 20.0, 20.0, 20.0, 20.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(7), 25.0, 25.0, 25.0, 25.0, 100.0));
+  
+    // Stabilize a bit
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(8), 25.0, 25.0, 25.0, 25.0, 100.0));
+  
+    // Then a sharp drop—enough bars to ensure the cross down is recognized
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(9), 15.0, 15.0, 15.0, 15.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(10), 10.0, 10.0, 10.0, 10.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(11), 5.0, 5.0, 5.0, 5.0, 100.0));
+  
+    // One extra bar so TA4J sees the cross from the previous bar
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(12), 5.0, 5.0, 5.0, 5.0, 100.0));
+  
     return series;
   }
 
@@ -197,44 +137,25 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
     logger.fine("Creating bar series to test short EMA crossing up...");
     BarSeries series = new BaseBarSeries();
     ZonedDateTime now = ZonedDateTime.now();
-
-    // Start with steady prices to establish baseline EMAs
+  
+    // 5 bars at 10 to establish baseline
     for (int i = 0; i < 5; i++) {
-      Bar bar =
-          new BaseBar(
-              Duration.ofMinutes(1), now.plusMinutes(i), 10.0, 10.0, 10.0, 10.0, 100.0);
+      Bar bar = new BaseBar(
+          Duration.ofMinutes(1),
+          now.plusMinutes(i),
+          10.0, 10.0, 10.0, 10.0,
+          100.0);
       series.addBar(bar);
     }
-
-    // Sharp upward movement to trigger cross up
-    series.addBar(
-        new BaseBar(
-            Duration.ofMinutes(1),
-            now.plusMinutes(5),
-            15.0,
-            15.0,
-            15.0,
-            15.0,
-            100.0));
-    series.addBar(
-        new BaseBar(
-            Duration.ofMinutes(1),
-            now.plusMinutes(6),
-            20.0,
-            20.0,
-            20.0,
-            20.0,
-            100.0));
-    series.addBar(
-        new BaseBar(
-            Duration.ofMinutes(1),
-            now.plusMinutes(7),
-            25.0,
-            25.0,
-            25.0,
-            25.0,
-            100.0));
-
+  
+    // Gradually move upward to let short EMA inch above long EMA
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(5), 12.0, 12.0, 12.0, 12.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(6), 14.0, 14.0, 14.0, 14.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(7), 18.0, 18.0, 18.0, 18.0, 100.0));
+  
+    // IMPORTANT: One extra bar to confirm short > long *on the next bar*
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(8), 20.0, 20.0, 20.0, 20.0, 100.0));
+  
     return series;
   }
 }

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -2,6 +2,7 @@ package com.verlumen.tradestream.strategies.movingaverages;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.common.collect.Range;
 import com.google.common.flogger.FluentLogger;
 import com.google.inject.Guice;
 import com.google.inject.Inject;

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -9,6 +9,8 @@ import com.verlumen.tradestream.strategies.DoubleEmaCrossoverParameters;
 import com.verlumen.tradestream.strategies.StrategyType;
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,87 +27,213 @@ import org.ta4j.core.backtest.BarSeriesManager;
 @RunWith(JUnit4.class)
 public class DoubleEmaCrossoverStrategyFactoryTest {
 
+  private static final Logger logger =
+      Logger.getLogger(DoubleEmaCrossoverStrategyFactoryTest.class.getName());
+
   @Inject private DoubleEmaCrossoverStrategyFactory factory;
 
   @Before
   public void setUp() {
+    logger.info("Setting up test dependencies via Guice injector...");
     Guice.createInjector().injectMembers(this);
   }
 
   @Test
   public void getStrategyType_returnsCorrectType() {
+    logger.info("Executing getStrategyType_returnsCorrectType test...");
     StrategyType strategyType = factory.getStrategyType();
+    logger.log(Level.FINE, "StrategyType obtained: {0}", strategyType);
+
     assertThat(strategyType).isEqualTo(StrategyType.DOUBLE_EMA_CROSSOVER);
+    logger.info("getStrategyType_returnsCorrectType test passed.");
   }
 
   @Test
   public void createStrategy_entryRule_triggersOnShortEmaCrossUp()
       throws InvalidProtocolBufferException {
+    logger.info("Executing createStrategy_entryRule_triggersOnShortEmaCrossUp test...");
     DoubleEmaCrossoverParameters params =
         DoubleEmaCrossoverParameters.newBuilder().setShortEmaPeriod(2).setLongEmaPeriod(3).build();
+    logger.log(Level.FINE, "Parameters for short/long EMA: {0}", params);
+
     BarSeries series = createCrossUpSeries();
     Strategy strategy = factory.createStrategy(series, params);
     BarSeriesManager manager = new BarSeriesManager(series);
     TradingRecord tradingRecord = manager.run(strategy);
-    
+
+    logger.log(
+        Level.FINE,
+        "Finished running strategy. Position count: {0}",
+        tradingRecord.getPositionCount());
     assertThat(tradingRecord.getPositionCount()).isGreaterThan(0);
+
+    logger.info("createStrategy_entryRule_triggersOnShortEmaCrossUp test passed.");
   }
 
   @Test
   public void createStrategy_exitRule_triggersOnShortEmaCrossDown()
       throws InvalidProtocolBufferException {
+    logger.info("Executing createStrategy_exitRule_triggersOnShortEmaCrossDown test...");
     DoubleEmaCrossoverParameters params =
         DoubleEmaCrossoverParameters.newBuilder().setShortEmaPeriod(2).setLongEmaPeriod(3).build();
-    BarSeries series = createCrossDownSeries();
+    logger.log(Level.FINE, "Parameters for short/long EMA: {0}", params);
 
+    BarSeries series = createCrossDownSeries();
     Strategy strategy = factory.createStrategy(series, params);
     BarSeriesManager manager = new BarSeriesManager(series);
     TradingRecord tradingRecord = manager.run(strategy);
 
+    logger.log(
+        Level.FINE,
+        "Finished running strategy. Position count: {0}",
+        tradingRecord.getPositionCount());
     assertThat(tradingRecord.getPositionCount()).isEqualTo(1);
+
     Position position = tradingRecord.getPositions().get(0);
+    logger.log(
+        Level.FINE,
+        "Validating that entry index ({0}) < exit index ({1})",
+        new Object[] {position.getEntry().getIndex(), position.getExit().getIndex()});
     assertThat(position.getEntry().getIndex()).isLessThan(position.getExit().getIndex());
+
+    logger.info("createStrategy_exitRule_triggersOnShortEmaCrossDown test passed.");
   }
 
   private BarSeries createCrossDownSeries() {
+    logger.fine("Creating bar series to test short EMA crossing down...");
     BarSeries series = new BaseBarSeries();
     ZonedDateTime now = ZonedDateTime.now();
 
     // Establish a baseline with steady low price
     for (int i = 0; i < 5; i++) {
-      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(i), 10.0, 10.0, 10.0, 10.0, 100.0));
+      Bar bar =
+          new BaseBar(
+              Duration.ofMinutes(1), now.plusMinutes(i), 10.0, 10.0, 10.0, 10.0, 100.0);
+      series.addBar(bar);
     }
 
     // Sharp upward movement to trigger short EMA crossing above long EMA
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(5), 20.0, 20.0, 20.0, 20.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(6), 25.0, 25.0, 25.0, 25.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(7), 30.0, 30.0, 30.0, 30.0, 100.0));
+    series.addBar(
+        new BaseBar(
+            Duration.ofMinutes(1),
+            now.plusMinutes(5),
+            20.0,
+            20.0,
+            20.0,
+            20.0,
+            100.0));
+    series.addBar(
+        new BaseBar(
+            Duration.ofMinutes(1),
+            now.plusMinutes(6),
+            25.0,
+            25.0,
+            25.0,
+            25.0,
+            100.0));
+    series.addBar(
+        new BaseBar(
+            Duration.ofMinutes(1),
+            now.plusMinutes(7),
+            30.0,
+            30.0,
+            30.0,
+            30.0,
+            100.0));
 
     // Hold at higher level briefly
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(8), 30.0, 30.0, 30.0, 30.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(9), 30.0, 30.0, 30.0, 30.0, 100.0));
+    series.addBar(
+        new BaseBar(
+            Duration.ofMinutes(1),
+            now.plusMinutes(8),
+            30.0,
+            30.0,
+            30.0,
+            30.0,
+            100.0));
+    series.addBar(
+        new BaseBar(
+            Duration.ofMinutes(1),
+            now.plusMinutes(9),
+            30.0,
+            30.0,
+            30.0,
+            30.0,
+            100.0));
 
     // Sharp decline to trigger short EMA crossing below long EMA
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(10), 15.0, 15.0, 15.0, 15.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(11), 10.0, 10.0, 10.0, 10.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(12), 5.0, 5.0, 5.0, 5.0, 100.0));
+    series.addBar(
+        new BaseBar(
+            Duration.ofMinutes(1),
+            now.plusMinutes(10),
+            15.0,
+            15.0,
+            15.0,
+            15.0,
+            100.0));
+    series.addBar(
+        new BaseBar(
+            Duration.ofMinutes(1),
+            now.plusMinutes(11),
+            10.0,
+            10.0,
+            10.0,
+            10.0,
+            100.0));
+    series.addBar(
+        new BaseBar(
+            Duration.ofMinutes(1),
+            now.plusMinutes(12),
+            5.0,
+            5.0,
+            5.0,
+            5.0,
+            100.0));
 
     return series;
   }
 
   private BarSeries createCrossUpSeries() {
+    logger.fine("Creating bar series to test short EMA crossing up...");
     BarSeries series = new BaseBarSeries();
     ZonedDateTime now = ZonedDateTime.now();
 
     // Start with steady prices to establish baseline EMAs
     for (int i = 0; i < 5; i++) {
-        series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(i), 10.0, 10.0, 10.0, 10.0, 100.0));
+      Bar bar =
+          new BaseBar(
+              Duration.ofMinutes(1), now.plusMinutes(i), 10.0, 10.0, 10.0, 10.0, 100.0);
+      series.addBar(bar);
     }
 
     // Sharp upward movement to trigger cross up
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(5), 15.0, 15.0, 15.0, 15.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(6), 20.0, 20.0, 20.0, 20.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(7), 25.0, 25.0, 25.0, 25.0, 100.0));
+    series.addBar(
+        new BaseBar(
+            Duration.ofMinutes(1),
+            now.plusMinutes(5),
+            15.0,
+            15.0,
+            15.0,
+            15.0,
+            100.0));
+    series.addBar(
+        new BaseBar(
+            Duration.ofMinutes(1),
+            now.plusMinutes(6),
+            20.0,
+            20.0,
+            20.0,
+            20.0,
+            100.0));
+    series.addBar(
+        new BaseBar(
+            Duration.ofMinutes(1),
+            now.plusMinutes(7),
+            25.0,
+            25.0,
+            25.0,
+            25.0,
+            100.0));
 
     return series;
   }

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -6,8 +6,8 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.inject.Guice;
 import com.google.inject.Inject;
-import com.verlumen.tradestream.strategies.DoubleEmaCrossoverParameters;
 import com.google.protobuf.InvalidProtocolBufferException;
+import com.verlumen.tradestream.strategies.DoubleEmaCrossoverParameters;
 import com.verlumen.tradestream.strategies.StrategyType;
 import java.time.Duration;
 import java.time.ZonedDateTime;
@@ -18,6 +18,8 @@ import org.junit.runners.JUnit4;
 import org.ta4j.core.BaseBar;
 import org.ta4j.core.BaseBarSeries;
 import org.ta4j.core.Strategy;
+import org.ta4j.core.indicators.EMAIndicator;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 
 @RunWith(JUnit4.class)
 public class DoubleEmaCrossoverStrategyFactoryTest {
@@ -98,6 +100,7 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
         // Should detect entry when short EMA crosses above long EMA
         assertTrue("Entry rule should trigger when short EMA crosses above long EMA",
             strategy.getEntryRule().isSatisfied(8));
+    }
 
     @Test
     public void exitRule_shouldTrigger_whenShortEmaCrossesBelowLongEma() {
@@ -117,9 +120,10 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
         // Should detect exit when short EMA crosses below long EMA
         assertTrue("Exit rule should trigger when short EMA crosses below long EMA",
             strategy.getExitRule().isSatisfied(12));
+    }
 
     @Test(expected = IllegalArgumentException.class)
-    public void constructor_shouldThrowException_whenShortEmaPeriodIsNegative() throws InvalidProtocolBufferException {
+    public void validateShortEmaPeriod() throws InvalidProtocolBufferException {
         params = DoubleEmaCrossoverParameters.newBuilder()
             .setShortEmaPeriod(-1)
             .setLongEmaPeriod(LONG_EMA)
@@ -128,7 +132,7 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void constructor_shouldThrowException_whenLongEmaPeriodIsNegative() throws InvalidProtocolBufferException {
+    public void validateLongEmaPeriod() throws InvalidProtocolBufferException {
         params = DoubleEmaCrossoverParameters.newBuilder()
             .setShortEmaPeriod(SHORT_EMA)
             .setLongEmaPeriod(-1)
@@ -137,7 +141,7 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void constructor_shouldThrowException_whenLongEmaPeriodLessThanShortPeriod() throws InvalidProtocolBufferException {
+    public void validateEmaPeriodOrdering() throws InvalidProtocolBufferException {
         params = DoubleEmaCrossoverParameters.newBuilder()
             .setShortEmaPeriod(LONG_EMA)
             .setLongEmaPeriod(SHORT_EMA)

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -20,7 +20,7 @@ import org.ta4j.core.BaseBarSeries;
 import org.ta4j.core.Position;
 import org.ta4j.core.Strategy;
 import org.ta4j.core.TradingRecord;
-import org.ta4j.core.backtest.BarSeriesManager
+import org.ta4j.core.backtest.BarSeriesManager;
 import org.ta4j.core.indicators.EMAIndicator;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.rules.CrossedDownIndicatorRule;

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -25,6 +25,7 @@ import org.ta4j.core.rules.CrossedUpIndicatorRule;
 
 @RunWith(JUnit4.class)
 public class DoubleEmaCrossoverStrategyFactoryTest {
+  private static final BarSeries SERIES = newBarSeries();
 
   @Inject
   private DoubleEmaCrossoverStrategyFactory factory;
@@ -35,178 +36,106 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
   }
 
   @Test
-  public void getStrategyType_returnsCorrectType() {
-    // Arrange & Act
+  void createStrategy_validParameters_createsStrategy() throws InvalidProtocolBufferException {
+    // Arrange
+    DoubleEmaCrossoverParameters params =
+        DoubleEmaCrossoverParameters.newBuilder().setShortEmaPeriod(5).setLongEmaPeriod(10).build();
+
+    // Act
+    Strategy strategy = factory.createStrategy(SERIES, params);
+
+    // Assert
+    assertThat(strategy).isNotNull();
+  }
+
+  @Test
+  void createStrategy_shortEmaPeriodZero_throwsIllegalArgumentException() {
+    // Arrange
+    DoubleEmaCrossoverParameters params =
+        DoubleEmaCrossoverParameters.newBuilder().setShortEmaPeriod(0).setLongEmaPeriod(10).build();
+
+    // Act
+    Throwable thrown =
+        assertThrows(IllegalArgumentException.class, () -> factory.createStrategy(SERIES, params));
+
+    // Assert
+    assertThat(thrown).hasMessageThat().contains("shortEmaPeriod");
+  }
+
+  @Test
+  void createStrategy_shortEmaPeriodNegative_throwsIllegalArgumentException() {
+    // Arrange
+    DoubleEmaCrossoverParameters params =
+        DoubleEmaCrossoverParameters.newBuilder().setShortEmaPeriod(-1).setLongEmaPeriod(10).build();
+
+    // Act
+    Throwable thrown =
+        assertThrows(IllegalArgumentException.class, () -> factory.createStrategy(SERIES, params));
+
+    // Assert
+    assertThat(thrown).hasMessageThat().contains("shortEmaPeriod");
+  }
+
+  @Test
+  void createStrategy_longEmaPeriodZero_throwsIllegalArgumentException() {
+    // Arrange
+    DoubleEmaCrossoverParameters params =
+        DoubleEmaCrossoverParameters.newBuilder().setShortEmaPeriod(5).setLongEmaPeriod(0).build();
+
+    // Act
+    Throwable thrown =
+        assertThrows(IllegalArgumentException.class, () -> factory.createStrategy(SERIES, params));
+
+    // Assert
+    assertThat(thrown).hasMessageThat().contains("longEmaPeriod");
+  }
+
+  @Test
+  void createStrategy_longEmaPeriodNegative_throwsIllegalArgumentException() {
+    // Arrange
+    DoubleEmaCrossoverParameters params =
+        DoubleEmaCrossoverParameters.newBuilder().setShortEmaPeriod(5).setLongEmaPeriod(-1).build();
+
+    // Act
+    Throwable thrown =
+        assertThrows(IllegalArgumentException.class, () -> factory.createStrategy(SERIES, params));
+
+    // Assert
+    assertThat(thrown).hasMessageThat().contains("longEmaPeriod");
+  }
+
+  @Test
+  void createStrategy_longEmaPeriodLessThanOrEqualToShortEmaPeriod_throwsIllegalArgumentException() {
+    // Arrange
+    DoubleEmaCrossoverParameters params =
+        DoubleEmaCrossoverParameters.newBuilder().setShortEmaPeriod(10).setLongEmaPeriod(10).build();
+
+    // Act
+    Throwable thrown =
+        assertThrows(IllegalArgumentException.class, () -> factory.createStrategy(SERIES, params));
+
+    // Assert
+    assertThat(thrown)
+        .hasMessageThat()
+        .contains("longEmaPeriod must be greater than shortEmaPeriod");
+  }
+
+  @Test
+  void getStrategyType_returnsDoubleEmaCrossover() {
+    // Arrange (no specific arrangement needed)
+
+    // Act
     StrategyType strategyType = factory.getStrategyType();
 
     // Assert
     assertThat(strategyType).isEqualTo(StrategyType.DOUBLE_EMA_CROSSOVER);
   }
 
-  @Test
-  public void createStrategy_entryRule_isCrossedUpIndicatorRule()
-      throws InvalidProtocolBufferException {
-    // Arrange
-    DoubleEmaCrossoverParameters params = DoubleEmaCrossoverParameters.newBuilder()
-        .setShortEmaPeriod(5)
-        .setLongEmaPeriod(20)
-        .build();
-    BarSeries series = createTestBarSeries();
-
-    // Act
-    Strategy strategy = factory.createStrategy(series, params);
-
-    // Assert
-    // We can still verify the type of the entry rule
-    assertThat(strategy.getEntryRule()).isInstanceOf(CrossedUpIndicatorRule.class);
-  }
-
-  @Test
-  public void createStrategy_exitRule_isCrossedDownIndicatorRule()
-      throws InvalidProtocolBufferException {
-    // Arrange
-    DoubleEmaCrossoverParameters params = DoubleEmaCrossoverParameters.newBuilder()
-        .setShortEmaPeriod(5)
-        .setLongEmaPeriod(20)
-        .build();
-    BarSeries series = createTestBarSeries();
-
-    // Act
-    Strategy strategy = factory.createStrategy(series, params);
-
-    // Assert
-    assertThat(strategy.getExitRule()).isInstanceOf(CrossedDownIndicatorRule.class);
-  }
-
-  /**
-   * A more functional test verifying that the entry rule is satisfied at the correct index after
-   * short EMA crosses above long EMA.
-   *
-   * Note: This requires creating a BarSeries that actually triggers a cross-up if shortEmaPeriod <
-   * longEmaPeriod.
-   */
-  @Test
-  public void createStrategy_entryRule_triggersOnShortEmaCrossUp()
-      throws InvalidProtocolBufferException {
-    // Arrange
-     DoubleEmaCrossoverParameters params = DoubleEmaCrossoverParameters.newBuilder()
-         // Use smaller periods so the crossover can happen quickly
-         .setShortEmaPeriod(2)
-         .setLongEmaPeriod(3)
-         .build();
-
-     // This series (below) is engineered so that around the last bar,
-     // the short EMA (2) crosses above the long EMA (3) at index 3.
-     BarSeries series = createCrossUpSeries();
-    Strategy strategy = factory.createStrategy(series, params);
-
-    // Act & Assert
-    // We'll test that the entry rule becomes true at some bar
-    boolean entrySatisfiedAtIndex = false;
-    for (int i = series.getBeginIndex(); i <= series.getEndIndex(); i++) {
-      if (strategy.getEntryRule().isSatisfied(i)) {
-        entrySatisfiedAtIndex = true;
-        break;
-      }
-    }
-    // Because we've engineered the data to cross, we expect at least one bar to trigger
-    assertThat(entrySatisfiedAtIndex).isTrue();
-  }
-
-  /**
-   * A more functional test verifying that the exit rule is satisfied at the correct index after short
-   * EMA crosses below long EMA.
-   */
-  @Test
-  public void createStrategy_exitRule_triggersOnShortEmaCrossDown()
-      throws InvalidProtocolBufferException {
-    // Arrange
-    DoubleEmaCrossoverParameters params = DoubleEmaCrossoverParameters.newBuilder()
-        .setShortEmaPeriod(2)
-        .setLongEmaPeriod(3)
-        .build();
-
-    BarSeries series = createCrossDownSeries();
-    Strategy strategy = factory.createStrategy(series, params);
-
-    // Act & Assert
-    // We'll test that the exit rule becomes true at some bar
-    boolean exitSatisfiedAtIndex = false;
-    for (int i = series.getBeginIndex(); i <= series.getEndIndex(); i++) {
-      if (strategy.getExitRule().isSatisfied(i)) {
-        exitSatisfiedAtIndex = true;
-        break;
-      }
-    }
-
-    // Debugging Output:
-    ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
-    EMAIndicator shortEma = new EMAIndicator(closePrice, params.getShortEmaPeriod());
-    EMAIndicator longEma = new EMAIndicator(closePrice, params.getLongEmaPeriod());
-    for (int i = 0; i <= series.getEndIndex(); i++) {
-      System.out.println(
-          "Index: " + i + ", Short EMA: " + shortEma.getValue(i) + ", Long EMA: " + longEma.getValue(i));
-    }
-
-    assertThat(exitSatisfiedAtIndex).isTrue();
-  }
-
-  private BarSeries createTestBarSeries() {
+  private static BarSeries newBarSeries() {
     BarSeries series = new BaseBarSeries();
     ZonedDateTime now = ZonedDateTime.now();
-
-    // With newer TA4j, we must supply (Duration, endTime, open, high, low, close, volume)
-    // Below is just an example with arbitrary values
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(1),
-        10.0, 12.0, 8.0, 11.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(2),
-        11.0, 13.0, 9.0, 12.0, 120.0));
-
-    return series;
-  }
-
-  /**
-   * Series designed so that short EMA crosses up the long EMA. The short period is 2, and the long
-   * is 3, so around the last bar the short EMA rises above the long.
-   *
-   * Crossover is expected at index 3.
-   */
-  private BarSeries createCrossUpSeries() {
-    BarSeries series = new BaseBarSeries();
-
-    ZonedDateTime now = ZonedDateTime.now();
-
-    // For the first few bars, keep the close price steady or slightly decreasing
-    // Then spike upward so that short EMA crosses above the long EMA
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(1),
-        10.0, 10.0, 10.0, 10.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(2),
-        10.0, 10.0, 10.0, 10.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(3),
-        9.5,  9.5,  9.0,  9.0,  100.0));
-    // Big jump
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(4),
-        10.0, 15.0, 10.0, 15.0, 100.0));
-
-    return series;
-  }
-
-  private BarSeries createCrossDownSeries() {
-    BarSeries series = new BaseBarSeries();
-    // The crossover is expected at index 6.
-    ZonedDateTime now = ZonedDateTime.now();
-
-    // 1) Start with some higher values to ensure short EMA > long EMA initially.
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(1), 18.0, 18.0, 18.0, 18.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(2), 17.0, 17.0, 17.0, 17.0, 100.0));
-
-    // 2) Gradually decrease further, so short EMA crosses below.
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(3), 16.0, 16.0, 16.0, 16.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(4), 14.0, 14.0, 14.0, 14.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(5), 12.0, 12.0, 12.0, 12.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(6), 10.0, 10.0, 10.0, 10.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(7), 8.0, 8.0, 8.0, 8.0, 100.0));
-
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.minusMinutes(2), 10, 12, 8, 11));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.minusMinutes(1), 11, 13, 9, 12));
     return series;
   }
 }

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -25,7 +25,6 @@ import org.ta4j.core.rules.CrossedUpIndicatorRule;
 
 @RunWith(JUnit4.class)
 public class DoubleEmaCrossoverStrategyFactoryTest {
-  private static final BarSeries SERIES = newBarSeries();
 
   @Inject
   private DoubleEmaCrossoverStrategyFactory factory;
@@ -36,106 +35,178 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
   }
 
   @Test
-  void createStrategy_validParameters_createsStrategy() throws InvalidProtocolBufferException {
-    // Arrange
-    DoubleEmaCrossoverParameters params =
-        DoubleEmaCrossoverParameters.newBuilder().setShortEmaPeriod(5).setLongEmaPeriod(10).build();
-
-    // Act
-    Strategy strategy = factory.createStrategy(SERIES, params);
-
-    // Assert
-    assertThat(strategy).isNotNull();
-  }
-
-  @Test
-  void createStrategy_shortEmaPeriodZero_throwsIllegalArgumentException() {
-    // Arrange
-    DoubleEmaCrossoverParameters params =
-        DoubleEmaCrossoverParameters.newBuilder().setShortEmaPeriod(0).setLongEmaPeriod(10).build();
-
-    // Act
-    Throwable thrown =
-        assertThrows(IllegalArgumentException.class, () -> factory.createStrategy(SERIES, params));
-
-    // Assert
-    assertThat(thrown).hasMessageThat().contains("shortEmaPeriod");
-  }
-
-  @Test
-  void createStrategy_shortEmaPeriodNegative_throwsIllegalArgumentException() {
-    // Arrange
-    DoubleEmaCrossoverParameters params =
-        DoubleEmaCrossoverParameters.newBuilder().setShortEmaPeriod(-1).setLongEmaPeriod(10).build();
-
-    // Act
-    Throwable thrown =
-        assertThrows(IllegalArgumentException.class, () -> factory.createStrategy(SERIES, params));
-
-    // Assert
-    assertThat(thrown).hasMessageThat().contains("shortEmaPeriod");
-  }
-
-  @Test
-  void createStrategy_longEmaPeriodZero_throwsIllegalArgumentException() {
-    // Arrange
-    DoubleEmaCrossoverParameters params =
-        DoubleEmaCrossoverParameters.newBuilder().setShortEmaPeriod(5).setLongEmaPeriod(0).build();
-
-    // Act
-    Throwable thrown =
-        assertThrows(IllegalArgumentException.class, () -> factory.createStrategy(SERIES, params));
-
-    // Assert
-    assertThat(thrown).hasMessageThat().contains("longEmaPeriod");
-  }
-
-  @Test
-  void createStrategy_longEmaPeriodNegative_throwsIllegalArgumentException() {
-    // Arrange
-    DoubleEmaCrossoverParameters params =
-        DoubleEmaCrossoverParameters.newBuilder().setShortEmaPeriod(5).setLongEmaPeriod(-1).build();
-
-    // Act
-    Throwable thrown =
-        assertThrows(IllegalArgumentException.class, () -> factory.createStrategy(SERIES, params));
-
-    // Assert
-    assertThat(thrown).hasMessageThat().contains("longEmaPeriod");
-  }
-
-  @Test
-  void createStrategy_longEmaPeriodLessThanOrEqualToShortEmaPeriod_throwsIllegalArgumentException() {
-    // Arrange
-    DoubleEmaCrossoverParameters params =
-        DoubleEmaCrossoverParameters.newBuilder().setShortEmaPeriod(10).setLongEmaPeriod(10).build();
-
-    // Act
-    Throwable thrown =
-        assertThrows(IllegalArgumentException.class, () -> factory.createStrategy(SERIES, params));
-
-    // Assert
-    assertThat(thrown)
-        .hasMessageThat()
-        .contains("longEmaPeriod must be greater than shortEmaPeriod");
-  }
-
-  @Test
-  void getStrategyType_returnsDoubleEmaCrossover() {
-    // Arrange (no specific arrangement needed)
-
-    // Act
+  public void getStrategyType_returnsCorrectType() {
+    // Arrange & Act
     StrategyType strategyType = factory.getStrategyType();
 
     // Assert
     assertThat(strategyType).isEqualTo(StrategyType.DOUBLE_EMA_CROSSOVER);
   }
 
-  private static BarSeries newBarSeries() {
+  @Test
+  public void createStrategy_entryRule_isCrossedUpIndicatorRule()
+      throws InvalidProtocolBufferException {
+    // Arrange
+    DoubleEmaCrossoverParameters params = DoubleEmaCrossoverParameters.newBuilder()
+        .setShortEmaPeriod(5)
+        .setLongEmaPeriod(20)
+        .build();
+    BarSeries series = createTestBarSeries();
+
+    // Act
+    Strategy strategy = factory.createStrategy(series, params);
+
+    // Assert
+    // We can still verify the type of the entry rule
+    assertThat(strategy.getEntryRule()).isInstanceOf(CrossedUpIndicatorRule.class);
+  }
+
+  @Test
+  public void createStrategy_exitRule_isCrossedDownIndicatorRule()
+      throws InvalidProtocolBufferException {
+    // Arrange
+    DoubleEmaCrossoverParameters params = DoubleEmaCrossoverParameters.newBuilder()
+        .setShortEmaPeriod(5)
+        .setLongEmaPeriod(20)
+        .build();
+    BarSeries series = createTestBarSeries();
+
+    // Act
+    Strategy strategy = factory.createStrategy(series, params);
+
+    // Assert
+    assertThat(strategy.getExitRule()).isInstanceOf(CrossedDownIndicatorRule.class);
+  }
+
+  /**
+   * A more functional test verifying that the entry rule is satisfied at the correct index after
+   * short EMA crosses above long EMA.
+   *
+   * Note: This requires creating a BarSeries that actually triggers a cross-up if shortEmaPeriod <
+   * longEmaPeriod.
+   */
+  @Test
+  public void createStrategy_entryRule_triggersOnShortEmaCrossUp()
+      throws InvalidProtocolBufferException {
+    // Arrange
+     DoubleEmaCrossoverParameters params = DoubleEmaCrossoverParameters.newBuilder()
+         // Use smaller periods so the crossover can happen quickly
+         .setShortEmaPeriod(2)
+         .setLongEmaPeriod(3)
+         .build();
+
+     // This series (below) is engineered so that around the last bar,
+     // the short EMA (2) crosses above the long EMA (3) at index 3.
+     BarSeries series = createCrossUpSeries();
+    Strategy strategy = factory.createStrategy(series, params);
+
+    // Act & Assert
+    // We'll test that the entry rule becomes true at some bar
+    boolean entrySatisfiedAtIndex = false;
+    for (int i = series.getBeginIndex(); i <= series.getEndIndex(); i++) {
+      if (strategy.getEntryRule().isSatisfied(i)) {
+        entrySatisfiedAtIndex = true;
+        break;
+      }
+    }
+    // Because we've engineered the data to cross, we expect at least one bar to trigger
+    assertThat(entrySatisfiedAtIndex).isTrue();
+  }
+
+  /**
+   * A more functional test verifying that the exit rule is satisfied at the correct index after short
+   * EMA crosses below long EMA.
+   */
+  @Test
+  public void createStrategy_exitRule_triggersOnShortEmaCrossDown()
+      throws InvalidProtocolBufferException {
+    // Arrange
+    DoubleEmaCrossoverParameters params = DoubleEmaCrossoverParameters.newBuilder()
+        .setShortEmaPeriod(2)
+        .setLongEmaPeriod(3)
+        .build();
+
+    BarSeries series = createCrossDownSeries();
+    Strategy strategy = factory.createStrategy(series, params);
+
+    // Act & Assert
+    // We'll test that the exit rule becomes true at some bar
+    boolean exitSatisfiedAtIndex = false;
+    for (int i = series.getBeginIndex(); i <= series.getEndIndex(); i++) {
+      if (strategy.getExitRule().isSatisfied(i)) {
+        exitSatisfiedAtIndex = true;
+        break;
+      }
+    }
+
+    // Debugging Output:
+    ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
+    EMAIndicator shortEma = new EMAIndicator(closePrice, params.getShortEmaPeriod());
+    EMAIndicator longEma = new EMAIndicator(closePrice, params.getLongEmaPeriod());
+    for (int i = 0; i <= series.getEndIndex(); i++) {
+      System.out.println(
+          "Index: " + i + ", Short EMA: " + shortEma.getValue(i) + ", Long EMA: " + longEma.getValue(i));
+    }
+
+    assertThat(exitSatisfiedAtIndex).isTrue();
+  }
+
+  private BarSeries createTestBarSeries() {
     BarSeries series = new BaseBarSeries();
     ZonedDateTime now = ZonedDateTime.now();
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.minusMinutes(2), 10, 12, 8, 11));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.minusMinutes(1), 11, 13, 9, 12));
+
+    // With newer TA4j, we must supply (Duration, endTime, open, high, low, close, volume)
+    // Below is just an example with arbitrary values
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(1),
+        10.0, 12.0, 8.0, 11.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(2),
+        11.0, 13.0, 9.0, 12.0, 120.0));
+
+    return series;
+  }
+
+  /**
+   * Series designed so that short EMA crosses up the long EMA. The short period is 2, and the long
+   * is 3, so around the last bar the short EMA rises above the long.
+   *
+   * Crossover is expected at index 3.
+   */
+  private BarSeries createCrossUpSeries() {
+    BarSeries series = new BaseBarSeries();
+
+    ZonedDateTime now = ZonedDateTime.now();
+
+    // For the first few bars, keep the close price steady or slightly decreasing
+    // Then spike upward so that short EMA crosses above the long EMA
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(1),
+        10.0, 10.0, 10.0, 10.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(2),
+        10.0, 10.0, 10.0, 10.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(3),
+        9.5,  9.5,  9.0,  9.0,  100.0));
+    // Big jump
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(4),
+        10.0, 15.0, 10.0, 15.0, 100.0));
+
+    return series;
+  }
+
+  private BarSeries createCrossDownSeries() {
+    BarSeries series = new BaseBarSeries();
+    // The crossover is expected at index 6.
+    ZonedDateTime now = ZonedDateTime.now();
+
+    // 1) Start with some higher values to ensure short EMA > long EMA initially.
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(1), 18.0, 18.0, 18.0, 18.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(2), 17.0, 17.0, 17.0, 17.0, 100.0));
+
+    // 2) Gradually decrease further, so short EMA crosses below.
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(3), 16.0, 16.0, 16.0, 16.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(4), 14.0, 14.0, 14.0, 14.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(5), 12.0, 12.0, 12.0, 12.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(6), 10.0, 10.0, 10.0, 10.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(7), 8.0, 8.0, 8.0, 8.0, 100.0));
+
     return series;
   }
 }

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -26,9 +26,11 @@ import org.ta4j.core.backtest.BarSeriesManager;
 
 @RunWith(JUnit4.class)
 public class DoubleEmaCrossoverStrategyFactoryTest {
-
   private static final Logger logger =
       Logger.getLogger(DoubleEmaCrossoverStrategyFactoryTest.class.getName());
+
+  private static final int SHORT_EMA = 3;
+  private static final int LONG_EMA = 7;
 
   @Inject private DoubleEmaCrossoverStrategyFactory factory;
 
@@ -53,7 +55,11 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
       throws InvalidProtocolBufferException {
     logger.info("Executing createStrategy_entryRule_triggersOnShortEmaCrossUp test...");
     DoubleEmaCrossoverParameters params =
-        DoubleEmaCrossoverParameters.newBuilder().setShortEmaPeriod(2).setLongEmaPeriod(3).build();
+        DoubleEmaCrossoverParameters
+          .newBuilder()
+          .setShortEmaPeriod(SHORT_EMA)
+          .setLongEmaPeriod(LONG_EMA)
+          .build();
     logger.log(Level.FINE, "Parameters for short/long EMA: {0}", params);
 
     BarSeries series = createCrossUpSeries();
@@ -75,7 +81,12 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
       throws InvalidProtocolBufferException {
     logger.info("Executing createStrategy_exitRule_triggersOnShortEmaCrossDown test...");
     DoubleEmaCrossoverParameters params =
-        DoubleEmaCrossoverParameters.newBuilder().setShortEmaPeriod(2).setLongEmaPeriod(3).build();
+    DoubleEmaCrossoverParameters params =
+        DoubleEmaCrossoverParameters
+          .newBuilder()
+          .setShortEmaPeriod(SHORT_EMA)
+          .setLongEmaPeriod(LONG_EMA)
+          .build();
     logger.log(Level.FINE, "Parameters for short/long EMA: {0}", params);
 
     BarSeries series = createCrossDownSeries();

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -30,8 +30,8 @@ import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 public class DoubleEmaCrossoverStrategyFactoryTest {
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
-  private static final int SHORT_EMA = 2;
-  private static final int LONG_EMA = 5;
+  private static final int SHORT_EMA = 3;
+  private static final int LONG_EMA = 7;
 
   @Inject private DoubleEmaCrossoverStrategyFactory factory;
 

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -147,8 +147,17 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
   
   
       // Act & Assert
-      boolean lastBarExitSatisfied = strategy.getExitRule().isSatisfied(lastBarIndex);
+      // We'll test that the exit rule becomes true at some bar
       assertThat(lastBarExitSatisfied).isTrue();
+      boolean anyExitSatisfied = false;
+      for (int i = series.getBeginIndex(); i <= series.getEndIndex(); i++) {
+        if (strategy.getExitRule().isSatisfied(i)) {
+          anyExitSatisfied = true;
+          break;
+        }
+      }
+
+      assertThat(anyExitSatisfied).isTrue();
   }
 
   private BarSeries createTestBarSeries() {

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -192,21 +192,25 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
   }
 
   private BarSeries createCrossDownSeries() {
-    BarSeries series = new BaseBarSeries();
-    // The crossover is expected at index 6.
-    ZonedDateTime now = ZonedDateTime.now();
-
-    // 1) Start with some higher values to ensure short EMA > long EMA initially.
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(1), 18.0, 18.0, 18.0, 18.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(2), 17.0, 17.0, 17.0, 17.0, 100.0));
-
-    // 2) Gradually decrease further, so short EMA crosses below.
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(3), 16.0, 16.0, 16.0, 16.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(4), 14.0, 14.0, 14.0, 14.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(5), 12.0, 12.0, 12.0, 12.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(6), 10.0, 10.0, 10.0, 10.0, 100.0));
-    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(7), 8.0, 8.0, 8.0, 8.0, 100.0));
-
-    return series;
+      BarSeries series = new BaseBarSeries();
+      ZonedDateTime now = ZonedDateTime.now();
+  
+      // Start with very high values to ensure short EMA starts above long EMA
+      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(1), 
+          25.0, 25.0, 25.0, 25.0, 100.0));
+      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(2), 
+          24.0, 24.0, 24.0, 24.0, 100.0));
+          
+      // Then sharp decline to force crossover
+      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(3), 
+          15.0, 15.0, 15.0, 15.0, 100.0));
+      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(4), 
+          10.0, 10.0, 10.0, 10.0, 100.0));
+      
+      // Continue lower to maintain short EMA below long EMA
+      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(5), 
+          8.0, 8.0, 8.0, 8.0, 100.0));
+  
+      return series;
   }
 }

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -21,10 +21,6 @@ import org.ta4j.core.Position;
 import org.ta4j.core.Strategy;
 import org.ta4j.core.TradingRecord;
 import org.ta4j.core.backtest.BarSeriesManager;
-import org.ta4j.core.indicators.EMAIndicator;
-import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
-import org.ta4j.core.rules.CrossedDownIndicatorRule;
-import org.ta4j.core.rules.CrossedUpIndicatorRule;
 
 @RunWith(JUnit4.class)
 public class DoubleEmaCrossoverStrategyFactoryTest {
@@ -38,165 +34,79 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
 
   @Test
   public void getStrategyType_returnsCorrectType() {
-    // Arrange & Act
     StrategyType strategyType = factory.getStrategyType();
-
-    // Assert
     assertThat(strategyType).isEqualTo(StrategyType.DOUBLE_EMA_CROSSOVER);
   }
 
   @Test
-  public void createStrategy_entryRule_isCrossedUpIndicatorRule()
-      throws InvalidProtocolBufferException {
-    // Arrange
-    DoubleEmaCrossoverParameters params =
-        DoubleEmaCrossoverParameters.newBuilder().setShortEmaPeriod(5).setLongEmaPeriod(20).build();
-    BarSeries series = createTestBarSeries();
-
-    // Act
-    Strategy strategy = factory.createStrategy(series, params);
-
-    // Assert
-    // We can still verify the type of the entry rule
-    assertThat(strategy.getEntryRule()).isInstanceOf(CrossedUpIndicatorRule.class);
-  }
-
-  @Test
-  public void createStrategy_exitRule_isCrossedDownIndicatorRule()
-      throws InvalidProtocolBufferException {
-    // Arrange
-    DoubleEmaCrossoverParameters params =
-        DoubleEmaCrossoverParameters.newBuilder().setShortEmaPeriod(5).setLongEmaPeriod(20).build();
-    BarSeries series = createTestBarSeries();
-
-    // Act
-    Strategy strategy = factory.createStrategy(series, params);
-
-    // Assert
-    assertThat(strategy.getExitRule()).isInstanceOf(CrossedDownIndicatorRule.class);
-  }
-
-  /**
-   * A more functional test verifying that the entry rule is satisfied at the correct index after
-   * short EMA crosses above long EMA.
-   *
-   * <p>Note: This requires creating a BarSeries that actually triggers a cross-up if shortEmaPeriod <
-   * longEmaPeriod.
-   */
-  @Test
   public void createStrategy_entryRule_triggersOnShortEmaCrossUp()
       throws InvalidProtocolBufferException {
-    // Arrange
     DoubleEmaCrossoverParameters params =
-        DoubleEmaCrossoverParameters.newBuilder()
-            // Use smaller periods so the crossover can happen quickly
-            .setShortEmaPeriod(2)
-            .setLongEmaPeriod(3)
-            .build();
-
-    // This series (below) is engineered so that around the last bar,
-    // the short EMA (2) crosses above the long EMA (3) at index 3.
+        DoubleEmaCrossoverParameters.newBuilder().setShortEmaPeriod(2).setLongEmaPeriod(3).build();
     BarSeries series = createCrossUpSeries();
     Strategy strategy = factory.createStrategy(series, params);
-
-    // Act & Assert
-    // We'll test that the entry rule becomes true at some bar
-    boolean entrySatisfiedAtIndex = false;
-    for (int i = series.getBeginIndex(); i <= series.getEndIndex(); i++) {
-      if (strategy.getEntryRule().isSatisfied(i)) {
-        entrySatisfiedAtIndex = true;
-        break;
-      }
-    }
-    // Because we've engineered the data to cross, we expect at least one bar to trigger
-    assertThat(entrySatisfiedAtIndex).isTrue();
+    BarSeriesManager manager = new BarSeriesManager(series);
+    TradingRecord tradingRecord = manager.run(strategy);
+    
+    assertThat(tradingRecord.getPositionCount()).isGreaterThan(0);
   }
 
-  /**
-   * A more functional test verifying that the exit rule is satisfied at the correct index after short
-   * EMA crosses below long EMA.
-   */
   @Test
   public void createStrategy_exitRule_triggersOnShortEmaCrossDown()
       throws InvalidProtocolBufferException {
-    // Arrange
     DoubleEmaCrossoverParameters params =
         DoubleEmaCrossoverParameters.newBuilder().setShortEmaPeriod(2).setLongEmaPeriod(3).build();
     BarSeries series = createCrossDownSeries();
 
-    // Act
     Strategy strategy = factory.createStrategy(series, params);
     BarSeriesManager manager = new BarSeriesManager(series);
     TradingRecord tradingRecord = manager.run(strategy);
 
-    // Assert
-    // Should enter position when short EMA crosses above long EMA
-    // and exit when it crosses below
     assertThat(tradingRecord.getPositionCount()).isEqualTo(1);
     Position position = tradingRecord.getPositions().get(0);
     assertThat(position.getEntry().getIndex()).isLessThan(position.getExit().getIndex());
-  }
-
-  private BarSeries createTestBarSeries() {
-    BarSeries series = new BaseBarSeries();
-    ZonedDateTime now = ZonedDateTime.now();
-
-    // With newer TA4j, we must supply (Duration, endTime, open, high, low, close, volume)
-    // Below is just an example with arbitrary values
-    series.addBar(
-        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(1), 10.0, 12.0, 8.0, 11.0, 100.0));
-    series.addBar(
-        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(2), 11.0, 13.0, 9.0, 12.0, 120.0));
-
-    return series;
-  }
-
-  /**
-   * Series designed so that short EMA crosses up the long EMA. The short period is 2, and the long
-   * is 3, so around the last bar the short EMA rises above the long.
-   *
-   * <p>Crossover is expected at index 3.
-   */
-  private BarSeries createCrossUpSeries() {
-    BarSeries series = new BaseBarSeries();
-
-    ZonedDateTime now = ZonedDateTime.now();
-
-    // For the first few bars, keep the close price steady or slightly decreasing
-    // Then spike upward so that short EMA crosses above the long EMA
-    series.addBar(
-        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(1), 10.0, 10.0, 10.0, 10.0, 100.0));
-    series.addBar(
-        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(2), 10.0, 10.0, 10.0, 10.0, 100.0));
-    series.addBar(
-        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(3), 9.5, 9.5, 9.0, 9.0, 100.0));
-    // Big jump
-    series.addBar(
-        new BaseBar(Duration.ofMinutes(1), now.plusMinutes(4), 10.0, 15.0, 10.0, 15.0, 100.0));
-
-    return series;
   }
 
   private BarSeries createCrossDownSeries() {
       BarSeries series = new BaseBarSeries();
       ZonedDateTime now = ZonedDateTime.now();
 
-      // Initial steady price to establish baseline EMAs (3+ bars for stability)
-      series.addBar(new BaseBar(Duration.ofMinutes(1), now, 10.0, 10.0, 10.0, 10.0, 100.0));
-      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(1), 10.0, 10.0, 10.0, 10.0, 100.0));
-      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(2), 10.0, 10.0, 10.0, 10.0, 100.0));
-      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(3), 10.0, 10.0, 10.0, 10.0, 100.0));
+      // Establish a baseline with steady low price
+      for (int i = 0; i < 5; i++) {
+          series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(i), 10.0, 10.0, 10.0, 10.0, 100.0));
+      }
 
-      // Strong upward movement to get short EMA above long EMA
-      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(4), 20.0, 20.0, 20.0, 20.0, 100.0));
-      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(5), 25.0, 25.0, 25.0, 25.0, 100.0));
-      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(6), 30.0, 30.0, 30.0, 30.0, 100.0));
+      // Sharp upward movement to trigger short EMA crossing above long EMA
+      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(5), 20.0, 20.0, 20.0, 20.0, 100.0));
+      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(6), 25.0, 25.0, 25.0, 25.0, 100.0));
+      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(7), 30.0, 30.0, 30.0, 30.0, 100.0));
+      
+      // Hold at higher level briefly
+      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(8), 30.0, 30.0, 30.0, 30.0, 100.0));
+      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(9), 30.0, 30.0, 30.0, 30.0, 100.0));
 
       // Sharp decline to trigger short EMA crossing below long EMA
-      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(7), 15.0, 15.0, 15.0, 15.0, 100.0));
-      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(8), 10.0, 10.0, 10.0, 10.0, 100.0));
-      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(9), 5.0, 5.0, 5.0, 5.0, 100.0));
+      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(10), 15.0, 15.0, 15.0, 15.0, 100.0));
+      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(11), 10.0, 10.0, 10.0, 10.0, 100.0));
+      series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(12), 5.0, 5.0, 5.0, 5.0, 100.0));
 
       return series;
+  }
+
+  private BarSeries createCrossUpSeries() {
+    BarSeries series = new BaseBarSeries();
+    ZonedDateTime now = ZonedDateTime.now();
+
+    // Start with steady prices to establish baseline EMAs
+    for (int i = 0; i < 5; i++) {
+        series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(i), 10.0, 10.0, 10.0, 10.0, 100.0));
+    }
+
+    // Sharp upward movement to trigger cross up
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(5), 15.0, 15.0, 15.0, 15.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(6), 20.0, 20.0, 20.0, 20.0, 100.0));
+    series.addBar(new BaseBar(Duration.ofMinutes(1), now.plusMinutes(7), 25.0, 25.0, 25.0, 25.0, 100.0));
+
+    return series;
   }
 }

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -18,6 +18,8 @@ import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseBar;
 import org.ta4j.core.BaseBarSeries;
 import org.ta4j.core.Strategy;
+import org.ta4j.core.indicators.EMAIndicator;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.rules.CrossedDownIndicatorRule;
 import org.ta4j.core.rules.CrossedUpIndicatorRule;
 


### PR DESCRIPTION
This PR introduces the `DoubleEmaCrossoverStrategyFactory` for creating Double EMA Crossover strategies using Ta4j. The implementation defines strategy rules based on EMA crossovers. 

Key Changes:
1. Added `DoubleEmaCrossoverStrategyFactory` under `strategies/movingaverages`.
2. Implemented a comprehensive test suite for the factory, including:
   - Verification of entry and exit rules.
   - Functional tests with engineered BarSeries to trigger crossovers.
3. Updated Bazel `BUILD` files for the new library and test dependencies. 

This enhancement aligns with the modular design of the strategies module.