### PR TITLE
Add Rule-Based Strategy Creation to `StrategyFactory`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
@@ -7,6 +7,8 @@ import com.verlumen.tradestream.strategies.StrategyType;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseStrategy;
+import org.ta4j.core.Rule;
 import org.ta4j.core.Strategy;
 
 /**
@@ -41,6 +43,17 @@ public interface StrategyFactory<T extends Message> {
     return createStrategy(series, parameters.unpack(getParameterClass()));
   }
 
+  /**
+   * Creates a Ta4j Strategy object from the provided {@link Rule} and {@link Rule}.
+   *
+   * @param entryRule     The {@link Rule} that signals an entry into a position.
+   * @param exitRule The {@link Rule} that signals an exit from a position.
+   * @return The created {@link Strategy} object.
+   */
+  default Strategy createStrategy(BarSeries series, Rule entryRule, Rule exitRule) {
+    return new BaseStrategy(getStrategyType().name(), entryRule, exitRule);
+  }
+  
   /**
    * Gets the {@link StrategyType} that this factory handles.
    *


### PR DESCRIPTION
Enhanced the `StrategyFactory` interface by adding support for creating strategies directly from entry and exit rules:

- Introduced a new default method `createStrategy(BarSeries series, Rule entryRule, Rule exitRule)` that returns a `BaseStrategy`.
- Ensures compatibility with custom strategies by leveraging the Ta4j `Rule` interface.
- Updated documentation for better clarity and usage instructions.

This addition simplifies the process of creating strategies programmatically when entry and exit rules are pre-defined, improving developer productivity and flexibility.