### PR TITLE
Add BacktestRunner Interface and Build Rules for Backtesting Module

### DIFF
--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -1,0 +1,11 @@
+java_library(
+    name = "backtest_runner",
+    srcs = ["BacktestRunner.java"],
+    deps = [
+        "//protos:backtesting_java_proto",
+        "//protos:strategies_java_proto",
+        "//third_party:auto_value",
+        "//third_party:guice",
+        "//third_party:ta4j_core",
+    ],
+)

--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -5,7 +5,6 @@ java_library(
         "//protos:backtesting_java_proto",
         "//protos:strategies_java_proto",
         "//third_party:auto_value",
-        "//third_party:guice",
         "//third_party:ta4j_core",
     ],
 )

--- a/src/main/java/com/verlumen/tradestream/backtesting/BacktestRunner.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BacktestRunner.java
@@ -5,10 +5,7 @@ import com.verlumen.tradestream.backtesting.BacktestResult;
 import com.verlumen.tradestream.backtesting.TimeframeResult;
 import com.verlumen.tradestream.strategies.StrategyType;
 import org.ta4j.core.BarSeries;
-import org.ta4j.core.AnalysisCriterion;
 import org.ta4j.core.Strategy;
-import org.ta4j.core.TradingRecord;
-import org.ta4j.core.analysis.criteria.*;
 
 /**
  * Interface for running backtests on trading strategies.

--- a/src/main/java/com/verlumen/tradestream/backtesting/BacktestRunner.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BacktestRunner.java
@@ -2,7 +2,6 @@ package com.verlumen.tradestream.backtesting;
 
 import com.google.auto.value.AutoValue;
 import com.verlumen.tradestream.backtesting.BacktestResult;
-import com.verlumen.tradestream.backtesting.TimeframeResult;
 import com.verlumen.tradestream.strategies.StrategyType;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Strategy;

--- a/src/main/java/com/verlumen/tradestream/backtesting/BacktestRunner.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BacktestRunner.java
@@ -1,0 +1,46 @@
+package com.verlumen.tradestream.backtesting;
+
+import com.google.auto.value.AutoValue;
+import com.verlumen.tradestream.backtesting.BacktestResult;
+import com.verlumen.tradestream.backtesting.TimeframeResult;
+import com.verlumen.tradestream.strategies.StrategyType;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.AnalysisCriterion;
+import org.ta4j.core.Strategy;
+import org.ta4j.core.TradingRecord;
+import org.ta4j.core.analysis.criteria.*;
+
+/**
+ * Interface for running backtests on trading strategies.
+ */
+interface BacktestRunner {
+  /**
+   * Runs a backtest for the given strategy over the provided bar series.
+   *
+   * @param request Parameters and configuration for the backtest run
+   * @return Results of the backtest analysis
+   */
+  BacktestResult runBacktest(BacktestRequest request);
+
+  /**
+   * Configuration for a backtest run.
+   */
+  @AutoValue
+  abstract class BacktestRequest {
+    abstract BarSeries barSeries();
+    abstract Strategy strategy();
+    abstract StrategyType strategyType();
+
+    static Builder builder() {
+      return new AutoValue_BacktestRunner_BacktestRequest.Builder();
+    }
+
+    @AutoValue.Builder
+    abstract static class Builder {
+      abstract Builder setBarSeries(BarSeries barSeries);
+      abstract Builder setStrategy(Strategy strategy);
+      abstract Builder setStrategyType(StrategyType strategyType);
+      abstract BacktestRequest build();
+    }
+  }
+}


### PR DESCRIPTION
Introduced the foundational components for the backtesting module:  
- **`BacktestRunner` Interface:** Defines the contract for running backtests with methods to configure and execute strategy evaluations over bar series data.  
  - Added `BacktestRequest` as a nested class for encapsulating parameters and configurations, leveraging `@AutoValue` for immutability and type safety.  
- **Bazel Build Rule:** Added `backtest_runner` to the `BUILD` file in the `backtesting` package, with dependencies on:  
  - Protocol buffer definitions (`backtesting_java_proto`, `strategies_java_proto`).  
  - External libraries (`auto_value`, `ta4j_core`).  

These changes set the stage for implementing and testing backtesting functionality in the `tradestream` project.