### PR TITLE
Add Jenetics Library Integration to Bazel Configuration

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -51,6 +51,7 @@ maven.install(
         "com.ryanharter.auto.value:auto-value-gson:1.3.1",
         "com.ryanharter.auto.value:auto-value-gson-annotations:0.8.0",
         "com.ryanharter.auto.value:auto-value-gson-factory:1.3.1",
+        "io.jenetics:jenetics:8.1.0",
         "io.reactivex.rxjava3:rxjava:3.1.6",
         "javax.inject:javax.inject:1",
         "net.sourceforge.argparse4j:argparse4j:0.9.0",

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -151,6 +151,14 @@ java_library(
 )
 
 java_library(
+    name = "jenetics",
+    visibility = ["//visibility:public"],
+    exports = [
+        "@maven//:io_jenetics_jenetics",
+    ],
+)
+
+java_library(
     name = "junit",
     visibility = ["//visibility:public"],
     exports = [


### PR DESCRIPTION
This update integrates the **Jenetics** library (version 8.1.0) into the Bazel build system for the project, enabling its use in Java components. The changes include:

1. **MODULE.bazel Updates:**
   - Added `"io.jenetics:jenetics:8.1.0"` to the Maven dependencies list for installation using `maven.install`.

2. **third_party/BUILD Updates:**
   - Created a new `java_library` target named `"jenetics"`.
   - Set its visibility to `public`, allowing usage across the repository.
   - Exported the Jenetics Maven artifact (`@maven//:io_jenetics_jenetics`) for use in dependent modules.

These changes allow seamless inclusion and use of Jenetics, a Java library for evolutionary algorithms and genetic programming, in the project's Java modules while maintaining a clean and modular build configuration.