### PR TITLE
Refactor `AppTest` Dependencies to Use `third_party`

### DIFF
--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -6,17 +6,17 @@ java_test(
       "AppTest.java"
     ],
     deps = [
-        "@maven//:com_google_inject_extensions_guice_testlib",
-        "@maven//:com_google_inject_guice",
-        "@maven//:com_google_truth_truth",
-        "@maven//:junit_junit",
-        "@maven//:org_mockito_mockito_core",
         "//src/main/java/com/verlumen/tradestream/ingestion:app",
         "//src/main/java/com/verlumen/tradestream/ingestion:real_time_data_ingestion",
         "//src/main/java/com/verlumen/tradestream/ingestion:run_mode",
+        "//third_party:guice",
+        "//third_party:guice_testlib",
+        "//third_party:junit",
+        "//third_party:mockito_core",
+        "//third_party:truth",
     ],
     runtime_deps = [
-        "@maven//:com_google_flogger_flogger_system_backend",
+        "//third_party:flogger_system_backend",
     ],
 )
 


### PR DESCRIPTION
- **Context:** This change updates the dependency declarations in the `AppTest` target to utilize the project's `third_party` library definitions. This promotes a consistent approach to dependency management throughout the project.
- **Changes:**
    - Replaced direct Maven dependency declarations for Guice, Guice Testlib, Truth, JUnit, and Mockito with their corresponding `third_party` equivalents.
    - Updated the `runtime_deps` to use the `third_party` definition for Flogger System Backend.
- **Benefits:**
    - Improves consistency in dependency management across all build targets.
    - Centralizes dependency versioning and configurations within the `third_party` directory.
    - Simplifies dependency updates and reduces the risk of version conflicts.