### PR TITLE
 Simplify `createStrategy` Method in `StrategyFactory`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
@@ -50,7 +50,7 @@ public interface StrategyFactory<T extends Message> {
    * @param exitRule The {@link Rule} that signals an exit from a position.
    * @return The created {@link Strategy} object.
    */
-  default Strategy createStrategy(BarSeries series, Rule entryRule, Rule exitRule) {
+  default Strategy createStrategy(Rule entryRule, Rule exitRule) {
     return new BaseStrategy(getStrategyType().name(), entryRule, exitRule);
   }
   


### PR DESCRIPTION
This PR refines the `createStrategy` method in the `StrategyFactory` interface. The `BarSeries` parameter was removed from the method signature as it was unnecessary for the creation of a `BaseStrategy` instance. The updated method now focuses solely on the `Rule` objects for entry and exit signals, improving clarity and reducing redundancy in the API.