### PR TITLE
Refactor `CandleBuilderTest` Dependencies to Use `third_party`

### DIFF
--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -24,11 +24,11 @@ java_test(
     name = "CandleBuilderTest",
     srcs = ["CandleBuilderTest.java"],
     deps = [
-        "@maven//:com_google_truth_truth",
-        "@maven//:com_google_testparameterinjector_test_parameter_injector",
-        "@maven//:junit_junit",
         "//protos:marketdata_java_proto",
         "//src/main/java/com/verlumen/tradestream/ingestion:candle_builder",
+        "//third_party:junit",
+        "//third_party:test_parameter_injector",
+        "//third_party:truth",
     ],
 )
 


### PR DESCRIPTION
- **Context:** This change updates the dependency declarations for `CandleBuilderTest` to align with the project's standard practice of using `third_party` libraries. This promotes consistency and simplifies dependency management.
- **Changes:**
    - Replaced direct Maven dependencies for Truth, Test Parameter Injector, and JUnit with their corresponding `third_party` declarations.
- **Benefits:**
    - Ensures consistent dependency management across build files.
    - Centralizes dependency definitions in the `third_party` directory.
    - Facilitates easier updates and reduces potential conflicts.