### PR TITLE
Refactor `RealTimeDataIngestionImplTest` Dependencies to Use `third_party`

### DIFF
--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -127,12 +127,6 @@ java_test(
     name = "RealTimeDataIngestionImplTest",
     srcs = ["RealTimeDataIngestionImplTest.java"],
     deps = [
-        "@maven//:com_google_guava_guava",
-        "@maven//:com_google_inject_extensions_guice_testlib",
-        "@maven//:com_google_inject_guice",
-        "@maven//:com_google_truth_truth",
-        "@maven//:junit_junit",
-        "@maven//:org_mockito_mockito_core",
         "//protos:marketdata_java_proto",
         "//src/main/java/com/verlumen/tradestream/ingestion:candle_manager",
         "//src/main/java/com/verlumen/tradestream/ingestion:candle_publisher",
@@ -142,6 +136,12 @@ java_test(
         "//src/main/java/com/verlumen/tradestream/ingestion:trade_processor",
         "//src/main/java/com/verlumen/tradestream/ingestion:real_time_data_ingestion_impl",
         "//src/main/java/com/verlumen/tradestream/instruments:currency_pair",
+        "//third_party:guava",
+        "//third_party:guice",
+        "//third_party:guice_testlib",
+        "//third_party:junit",
+        "//third_party:mockito_core",
+        "//third_party:truth",
     ],
 )
 


### PR DESCRIPTION
- **Context:** This change updates the dependency management for the `RealTimeDataIngestionImplTest` target to use the project's standard `third_party` library definitions. This ensures consistent dependency management practices throughout the project.
- **Changes:**
    - Replaced direct Maven dependencies for Guava, Guice Testlib, Guice, Truth, JUnit, and Mockito with their corresponding `third_party` declarations.
- **Benefits:**
    - Improves consistency in dependency management across all build files.
    - Centralizes dependency versioning and configuration within the `third_party` directory.
    - Simplifies dependency updates and reduces the potential for version conflicts.