### PR TITLE
feat: Add `unstableBars` parameter to `createStrategy` and improve Javadoc

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
@@ -44,14 +44,15 @@ public interface StrategyFactory<T extends Message> {
   }
 
   /**
-   * Creates a Ta4j Strategy object from the provided {@link Rule} and {@link Rule}.
+   * Creates a Ta4j Strategy object from the provided entry and exit rules.
    *
-   * @param entryRule     The {@link Rule} that signals an entry into a position.
-   * @param exitRule The {@link Rule} that signals an exit from a position.
-   * @return The created {@link Strategy} object.
+   * @param entryRule     The {@link Rule} that triggers the opening of a new position.
+   * @param exitRule      The {@link Rule} that triggers the closing of an existing position.
+   * @param unstableBars The number of initial bars to ignore when evaluating the strategy. This helps to avoid early, possibly misleading, signals.
+   * @return The newly created {@link Strategy} object.
    */
-  default Strategy createStrategy(Rule entryRule, Rule exitRule) {
-    return new BaseStrategy(getStrategyType().name(), entryRule, exitRule);
+  default Strategy createStrategy(Rule entryRule, Rule exitRule, int unstableBars) {
+    return new BaseStrategy(getStrategyType().name(), entryRule, exitRule, unstableBars);
   }
   
   /**


### PR DESCRIPTION
This commit introduces a new `unstableBars` parameter to the `createStrategy` method in the `StrategyFactory` interface.

The `unstableBars` parameter allows specifying the number of initial bars to ignore when evaluating the strategy, helping to avoid potentially misleading early signals.

Additionally, the Javadoc for the `createStrategy` method has been improved to provide clearer explanations for all parameters:

- `entryRule`: Clarified as the rule triggering the opening of a position.
- `exitRule`: Clarified as the rule triggering the closing of a position.
- `unstableBars`: Documented the purpose of ignoring initial bars.

These changes enhance the flexibility and understandability of strategy creation.