### PR TITLE
Migrate `currency_pair` Guava Dependency to `third_party:guava`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/instruments/BUILD
+++ b/src/main/java/com/verlumen/tradestream/instruments/BUILD
@@ -14,8 +14,8 @@ java_library(
     name = "currency_pair",
     srcs = ["CurrencyPair.java"],
     deps = [
-        "@maven//:com_google_guava_guava",
         "//third_party:auto_value",
+        "//third_party:guava",
         ":currency",
     ],
 )


### PR DESCRIPTION
Replaced the direct Maven dependency on `com_google_guava_guava` with the curated `third_party:guava` dependency for the `currency_pair` target in the `BUILD` file. This aligns the dependency management with the project's centralized `third_party` strategy, ensuring consistency and simplifying future updates.