### PR TITLE
Add Python Support with `rules_python` and Configure Pip in `MODULE.bazel`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -108,6 +108,9 @@ python.toolchain(
 
 use_repo(python, "python_3_10", "python_3_9", "python_versions", "pythons_hub")
 
+# Initialize and configure pip
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+
 use_repo(pip, "whl_mods_hub")
 
 # Parse pip dependencies for Python 3.10

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,3 +1,10 @@
+module(
+    name = "tradestream",
+    version = "1.0.0",
+    compatibility_level = 1,
+)
+
+# Existing dependencies
 bazel_dep(name = "aspect_bazel_lib", version = "2.8.1")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "container_structure_test", version = "1.16.0")
@@ -6,6 +13,7 @@ bazel_dep(name = "protobuf", repo_name = "com_google_protobuf", version = "29.1"
 bazel_dep(name = "rules_java", version = "8.3.1")
 bazel_dep(name = "rules_jvm_external", version = "6.5")
 bazel_dep(name = "rules_oci", version = "2.0.1")
+bazel_dep(name = "rules_python", version = "1.0.0")
 
 # Add Java toolchain configuration
 JAVA_LANGUAGE_LEVEL = "17"
@@ -19,11 +27,12 @@ java.toolchain(
 )
 use_repo(java, "java_tools")
 
-# Register the toolchain
+# Register Java toolchains
 register_toolchains(
     "@rules_java//toolchains:all",
 )
 
+# Configure Maven dependencies
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(
     artifacts = [
@@ -69,6 +78,7 @@ maven.install(
 )
 use_repo(maven, "maven")
 
+# Configure OCI dependencies
 oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
 
 oci.pull(
@@ -83,7 +93,27 @@ oci.pull(
 
 use_repo(oci, "openjdk_java")
 
+# Configure Bazel libraries
 bazel_lib = use_extension("@aspect_bazel_lib//lib:extensions.bzl", "toolchains")
 bazel_lib.jq()
 bazel_lib.tar()
 use_repo(bazel_lib, "bsd_tar_toolchains", "jq_toolchains")
+
+# Initialize and configure rules_python
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(
+    configure_coverage_tool = True,
+    python_version = "3.10",
+)
+
+use_repo(python, "python_3_10", "python_3_9", "python_versions", "pythons_hub")
+
+use_repo(pip, "whl_mods_hub")
+
+# Parse pip dependencies for Python 3.10
+pip.parse(
+    hub_name = "pip",
+    python_version = "3.10",
+)
+
+use_repo(pip, "pip")


### PR DESCRIPTION
This update enhances the `MODULE.bazel` configuration by integrating Python support using `rules_python` and setting up pip dependencies for Python 3.10.  

### Key Changes:  
1. **Dependencies Added:**
   - Added `rules_python` version `1.0.0` for Python support in Bazel.
2. **Python Toolchain Configuration:**
   - Configured the Python toolchain with coverage support enabled and defaulted to Python version `3.10`.
   - Added support for additional Python versions (`3.9` and `3.10`) via `python_versions`.
3. **Pip Integration:**
   - Integrated `pip` for Python dependency management.
   - Configured pip dependencies specifically for Python 3.10 using `pip.parse`.
4. **Improved Organization:**
   - Included additional comments to categorize and clarify the new configurations.

This PR introduces Python-related functionality, paving the way for Python-based build targets and dependencies while maintaining alignment with the Bazel ecosystem.