### PR TITLE
Add Strategy Engine Deployment Template to TradeStream Helm Chart

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,23 +55,40 @@ jobs:
             --repository localhost:5000/tradestream-data-ingestion \
             --tag "latest"
 
-      - name: Pull Image into Local Docker Daemon
+      - name: Build and Push the Strategy Engine Image
         run: |
-          # Pull the image from the local registry into the local Docker daemon
-          docker pull localhost:5000/tradestream-data-ingestion:latest
-          # Retag the image to remove the registry prefix, so Kubernetes doesn't try to pull it remotely
-          docker tag localhost:5000/tradestream-data-ingestion:latest tradestream-data-ingestion:latest
+          # Push to local registry
+          bazel run //src/main/java/com/verlumen/tradestream/strategies:push_image \
+            --verbose_failures \
+            --sandbox_debug \
+            -- \
+            --repository localhost:5000/tradestream-strategy-engine \
+            --tag "latest"
 
-      - name: Load Image into Minikube
+      - name: Pull Images into Local Docker Daemon
         run: |
-          # Load the retagged image (tradestream-data-ingestion:latest) into Minikube's image cache
+          # Pull the images from the local registry into the local Docker daemon
+          docker pull localhost:5000/tradestream-data-ingestion:latest
+          docker pull localhost:5000/tradestream-strategy-engine:latest
+
+          # Retag the images to remove the registry prefix, so Kubernetes doesn't try to pull them remotely
+          docker tag localhost:5000/tradestream-data-ingestion:latest tradestream-data-ingestion:latest
+          docker tag localhost:5000/tradestream-strategy-engine:latest tradestream-strategy-engine:latest
+
+      - name: Load Images into Minikube
+        run: |
+          # Load the retagged images into Minikube's image cache
           minikube image load tradestream-data-ingestion:latest
+          minikube image load tradestream-strategy-engine:latest
 
       - name: Install TradeStream Helm Chart
         run: |
           helm dependency update charts/tradestream && \
           helm install my-tradestream charts/tradestream \
             --namespace tradestream-namespace \
+            --set strategyEngine.image.repository=tradestream-strategy-engine \
+            --set strategyEngine.image.tag=latest \
+            --set 'strategyEngine.args[0]=--runMode=dry' \
             --set dataIngestion.image.repository=tradestream-data-ingestion \
             --set dataIngestion.image.tag=latest \
             --set 'dataIngestion.args[0]=--runMode=dry'

--- a/charts/tradestream/templates/strategy_engine.yaml
+++ b/charts/tradestream/templates/strategy_engine.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "tradestream.fullname" . }}-data-ingestion
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "tradestream.name" . }}
+    component: data-ingestion
+    release: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.dataIngestion.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "tradestream.name" . }}
+      component: data-ingestion
+  template:
+    metadata:
+      labels:
+        app: {{ include "tradestream.name" . }}
+        component: data-ingestion
+    spec:
+      containers:
+        - name: data-ingestion
+          args:
+          {{- range .Values.dataIngestion.args }}
+            - {{ . | quote }}
+          {{- end }}
+            - "--kafka.bootstrap.servers={{ include "tradestream.fullname" . }}-kafka.{{ .Release.Namespace }}.svc.cluster.local:9092"
+
+
+          image: "{{ .Values.dataIngestion.image.repository }}:{{ .Values.dataIngestion.image.tag }}"
+          imagePullPolicy: {{ default "IfNotPresent" .Values.dataIngestion.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.dataIngestion.service.port }}
+          env:
+            - name: COINMARKETCAP_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: coinmarketcap
+                  key: apiKey

--- a/charts/tradestream/templates/strategy_engine.yaml
+++ b/charts/tradestream/templates/strategy_engine.yaml
@@ -1,40 +1,34 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "tradestream.fullname" . }}-data-ingestion
+  name: {{ include "tradestream.fullname" . }}-strategy-engine
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "tradestream.name" . }}
-    component: data-ingestion
+    component: strategy-engine
     release: {{ .Release.Name }}
 spec:
