### PR TITLE
Update `StrategyFactory` to Include BarSeries Parameter

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
@@ -6,6 +6,7 @@ import com.google.protobuf.Message;
 import com.verlumen.tradestream.strategies.StrategyType;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import org.ta4j.core.BarSeries;
 import org.ta4j.core.Strategy;
 
 interface StrategyFactory<T extends Message> {
@@ -16,7 +17,7 @@ interface StrategyFactory<T extends Message> {
    * @return Strategy object
    * @throws InvalidProtocolBufferException If there is an error when unpacking the `Any` type
    */
-  Strategy createStrategy(T parameters) throws InvalidProtocolBufferException;
+  Strategy createStrategy(BarSeries series, T parameters) throws InvalidProtocolBufferException;
 
   /**
    * Creates a Ta4j Strategy object from the provided parameters
@@ -25,7 +26,7 @@ interface StrategyFactory<T extends Message> {
    * @return Strategy object
    * @throws InvalidProtocolBufferException If there is an error when unpacking the `Any` type
    */
-  default Strategy createStrategy(Any parameters) throws InvalidProtocolBufferException {
+  default Strategy createStrategy(BarSeries series, Any parameters) throws InvalidProtocolBufferException {
     return createStrategy(parameters.unpack(getParameterClass()));
   }
 

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
@@ -9,38 +9,50 @@ import java.lang.reflect.Type;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Strategy;
 
-interface StrategyFactory<T extends Message> {
+/**
+ * A factory interface for creating {@link Strategy} instances from provided parameters.
+ * Implementations of this interface are responsible for instantiating a specific type of
+ * trading strategy based on configuration data, often represented as a Protocol Buffer message.
+ *
+ * @param <T> The specific type of {@link Message} that holds the parameters for the strategy.
+ */
+public interface StrategyFactory<T extends Message> {
   /**
-   * Creates a Ta4j Strategy object from the provided parameters
+   * Creates a Ta4j Strategy object from the provided {@link BarSeries} and parameters.
    *
-   * @param parameters the parameters for the strategy
-   * @return Strategy object
-   * @throws InvalidProtocolBufferException If there is an error when unpacking the `Any` type
+   * @param series     The {@link BarSeries} to associate with the created strategy.
+   * @param parameters The parameters for configuring the strategy.
+   * @return The created {@link Strategy} object.
+   * @throws InvalidProtocolBufferException If there is an error when unpacking the parameters.
    */
   Strategy createStrategy(BarSeries series, T parameters) throws InvalidProtocolBufferException;
 
   /**
-   * Creates a Ta4j Strategy object from the provided parameters
+   * Creates a Ta4j Strategy object from the provided {@link BarSeries} and parameters.
+   * This is a convenience method that unpacks the parameters from an {@link Any} message
+   * before invoking {@link #createStrategy(BarSeries, Message)}.
    *
-   * @param parameters the parameters for the strategy in an Any
-   * @return Strategy object
-   * @throws InvalidProtocolBufferException If there is an error when unpacking the `Any` type
+   * @param series     The {@link BarSeries} to associate with the created strategy.
+   * @param parameters The parameters for the strategy wrapped in an {@link Any} message.
+   * @return The created {@link Strategy} object.
+   * @throws InvalidProtocolBufferException If there is an error when unpacking the {@link Any} message.
    */
   default Strategy createStrategy(BarSeries series, Any parameters) throws InvalidProtocolBufferException {
-    return createStrategy(parameters.unpack(getParameterClass()));
+    return createStrategy(series, parameters.unpack(getParameterClass()));
   }
 
   /**
-   * Gets the `StrategyType` this factory handles.
+   * Gets the {@link StrategyType} that this factory handles.
    *
-   * @return The StrategyType this factory handles.
+   * @return The {@link StrategyType} this factory is responsible for creating.
    */
   StrategyType getStrategyType();
 
   /**
-   * Returns the Class that this strategy unpacks the parameters into
+   * Returns the {@link Class} of the parameter message that this strategy factory uses.
+   * This is determined using reflection on the generic type parameter of the interface.
    *
-   * @return the Class that this factory unpacks `Any` into.
+   * @return The {@link Class} that this factory unpacks {@link Any} into.
    */
   default Class<T> getParameterClass() {
     Type genericSuperclass = getClass().getGenericInterfaces()[0];


### PR DESCRIPTION
Refactored the `StrategyFactory` interface to include `BarSeries` as a parameter for strategy creation:

- Added a `BarSeries` parameter to the `createStrategy` methods for better integration with Ta4j's data requirements.
- Updated the default `createStrategy(Any parameters)` method to delegate to the new method with `BarSeries`.
- Enhanced JavaDocs for better clarity, explaining the purpose and usage of the interface and its methods.

This change improves flexibility and aligns with the Ta4j library's design patterns, enabling more robust strategy implementations.