### PR TITLE
Add gRPC Dependency to MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,6 +8,7 @@ module(
 bazel_dep(name = "aspect_bazel_lib", version = "2.8.1")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "container_structure_test", version = "1.16.0")
+bazel_dep(name = "grpc", version = "1.63.1")
 bazel_dep(name = "grpc-java", repo_name = "io_grpc_grpc_java", version = "1.68.1")
 bazel_dep(name = "protobuf", repo_name = "com_google_protobuf", version = "29.1")
 bazel_dep(name = "rules_java", version = "8.5.1")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,7 @@ module(
 bazel_dep(name = "aspect_bazel_lib", version = "2.8.1")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "container_structure_test", version = "1.16.0")
-bazel_dep(name = "grpc", version = "1.63.1")
+bazel_dep(name = "grpc", version = "1.68.0")
 bazel_dep(name = "grpc-java", repo_name = "io_grpc_grpc_java", version = "1.68.1")
 bazel_dep(name = "protobuf", repo_name = "com_google_protobuf", version = "29.1")
 bazel_dep(name = "rules_java", version = "8.5.1")


### PR DESCRIPTION
This PR updates the `MODULE.bazel` file to include the `grpc` dependency alongside the existing `grpc-java`.  

### Key Changes:  
1. **gRPC Dependency Addition:**  
   - Added `bazel_dep(name = "grpc", version = "1.68.0")` to explicitly include the gRPC library for Bazel-based builds.  
   - Aligns the `grpc` versioning with the existing `grpc-java` dependency for consistency.  

2. **Existing Dependencies Maintained:**  
   - Preserved the existing `grpc-java` dependency (`1.68.1`), ensuring compatibility across both Java and non-Java gRPC implementations.  

### Benefits:  
- **Improved Compatibility:** Adds support for gRPC-based features in environments requiring native gRPC implementations.  
- **Consistency:** Ensures that the gRPC and gRPC-Java libraries are version-aligned, minimizing integration issues.  
- **Enhanced Functionality:** Enables gRPC usage across multiple languages and frameworks supported by Bazel.  

This enhancement improves the project's extensibility and compatibility with modern gRPC-based systems.