-  replicas: {{ .Values.dataIngestion.replicaCount }}
+  replicas: {{ .Values.strategyEngine.replicaCount }}
   selector:
     matchLabels:
       app: {{ include "tradestream.name" . }}
-      component: data-ingestion
+      component: strategy-engine
   template:
     metadata:
       labels:
         app: {{ include "tradestream.name" . }}
-        component: data-ingestion
+        component: strategy-engine
     spec:
       containers:
-        - name: data-ingestion
+        - name: strategy-engine
           args:
-          {{- range .Values.dataIngestion.args }}
+          {{- range .Values.strategyEngine.args }}
             - {{ . | quote }}
           {{- end }}
             - "--kafka.bootstrap.servers={{ include "tradestream.fullname" . }}-kafka.{{ .Release.Namespace }}.svc.cluster.local:9092"
 
 
-          image: "{{ .Values.dataIngestion.image.repository }}:{{ .Values.dataIngestion.image.tag }}"
-          imagePullPolicy: {{ default "IfNotPresent" .Values.dataIngestion.image.pullPolicy }}
+          image: "{{ .Values.strategyEngine.image.repository }}:{{ .Values.strategyEngine.image.tag }}"
+          imagePullPolicy: {{ default "IfNotPresent" .Values.strategyEngine.image.pullPolicy }}
           ports:
-            - containerPort: {{ .Values.dataIngestion.service.port }}
-          env:
-            - name: COINMARKETCAP_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: coinmarketcap
-                  key: apiKey
+            - containerPort: {{ .Values.strategyEngine.service.port }}

--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -20,10 +20,10 @@ dataIngestion:
   replicaCount: 1
   image:
     repository: "tradestreamhq/tradestream-data-ingestion"
-    tag: "v0.0.367-develop"
+    tag: "v0.0.368-develop"
   service:
     port: 8080
 strategyEngine:
   image:
     repository: "tradestreamhq/tradestream-strategy-engine"
-    tag: "v0.0.367-develop"
+    tag: "v0.0.368-develop"

--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -20,10 +20,10 @@ dataIngestion:
   replicaCount: 1
   image:
     repository: "tradestreamhq/tradestream-data-ingestion"
-    tag: "v0.0.368-develop"
+    tag: "v0.0.367-develop"
   service:
     port: 8080
 strategyEngine:
   image:
     repository: "tradestreamhq/tradestream-strategy-engine"
-    tag: "v0.0.368-develop"
+    tag: "v0.0.367-develop"

--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -27,3 +27,5 @@ strategyEngine:
   image:
     repository: "tradestreamhq/tradestream-strategy-engine"
     tag: "v0.0.367-develop"
+  service:
+    port: 8081


### PR DESCRIPTION
This PR introduces a new deployment configuration for the `Strategy Engine` as part of the TradeStream Helm chart. It adds support for deploying the `Strategy Engine` microservice, allowing for better modularity and configurability within the TradeStream architecture.

---

### **Key Changes**

#### 1. **Deployment Template (`strategy_engine.yaml`)**
   - Introduced a Kubernetes `Deployment` for the `Strategy Engine` component:
     - Configurable replicas via `strategyEngine.replicaCount`.
     - Includes runtime arguments via the `strategyEngine.args` value, allowing seamless customization.
     - Connects to Kafka by dynamically resolving the Kafka service address.
     - Uses configurable image repository, tag, and pull policy.

#### 2. **Values Configuration (`values.yaml`)**
   - Added `strategyEngine` block:
     - `image.repository`: Default image location for the `Strategy Engine`.
     - `image.tag`: Specifies the version/tag to use for deployment.
     - `service.port`: Default port for the service (8081).
   - Parameters can be overridden at runtime for flexibility.

This update ensures the `Strategy Engine` integrates seamlessly into the existing TradeStream deployment pipeline.