### PR TITLE
Fix Dependency Ordering in `strategy_manager` and `strategy_manager_impl`  

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -87,9 +87,9 @@ java_library(
     name = "strategy_manager",
     srcs = ["StrategyManager.java"],
     deps = [
-        "//third_party:ta4j_core",
         "//protos:strategies_java_proto",
         "//third_party:protobuf_java",
+        "//third_party:ta4j_core",
         ":strategy_factory",
     ],
 )
@@ -98,13 +98,13 @@ java_library(
     name = "strategy_manager_impl",
     srcs = ["StrategyManagerImpl.java"],
     deps = [
-        "//third_party:ta4j_core",
         "//protos:strategies_java_proto",
         "//third_party:auto_value",
         "//third_party:guava",
         "//third_party:guice",
         "//third_party:mug",
         "//third_party:protobuf_java",
+        "//third_party:ta4j_core",
         ":strategy_factory",
         ":strategy_manager",
     ],


### PR DESCRIPTION
Adjusted the order of dependencies in the Bazel `BUILD` file for `strategy_manager` and `strategy_manager_impl` to align with project conventions and improve readability. Specifically:  
- Moved `//third_party:ta4j_core` to follow `//third_party:protobuf_java` and `//protos:strategies_java_proto` for consistent grouping.  

These changes enhance maintainability and ensure logical organization of dependencies within the `strategies` module.