### PR TITLE
Add Bazel Module Declaration to `MODULE.bazel`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,3 +1,10 @@
+module(
+    name = "tradestream",
+    version = "0.0.1",
+    compatibility_level = 1,
+)
+
+# Existing dependencies
 bazel_dep(name = "aspect_bazel_lib", version = "2.8.1")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "container_structure_test", version = "1.16.0")
@@ -19,11 +26,12 @@ java.toolchain(
 )
 use_repo(java, "java_tools")
 
-# Register the toolchain
+# Register Java toolchains
 register_toolchains(
     "@rules_java//toolchains:all",
 )
 
+# Configure Maven dependencies
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(
     artifacts = [
@@ -69,6 +77,7 @@ maven.install(
 )
 use_repo(maven, "maven")
 
+# Configure OCI dependencies
 oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
 
 oci.pull(
@@ -83,6 +92,7 @@ oci.pull(
 
 use_repo(oci, "openjdk_java")
 
+# Configure Bazel libraries
 bazel_lib = use_extension("@aspect_bazel_lib//lib:extensions.bzl", "toolchains")
 bazel_lib.jq()
 bazel_lib.tar()


### PR DESCRIPTION
This update introduces the `module` statement in the `MODULE.bazel` file to define `tradestream` as a Bazel module with the following attributes:  

- **Name:** `tradestream`  
- **Version:** `0.0.1`  
- **Compatibility Level:** 1  

Additionally, comments were added to improve the readability of the configuration by grouping and labeling different dependency configurations and toolchain registrations.  

### Key Changes:  
- Added the `module` declaration for better integration with Bazel's module system.  
- Updated comments to categorize sections such as Maven dependencies, OCI setup, and Bazel libraries.  

This PR is focused on clarifying and organizing the existing `MODULE.bazel` file with minimal structural changes.