### PR TITLE
Add Kafka UI to Tradestream Chart

### DIFF
--- a/charts/tradestream/templates/kafka-ui.yaml
+++ b/charts/tradestream/templates/kafka-ui.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "tradestream.fullname" . }}-kafka-ui
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "tradestream.name" . }}
+    component: kafka-ui
+    release: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.kafkaUi.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "tradestream.name" . }}
+      component: kafka-ui
+  template:
+    metadata:
+      labels:
+        app: {{ include "tradestream.name" . }}
+        component: kafka-ui
+    spec:
+      containers:
+        - name: kafka-ui
+          image: "{{ .Values.kafkaUi.image.repository }}:{{ .Values.kafkaUi.image.tag }}"
+          imagePullPolicy: {{ .Values.kafkaUi.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.kafkaUi.service.port }}
+          env:
+            - name: KAFKA_CLUSTERS_0_NAME
+              value: "local"
+            - name: KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS
+              value: "{{ include "tradestream.fullname" . }}-kafka.{{ .Release.Namespace }}.svc.cluster.local:9092"
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "tradestream.fullname" . }}-kafka-ui
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "tradestream.name" . }}
+    component: kafka-ui
+    release: {{ .Release.Name }}
+spec:
+  type: {{ .Values.kafkaUi.service.type }}
+  ports:
+    - port: {{ .Values.kafkaUi.service.port }}
+      targetPort: {{ .Values.kafkaUi.service.port }}
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ include "tradestream.name" . }}
+    component: kafka-ui

--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -9,6 +9,15 @@ kafka:
       protocol: 'PLAINTEXT'
     controller:
       protocol: 'PLAINTEXT'
+kafkaUi:
+  replicaCount: 1
+  image:
+    repository: "provectuslabs/kafka-ui"
+    tag: "latest"
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    port: 8080
 dataIngestion:
   args:
     - "--runMode=wet"


### PR DESCRIPTION
This PR adds a Kafka UI deployment to the Tradestream Helm chart. This will allow users to easily monitor and manage their Kafka clusters deployed by the chart.

**Key changes:**

* Adds a new `kafka-ui.yaml` template file to define the Kafka UI deployment and service.
* Adds a new `kafkaUi` section to the `values.yaml` file to configure the Kafka UI, including:
    * `replicaCount`: Number of replicas for the Kafka UI deployment.
    * `image`: Configuration for the Kafka UI Docker image.
    * `service`: Configuration for the Kafka UI service.
* Sets the default Kafka UI image to `provectuslabs/kafka-ui:latest`.
* Configures the Kafka UI to connect to the Kafka cluster deployed by the chart.

**Benefits:**

* Provides a user-friendly interface for monitoring Kafka topics, consumer groups, and other metrics.
* Simplifies Kafka cluster management tasks.
* Improves observability and troubleshooting capabilities for Tradestream deployments.

**Testing:**

* Deployed the Tradestream chart with the new Kafka UI enabled.
* Verified that the Kafka UI is accessible and displays the expected information about the Kafka cluster.
