### PR TITLE
Refactor Proto Build Configuration for Enhanced Visibility and Consistency

### DIFF
--- a/protos/BUILD
+++ b/protos/BUILD
@@ -42,6 +42,6 @@ proto_library(
 
 java_proto_library(
     name = "strategies_java_proto",
-    visibility = ["//visibility:private"],
+    visibility = ["//visibility:public"],
     deps = [":strategies_proto"],
 )

--- a/protos/BUILD
+++ b/protos/BUILD
@@ -1,14 +1,5 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_grpc_grpc_java//:java_grpc_library.bzl", "java_grpc_library")
-
-package(
-    default_visibility = ["//visibility:public"]
-)
-
-java_grpc_library(
-    name = "backtesting_java_grpc",
-    srcs = [":backtesting_proto"],
-    deps = [":backtesting_java_proto"],
-)
 
 proto_library(
     name = "backtesting_proto",
@@ -18,32 +9,39 @@ proto_library(
         ":marketdata_proto",
         ":strategies_proto",
     ],
-    visibility = ["//visibility:private"],
+)
+
+java_grpc_library(
+    name = "backtesting_java_grpc",
+    visibility = ["//visibility:public"],
+    srcs = [":backtesting_proto"],
+    deps = [":backtesting_java_proto"],
 )
 
 java_proto_library(
     name = "backtesting_java_proto",
+    visibility = ["//visibility:public"],
     deps = [":backtesting_proto"],
 )
 
 proto_library(
     name = "marketdata_proto",
     srcs = ["marketdata.proto"],
-    visibility = ["//visibility:private"],
 )
 
 java_proto_library(
     name = "marketdata_java_proto",
+    visibility = ["//visibility:public"],
     deps = [":marketdata_proto"],
 )
 
 proto_library(
     name = "strategies_proto",
     srcs = ["strategies.proto"],
-    visibility = ["//visibility:private"],
 )
 
 java_proto_library(
     name = "strategies_java_proto",
+    visibility = ["//visibility:private"],
     deps = [":strategies_proto"],
 )


### PR DESCRIPTION
This PR updates the `BUILD` file in the `protos` directory to streamline the configuration of proto and Java proto libraries.  

### Key Changes:  
1. **Standardized Visibility:**  
   - Adjusted visibility of proto and Java proto libraries to `//visibility:public` where appropriate, enabling broader accessibility for dependent modules.  
   - Ensures consistent application across `backtesting`, `marketdata`, and `strategies` libraries.  

2. **Refactored `java_grpc_library`:**  
   - The `backtesting_java_grpc` target now explicitly includes visibility and maintains dependencies on its respective proto library.  
   - Refactored to align with updated project standards for proto build files.  

3. **Introduced `proto_library` Loading:**  
   - Explicitly loaded the `proto_library` rule from Bazel's protobuf package for better dependency management.  

### Benefits:  
- Improves modularity and dependency clarity across the proto layer.  
- Facilitates easier integration with downstream components needing access to `backtesting`, `marketdata`, and `strategies` proto definitions.  
- Enhances maintainability by ensuring all libraries follow a consistent structure and visibility policy.  

This refactor positions the proto build configuration for scalability while aligning with best practices in protobuf and Bazel-based projects.