### PR TITLE
Refactor `KafkaPropertiesTest` Dependencies to Use `third_party`

### DIFF
--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -104,11 +104,11 @@ java_test(
     name = "KafkaPropertiesTest",
     srcs = ["KafkaPropertiesTest.java"],
     deps = [
-        "@maven//:com_google_inject_extensions_guice_testlib",
-        "@maven//:com_google_inject_guice",
-        "@maven//:com_google_truth_truth",
-        "@maven//:net_sourceforge_argparse4j_argparse4j",
         "//src/main/java/com/verlumen/tradestream/ingestion:kafka_properties",
+        "//third_party:argparse4j",
+        "//third_party:guice",
+        "//third_party:guice_testlib",
+        "//third_party:truth",
     ],
 )
 


### PR DESCRIPTION
- **Context:** This change updates the dependency declarations for `KafkaPropertiesTest` to utilize the project's standard `third_party` library definitions. This promotes consistency and simplifies dependency management across the project.
- **Changes:**
    - Replaced direct Maven dependencies for Guice Testlib, Guice, Truth, and Argparse4j with their corresponding `third_party` declarations.
- **Benefits:**
    - Ensures consistent dependency management across build files.
    - Centralizes dependency definitions within the `third_party` directory.
    - Facilitates easier updates and reduces the potential for conflicts.