### PR TITLE
Add `protobuf_java` and `ta4j_core` to `third_party` Dependencies  

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -142,6 +142,22 @@ java_library(
 )
 
 java_library(
+    name = "protobuf_java",
+    visibility = ["//visibility:public"],
+    exports = [
+        "@maven//:com_google_protobuf_protobuf_java",
+    ],
+)
+
+java_library(
+    name = "ta4j_core",
+    visibility = ["//visibility:public"],
+    exports = [
+        "@maven//:org_ta4j_ta4j_core",
+    ],
+)
+
+java_library(
     name = "xchange_core",
     visibility = ["//visibility:public"],
     exports = [


### PR DESCRIPTION
Introduced `third_party:protobuf_java` and `third_party:ta4j_core` targets to encapsulate `com.google.protobuf` and `org.ta4j.core` Maven dependencies, respectively. These additions improve dependency organization, provide a standardized interface for these libraries, and align with the project's centralized dependency management practices.