### PR TITLE
Refactor `CandlePublisherImplTest` Dependencies to Use `third_party`

### DIFF
--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -56,15 +56,15 @@ java_test(
     name = "CandlePublisherImplTest",
     srcs = ["CandlePublisherImplTest.java"],
     deps = [
-        "@maven//:com_google_inject_extensions_guice_assistedinject",
-        "@maven//:com_google_inject_extensions_guice_testlib",
-        "@maven//:com_google_inject_guice",
-        "@maven//:junit_junit",
-        "@maven//:org_apache_kafka_kafka_clients",
-        "@maven//:org_mockito_mockito_core",
         "//protos:marketdata_java_proto",
         "//src/main/java/com/verlumen/tradestream/ingestion:candle_publisher",
         "//src/main/java/com/verlumen/tradestream/ingestion:candle_publisher_impl",
+        "//third_party:guice",
+        "//third_party:guice_assistedinject",
+        "//third_party:guice_testlib",
+        "//third_party:junit",
+        "//third_party:kafka_clients",
+        "//third_party:mockito_core",
     ],
 )
 


### PR DESCRIPTION
- **Context:** This change standardizes the dependency management for the `CandlePublisherImplTest` by switching from direct Maven references to using the project's `third_party` dependency declarations. This promotes consistency and simplifies dependency updates.
- **Changes:**
    - Removed direct Maven dependencies for Guice, JUnit, Kafka Clients, and Mockito.
    - Added corresponding `third_party` dependencies for the same libraries.
- **Benefits:**
    - Improves consistency in dependency management across the project.
    - Centralizes dependency versions and configurations within the `third_party` directory.
    - Simplifies future dependency updates and reduces potential version conflicts.