### PR TITLE
Add Python Proto Libraries for Enhanced Multi-Language Support

### DIFF
--- a/protos/BUILD
+++ b/protos/BUILD
@@ -1,5 +1,6 @@
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_grpc_grpc_java//:java_grpc_library.bzl", "java_grpc_library")
+load("@rules_python//python:proto.bzl", "py_proto_library")
 
 proto_library(
     name = "backtesting_proto",
@@ -24,6 +25,12 @@ java_proto_library(
     deps = [":backtesting_proto"],
 )
 
+py_proto_library(
+    name = "backtesting_py_proto",
+    visibility = ["//visibility:public"],
+    deps = [":backtesting_proto"],
+)
+
 proto_library(
     name = "marketdata_proto",
     srcs = ["marketdata.proto"],
@@ -35,6 +42,12 @@ java_proto_library(
     deps = [":marketdata_proto"],
 )
 
+py_proto_library(
+    name = "marketdata_py_proto",
+    visibility = ["//visibility:public"],
+    deps = [":marketdata_proto"],
+)
+
 proto_library(
     name = "strategies_proto",
     srcs = ["strategies.proto"],
@@ -42,6 +55,12 @@ proto_library(
 
 java_proto_library(
     name = "strategies_java_proto",
+    visibility = ["//visibility:public"],
+    deps = [":strategies_proto"],
+)
+
+py_proto_library(
+    name = "strategies_py_proto",
     visibility = ["//visibility:public"],
     deps = [":strategies_proto"],
 )


### PR DESCRIPTION
This PR introduces `py_proto_library` targets to the `protos/BUILD` file, enabling Python-based projects to consume the same proto definitions used by Java and other services.  

### Key Changes:  
1. **Python Proto Libraries:**  
   - Added `py_proto_library` targets for `backtesting_proto`, `marketdata_proto`, and `strategies_proto`.  
   - Ensured these targets have `//visibility:public` for accessibility across the project.  

2. **Dependencies:**  
   - Each Python proto library depends on its respective `proto_library` target, ensuring alignment with the core proto definitions.  

3. **Updated BUILD File Loading:**  
   - Included the `py_proto_library` rule from Bazel's Python proto package to support the new Python libraries.  

### Benefits:  
- Expands multi-language support, enabling Python-based services and applications to consume proto definitions seamlessly.  
- Facilitates interoperability between Java and Python components within the ecosystem.  
- Aligns with best practices for supporting diverse language environments in modern distributed systems.  

This update is essential for Python-based workflows, ensuring smooth integration and consistency across all supported languages.