### PR TITLE
Add Strategy Engine to CI Workflow with Helm Integration  

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,28 +65,20 @@ jobs:
             --repository localhost:5000/tradestream-strategy-engine \
             --tag "latest"
 
-      - name: Pull the Data Ingestion Image into Local Docker Daemon
+      - name: Pull Images into Local Docker Daemon
         run: |
-          # Pull the image from the local registry into the local Docker daemon
+          # Pull the images from the local registry into the local Docker daemon
           docker pull localhost:5000/tradestream-data-ingestion:latest
-          # Retag the image to remove the registry prefix, so Kubernetes doesn't try to pull it remotely
-          docker tag localhost:5000/tradestream-data-ingestion:latest tradestream-data-ingestion:latest
-
-      - name: Pull the Strategy Engine Image into Local Docker Daemon
-        run: |
-          # Pull the image from the local registry into the local Docker daemon
           docker pull localhost:5000/tradestream-strategy-engine:latest
-          # Retag the image to remove the registry prefix, so Kubernetes doesn't try to pull it remotely
+
+          # Retag the images to remove the registry prefix, so Kubernetes doesn't try to pull them remotely
+          docker tag localhost:5000/tradestream-data-ingestion:latest tradestream-data-ingestion:latest
           docker tag localhost:5000/tradestream-strategy-engine:latest tradestream-strategy-engine:latest
 
-      - name: Load Data Ingestion Image into Minikube
+      - name: Load Images into Minikube
         run: |
-          # Load the retagged image (tradestream-data-ingestion:latest) into Minikube's image cache
+          # Load the retagged images into Minikube's image cache
           minikube image load tradestream-data-ingestion:latest
-
-      - name: Load Strategy Engine Image into Minikube
-        run: |
-          # Load the retagged image (tradestream-strategy-engine:latest) into Minikube's image cache
           minikube image load tradestream-strategy-engine:latest
 
       - name: Install TradeStream Helm Chart

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,7 +86,10 @@ jobs:
           helm dependency update charts/tradestream && \
           helm install my-tradestream charts/tradestream \
             --namespace tradestream-namespace \
-            --set dataIngestion.image.repository=tradestream-data-ingestion \
+            --set strategyEngine.image.repository=tradestream-strategy-engine \
+            --set strategyEngine.image.tag=latest \
+            --set 'strategyEngine.args[0]=--runMode=dry' \
+            --set dataIngestion.image.repository=tradestream-strategy-engine \
             --set dataIngestion.image.tag=latest \
             --set 'dataIngestion.args[0]=--runMode=dry'
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,17 +65,29 @@ jobs:
             --repository localhost:5000/tradestream-strategy-engine \
             --tag "latest"
 
-      - name: Pull Image into Local Docker Daemon
+      - name: Pull the Data Ingestion Image into Local Docker Daemon
         run: |
           # Pull the image from the local registry into the local Docker daemon
           docker pull localhost:5000/tradestream-data-ingestion:latest
           # Retag the image to remove the registry prefix, so Kubernetes doesn't try to pull it remotely
           docker tag localhost:5000/tradestream-data-ingestion:latest tradestream-data-ingestion:latest
 
-      - name: Load Image into Minikube
+      - name: Pull the Strategy Engine Image into Local Docker Daemon
+        run: |
+          # Pull the image from the local registry into the local Docker daemon
+          docker pull localhost:5000/tradestream-strategy-engine:latest
+          # Retag the image to remove the registry prefix, so Kubernetes doesn't try to pull it remotely
+          docker tag localhost:5000/tradestream-strategy-engine:latest tradestream-strategy-engine:latest
+
+      - name: Load Data Ingestion Image into Minikube
         run: |
           # Load the retagged image (tradestream-data-ingestion:latest) into Minikube's image cache
           minikube image load tradestream-data-ingestion:latest
+
+      - name: Load Strategy Engine Image into Minikube
+        run: |
+          # Load the retagged image (tradestream-strategy-engine:latest) into Minikube's image cache
+          minikube image load tradestream-strategy-engine:latest
 
       - name: Install TradeStream Helm Chart
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,7 +89,7 @@ jobs:
             --set strategyEngine.image.repository=tradestream-strategy-engine \
             --set strategyEngine.image.tag=latest \
             --set 'strategyEngine.args[0]=--runMode=dry' \
-            --set dataIngestion.image.repository=tradestream-strategy-engine \
+            --set dataIngestion.image.repository=tradestream-data-ingestion \
             --set dataIngestion.image.tag=latest \
             --set 'dataIngestion.args[0]=--runMode=dry'
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,6 +55,16 @@ jobs:
             --repository localhost:5000/tradestream-data-ingestion \
             --tag "latest"
 
+      - name: Build and Push the Strategy Engine Image
+        run: |
+          # Push to local registry
+          bazel run //src/main/java/com/verlumen/tradestream/strategies:push_image \
+            --verbose_failures \
+            --sandbox_debug \
+            -- \
+            --repository localhost:5000/tradestream-strategy-engine \
+            --tag "latest"
+
       - name: Pull Image into Local Docker Daemon
         run: |
           # Pull the image from the local registry into the local Docker daemon


### PR DESCRIPTION
This PR updates the GitHub Actions CI workflow to integrate the Strategy Engine image into the TradeStream deployment process. It includes building, tagging, pushing, and deploying the Strategy Engine Docker image alongside the existing Data Ingestion image.

### Key Changes:
1. **Build and Push the Strategy Engine Image:**
   - Added steps to build the `Strategy Engine` image using Bazel.
   - Pushed the image to the local registry (`localhost:5000`).

2. **Pull and Retag Images:**
   - Added steps to pull both the `Data Ingestion` and `Strategy Engine` images from the local registry.
   - Retagged images to remove the registry prefix, ensuring compatibility with Minikube's image cache.

3. **Minikube Integration:**
   - Loaded both `Data Ingestion` and `Strategy Engine` images into Minikube's image cache for use in local Kubernetes deployments.

4. **Helm Chart Updates:**
   - Updated the Helm deployment step to include `Strategy Engine` configuration.
   - Set the repository, tag, and runtime arguments for the `Strategy Engine` via Helm values.

### Benefits:
- Streamlines the CI workflow to handle both `Data Ingestion` and `Strategy Engine` images.
- Ensures seamless integration with local Kubernetes environments using Minikube.
- Improves deployment flexibility by enabling runtime argument customization for the `Strategy Engine`.

This update enhances the CI/CD process by integrating the new component, ensuring consistency across builds and deployments.