### PR TITLE
Update Dependency References for Moving Averages and Oscillators Strategies  

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/movingaverages/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/movingaverages/BUILD
@@ -6,11 +6,11 @@ java_library(
     name = "movingaverages_lib",
     srcs = glob(["*.java"]),
     deps = [
-        "@maven//:com_google_guava_guava",
-        "@maven//:com_google_inject_guice",
-        "@maven//:com_google_protobuf_protobuf_java",
-        "@maven//:org_ta4j_ta4j_core",
         "//protos:strategies_java_proto",
         "//src/main/java/com/verlumen/tradestream/strategies:strategy_factory",
+        "//third_party:guava",
+        "//third_party:guice",
+        "//third_party:protobuf_java",
+        "//third_party:ta4j_core",
     ],
 )

--- a/src/main/java/com/verlumen/tradestream/strategies/oscillators/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/oscillators/BUILD
@@ -11,5 +11,6 @@ java_library(
         "//third_party:guava",
         "//third_party:guice",
         "//third_party:protobuf_java",
+        "//third_party:ta4j_core",
     ],
 )

--- a/src/main/java/com/verlumen/tradestream/strategies/oscillators/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/oscillators/BUILD
@@ -6,11 +6,10 @@ java_library(
     name = "oscillators_lib",
     srcs = glob(["*.java"]),
     deps = [
-        "@maven//:com_google_guava_guava",
-        "@maven//:com_google_inject_guice",
-        "@maven//:com_google_protobuf_protobuf_java",
-        "@maven//:org_ta4j_ta4j_core",
         "//protos:strategies_java_proto",
         "//src/main/java/com/verlumen/tradestream/strategies:strategy_factory",
+        "//third_party:guava",
+        "//third_party:guice",
+        "//third_party:protobuf_java",
     ],
 )


### PR DESCRIPTION
This change refactors dependency declarations for the `movingaverages_lib` and `oscillators_lib` in the respective Bazel `BUILD` files.  

### Key Changes:  

- **Dependency Standardization:**  
  - Replaced references to Maven-resolved dependencies (e.g., `@maven//:`) with references to centralized third-party libraries (`//third_party:`).  
  - Consolidated dependencies for `guava`, `guice`, `protobuf_java`, and `ta4j_core` under `//third_party`.  

- **Impacted Targets:**  
  - `movingaverages_lib` in `strategies/movingaverages/BUILD`.  
  - `oscillators_lib` in `strategies/oscillators/BUILD`.  

### Benefits:  
- Improves maintainability by centralizing dependency management under `//third_party`.  
- Reduces duplication and ensures consistency across the project.  
- Simplifies updates to third-party dependencies in the future.  

This update aligns the project with best practices for dependency management in Bazel.