### PR TITLE
Refactor `ThinMarketTimerTaskImplTest` Dependencies to Use `third_party`

### DIFF
--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -166,17 +166,17 @@ java_test(
     name = "ThinMarketTimerTaskImplTest",
     srcs = ["ThinMarketTimerTaskImplTest.java"],
     deps = [
-        "@maven//:com_google_guava_guava",
-        "@maven//:com_google_inject_extensions_guice_testlib",
-        "@maven//:com_google_inject_guice",
-        "@maven//:com_google_truth_truth",
-        "@maven//:junit_junit",
-        "@maven//:org_mockito_mockito_core",
         "//src/main/java/com/verlumen/tradestream/ingestion:candle_manager",
         "//src/main/java/com/verlumen/tradestream/ingestion:currency_pair_metadata",
         "//src/main/java/com/verlumen/tradestream/ingestion:currency_pair_supply",
         "//src/main/java/com/verlumen/tradestream/ingestion:thin_market_timer_task_impl",
         "//src/main/java/com/verlumen/tradestream/instruments:currency_pair",
+        "//third_party:guava",
+        "//third_party:guice",
+        "//third_party:guice_testlib",
+        "//third_party:junit",
+        "//third_party:mockito_core",
+        "//third_party:truth",
     ],
 )
 


### PR DESCRIPTION
- **Context:** This change updates the dependency declarations for `ThinMarketTimerTaskImplTest` to utilize the project's standardized `third_party` library definitions. This ensures consistency in dependency management across the project.
- **Changes:**
    - Replaced direct Maven dependencies for Guava, Guice Testlib, Guice, Truth, JUnit, and Mockito with their corresponding `third_party` declarations.
- **Benefits:**
    - Promotes a consistent approach to dependency management within the project's build files.
    - Centralizes dependency versioning and management within the `third_party` directory.
    - Simplifies dependency updates and reduces the risk of version conflicts.