### PR TITLE
Refactor `PriceTrackerTest` Dependencies to Use `third_party`

### DIFF
--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -116,10 +116,10 @@ java_test(
     name = "PriceTrackerTest",
     srcs = ["PriceTrackerTest.java"],
     deps = [
-        "@maven//:com_google_inject_guice",
-        "@maven//:com_google_truth_truth",
-        "@maven//:junit_junit",
         "//src/main/java/com/verlumen/tradestream/ingestion:price_tracker",
+        "//third_party:guice",
+        "//third_party:junit",
+        "//third_party:truth",
     ],
 )
 


### PR DESCRIPTION
- **Context:** This change updates the dependency declarations for `PriceTrackerTest` to use the project's `third_party` library definitions. This promotes consistency and simplifies dependency management across the project.
- **Changes:**
    - Replaced direct Maven dependencies for Guice, Truth, and JUnit with their corresponding `third_party` declarations.
- **Benefits:**
    - Ensures a consistent approach to dependency management within the project's build files.
    - Centralizes dependency versioning and management within the `third_party` directory.
    - Simplifies dependency updates and reduces the risk of dependency conflicts.