### PR TITLE
Refactor Third-Party Library Definitions for Enhanced Modularity and Reusability

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -68,3 +68,52 @@ java_plugin(
         "@maven//:com_ryanharter_auto_value_auto_value_gson",
     ],
 )
+
+java_library(
+    name = "flogger",
+    visibility = ["//visibility:public"],
+    exports = [
+        "@maven//:com_google_flogger_flogger",
+    ],
+)
+
+java_library(
+    name = "flogger_system_backend",
+    neverlink = 1,
+    visibility = ["//visibility:public"],
+    exports = [
+        "@maven//:com_google_flogger_flogger_system_backend",
+    ],
+)
+
+java_library(
+    name = "guava",
+    visibility = ["//visibility:public"],
+    exports = [
+        "@maven//:com_google_guava_guava",
+    ],
+)
+
+java_library(
+    name = "guice",
+    visibility = ["//visibility:public"],
+    exports = [
+        "@maven//:com_google_inject_guice",
+    ],
+)
+
+java_library(
+    name = "guice_assistedinject",
+    visibility = ["//visibility:public"],
+    exports = [
+        "@maven//:com_google_inject_extensions_guice_assistedinject",
+    ],
+)
+
+java_library(
+    name = "kafka_clients",
+    visibility = ["//visibility:public"],
+    exports = [
+        "@maven//:org_apache_kafka_kafka_clients",
+    ],
+)

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -1,4 +1,12 @@
 java_library(
+    name = "argparse4j",
+    visibility = ["//visibility:public"],
+    exports = [
+        "@maven//:net_sourceforge_argparse4j_argparse4j",
+    ],
+)
+
+java_library(
     name = "auto_factory",
     exported_plugins = [
         ":auto_factory_plugin",
@@ -87,6 +95,14 @@ java_library(
 )
 
 java_library(
+    name = "gson",
+    visibility = ["//visibility:public"],
+    exports = [
+        "@maven//:com_google_code_gson_gson",
+    ],
+)
+
+java_library(
     name = "guava",
     visibility = ["//visibility:public"],
     exports = [
@@ -115,5 +131,29 @@ java_library(
     visibility = ["//visibility:public"],
     exports = [
         "@maven//:org_apache_kafka_kafka_clients",
+    ],
+)
+
+java_library(
+    name = "mug",
+    visibility = ["//visibility:public"],
+    exports = [
+        "@maven//:com_google_mug_mug",
+    ],
+)
+
+java_library(
+    name = "xchange_core",
+    visibility = ["//visibility:public"],
+    exports = [
+        "@maven//:org_knowm_xchange_xchange_core",
+    ],
+)
+
+java_library(
+    name = "xchange_stream_core",
+    visibility = ["//visibility:public"],
+    exports = [
+        "@maven//:org_knowm_xchange_xchange_stream_core",
     ],
 )


### PR DESCRIPTION
This PR refactors the `third_party/BUILD` file to modularize and streamline the definitions of frequently used third-party libraries. These changes improve maintainability and enable easier reuse of dependencies across the codebase.

### Key Changes
1. **Modularized Library Definitions**:
   - Extracted commonly used third-party libraries (e.g., `flogger`, `gson`, `guava`, `guice`, `kafka_clients`, etc.) into separate `java_library` targets within the `third_party/BUILD` file.
   - Provided consistent naming and visibility settings for each library.

2. **New Library Targets**:
   - Added `argparse4j` for argument parsing.
   - Added `flogger` and `flogger_system_backend` for structured logging.
   - Added `xchange_core` and `xchange_stream_core` for financial exchange API integration.
   - Defined additional dependencies for `guice`, `guice_assistedinject`, and others.

3. **Visibility and Export Improvements**:
   - Set `//visibility:public` for most libraries to ensure accessibility across all Bazel targets.
   - Used `exports` for clean propagation of Maven artifacts.

4. **Simplified Dependency Management**:
   - Centralized the management of third-party dependencies in the `third_party/BUILD` file.
   - Eliminated redundant declarations in individual `BUILD` files.

### Benefits
- **Improved Modularity**:
  - Each third-party library is encapsulated in its own Bazel target, making the build system more maintainable and scalable.

- **Ease of Reuse**:
  - The new structure enables straightforward reuse of third-party libraries in multiple Bazel targets.

- **Consistency**:
  - The uniform naming conventions and visibility settings reduce confusion and improve readability.

- **Future Proofing**:
  - Changes to library versions or configurations can be made in a single location, reducing maintenance overhead.

### Testing
- Verified that all existing targets build successfully using the updated `third_party/BUILD` definitions.
- Confirmed that dependencies are correctly resolved and propagated to downstream targets.
