### PR TITLE
Revert Protobuf Syntax to Edition-Based Format

### DIFF
--- a/protos/backtesting.proto
+++ b/protos/backtesting.proto
@@ -1,4 +1,4 @@
-syntax = "proto3";
+edition = "2023";
 
 package backtesting;
 

--- a/protos/marketdata.proto
+++ b/protos/marketdata.proto
@@ -1,4 +1,4 @@
-syntax = "proto3";
+edition = "2023";
 
 package marketdata;
 

--- a/protos/strategies.proto
+++ b/protos/strategies.proto
@@ -1,4 +1,4 @@
-syntax = "proto3";
+edition = "2023";
 
 package strategies;
 


### PR DESCRIPTION
This update reverts the Protobuf syntax from `proto3` to the edition-based format (`edition = "2023";`) across the `backtesting.proto`, `marketdata.proto`, and `strategies.proto` files. The changes include:

1. **Protobuf Syntax Reversion:**
   - Replaces `syntax = "proto3";` with `edition = "2023";` in all `.proto` files to align with the newer edition-based Protobuf specification.

2. **Maintained Package Names:**
   - Ensures the package declarations (`backtesting`, `marketdata`, and `strategies`) remain intact for consistency and compatibility.

This adjustment supports environments leveraging Protobuf's 2023 edition for enhanced features and future-proofing while maintaining backward compatibility with tools and workflows that support the edition-based syntax.