### PR TITLE
Refactor `ThinMarketTimerImplTest` Dependencies to Use `third_party`

### DIFF
--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -149,16 +149,16 @@ java_test(
     name = "ThinMarketTimerImplTest",
     srcs = ["ThinMarketTimerImplTest.java"],
     deps = [
-        "@maven//:com_google_inject_extensions_guice_testlib",
-        "@maven//:com_google_inject_guice",
-        "@maven//:com_google_guava_guava",
-        "@maven//:com_google_truth_truth",
-        "@maven//:junit_junit",
-        "@maven//:org_mockito_mockito_core",
         "//protos:marketdata_java_proto",
         "//src/main/java/com/verlumen/tradestream/ingestion:candle_manager",
         "//src/main/java/com/verlumen/tradestream/ingestion:thin_market_timer_impl",
         "//src/main/java/com/verlumen/tradestream/ingestion:thin_market_timer_task",
+        "//third_party:guava",
+        "//third_party:guice",
+        "//third_party:guice_testlib",
+        "//third_party:junit",
+        "//third_party:mockito_core",
+        "//third_party:truth",
     ],
 )
 


### PR DESCRIPTION
- **Context:** This change updates the dependency management for `ThinMarketTimerImplTest` to align with the project's standard practice of using `third_party` libraries. This ensures consistency and simplifies dependency maintenance.
- **Changes:**
    - Replaced direct Maven dependencies for Guice Testlib, Guice, Guava, Truth, JUnit, and Mockito with their corresponding `third_party` declarations.
- **Benefits:**
    - Improves consistency in dependency management across the project's build files.
    - Centralizes dependency versions and configurations within the `third_party` directory.
    - Facilitates easier dependency updates and reduces the risk of version conflicts.