### PR TITLE
Update Guava and Truth Library Versions in Maven Dependencies  

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -41,7 +41,7 @@ maven.install(
         "com.google.code.gson:gson:2.11.0",
         "com.google.flogger:flogger:0.8",
         "com.google.flogger:flogger-system-backend:0.8",
-        "com.google.guava:guava:31.1-jre",
+        "com.google.guava:guava:33.2.1-android",
         "com.google.inject.extensions:guice-assistedinject:7.0.0",
         "com.google.inject:guice:7.0.0",
         "com.google.mug:mug:8.2",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -66,7 +66,7 @@ maven.install(
         # Test Dependencies
         "com.google.inject.extensions:guice-testlib:7.0.0",
         "com.google.testparameterinjector:test-parameter-injector:1.9",
-        "com.google.truth:truth:1.4.2",
+        "com.google.truth:truth:1.4.4",
         "junit:junit:4.13.2",
         "org.mockito:mockito-core:4.3.1",
     ],

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -41,7 +41,7 @@ maven.install(
         "com.google.code.gson:gson:2.11.0",
         "com.google.flogger:flogger:0.8",
         "com.google.flogger:flogger-system-backend:0.8",
-        "com.google.guava:guava:33.2.1-android",
+        "com.google.guava:guava:33.4.0-jre",
         "com.google.inject.extensions:guice-assistedinject:7.0.0",
         "com.google.inject:guice:7.0.0",
         "com.google.mug:mug:8.2",


### PR DESCRIPTION
This update modifies the `MODULE.bazel` file to upgrade the versions of critical dependencies, **Guava** and **Truth**, ensuring compatibility with the latest features and improvements.  

### Key Changes:  
1. **Guava Library:**  
   - Upgraded from `31.1-jre` to `33.4.0-jre`.  
   - Brings enhanced features, performance optimizations, and security patches.  

2. **Truth Library:**  
   - Upgraded from `1.4.2` to `1.4.4`.  
   - Ensures compatibility with newer testing frameworks and bug fixes.  

### Benefits:  
- Improves overall stability and security of the codebase by aligning with the latest library versions.  
- Facilitates access to new APIs and features introduced in these updates.  
- Enhances maintainability and future-proofing for dependency management.  

These upgrades are integral for keeping the project dependencies up-to-date and ensuring robust, high-quality development and testing workflows.