### PR TITLE
Refactor Dependencies for `strategy_*` Targets to Use `third_party`  

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -77,9 +77,9 @@ java_library(
     name = "strategy_factory",
     srcs = ["StrategyFactory.java"],
     deps = [
-        "@maven//:com_google_protobuf_protobuf_java",
-        "@maven//:org_ta4j_ta4j_core",
         "//protos:strategies_java_proto",
+        "//third_party:protobuf_java",
+        "//third_party:ta4j_core",
     ],
 )
 
@@ -87,9 +87,9 @@ java_library(
     name = "strategy_manager",
     srcs = ["StrategyManager.java"],
     deps = [
-        "@maven//:com_google_protobuf_protobuf_java",
-        "@maven//:org_ta4j_ta4j_core",
+        "//third_party:ta4j_core",
         "//protos:strategies_java_proto",
+        "//third_party:protobuf_java",
         ":strategy_factory",
     ],
 )
@@ -98,13 +98,13 @@ java_library(
     name = "strategy_manager_impl",
     srcs = ["StrategyManagerImpl.java"],
     deps = [
-        "@maven//:com_google_protobuf_protobuf_java",
-        "@maven//:org_ta4j_ta4j_core",
+        "//third_party:ta4j_core",
         "//protos:strategies_java_proto",
         "//third_party:auto_value",
         "//third_party:guava",
         "//third_party:guice",
         "//third_party:mug",
+        "//third_party:protobuf_java",
         ":strategy_factory",
         ":strategy_manager",
     ],


### PR DESCRIPTION
Replaced direct Maven references for `com.google.protobuf` and `org.ta4j.core` in the `strategy_factory`, `strategy_manager`, and `strategy_manager_impl` targets with the corresponding `third_party:protobuf_java` and `third_party:ta4j_core` abstractions. This change centralizes dependency management, enhances maintainability, and ensures consistency across the project.