### PR TITLE
Add `data_consumption` Module with `CandleWindow` Interface 

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/dataconsumption/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/dataconsumption/BUILD
@@ -1,0 +1,16 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
+package(default_visibility = ["//visibility:public"])
+
+java_library(
+    name = "data_consumption_lib",
+    srcs = glob(["*.java"]),
+    deps = [
+        "//protos:marketdata_java_proto",
+        "//third_party:auto_value",
+        "//third_party:flogger",
+        "//third_party:guava",
+        "//third_party:guice",
+        "//third_party:kafka_clients",
+    ],
+)

--- a/src/main/java/com/verlumen/tradestream/strategies/dataconsumption/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/dataconsumption/BUILD
@@ -7,10 +7,6 @@ java_library(
     srcs = glob(["*.java"]),
     deps = [
         "//protos:marketdata_java_proto",
-        "//third_party:auto_value",
-        "//third_party:flogger",
         "//third_party:guava",
-        "//third_party:guice",
-        "//third_party:kafka_clients",
     ],
 )

--- a/src/main/java/com/verlumen/tradestream/strategies/dataconsumption/CandleWindow.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/dataconsumption/CandleWindow.java
@@ -1,0 +1,10 @@
+package com.verlumen.tradestream.strategies.dataconsumption;
+
+import com.google.common.collect.ImmutableList;
+import com.verlumen.tradestream.marketdata.Candle;
+
+public interface CandleWindow {
+    void addCandle(Candle candle);
+
+    ImmutableList<Candle> getCandles(int windowSize);
+}


### PR DESCRIPTION
Introduced a new `data_consumption` module to support data handling for strategies. Added the following:  
1. **`CandleWindow` Interface**: Defines methods for managing a window of candles, including adding candles and retrieving a fixed window size as an immutable list.  
2. **`data_consumption_lib`**: Bazel target managing the module, with dependencies on `marketdata_java_proto` and `third_party:guava`.  

This forms the foundation for implementing candle data management functionality in the strategy engine.