### PR TITLE
Refactor `HttpClientImplTest` Dependencies to Use `third_party`

### DIFF
--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -90,13 +90,13 @@ java_test(
     name = "HttpClientImplTest",
     srcs = ["HttpClientImplTest.java"],
     deps = [
-        "@maven//:com_google_inject_extensions_guice_testlib",
-        "@maven//:com_google_inject_guice",
-        "@maven//:com_google_truth_truth",
-        "@maven//:junit_junit",
-        "@maven//:org_mockito_mockito_core",
         "//src/main/java/com/verlumen/tradestream/ingestion:http_client_impl",
         "//src/main/java/com/verlumen/tradestream/ingestion:http_url_connection_factory",
+        "//third_party:guice",
+        "//third_party:guice_testlib",
+        "//third_party:junit",
+        "//third_party:mockito_core",
+        "//third_party:truth",
     ],
 )
 


### PR DESCRIPTION
- **Context:** This change updates the dependency declarations for `HttpClientImplTest` to use the project's standard `third_party` library definitions. This ensures consistent dependency management throughout the project.
- **Changes:**
    - Replaced direct Maven dependencies for Guice Testlib, Guice, Truth, JUnit, and Mockito with their corresponding `third_party` declarations.
- **Benefits:**
    - Promotes a consistent approach to dependency management within the project.
    - Centralizes dependency versioning and configuration within the `third_party` directory.
    - Simplifies dependency updates and reduces the risk of version conflicts.