### PR TITLE
Refactor `TradeProcessorTest` Dependencies to Use `third_party`

### DIFF
--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -184,9 +184,9 @@ java_test(
     name = "TradeProcessorTest",
     srcs = ["TradeProcessorTest.java"],
     deps = [
-        "@maven//:com_google_truth_truth",
-        "@maven//:junit_junit",
         "//protos:marketdata_java_proto",
         "//src/main/java/com/verlumen/tradestream/ingestion:trade_processor",
+        "//third_party:junit",
+        "//third_party:truth",
     ],
 )


### PR DESCRIPTION
- **Context:** This change updates the dependency declarations for `TradeProcessorTest` to utilize the project's standardized `third_party` library definitions. This ensures consistency in dependency management across the project.
- **Changes:**
    - Replaced direct Maven dependencies for Truth and JUnit with their corresponding `third_party` declarations.
- **Benefits:**
    - Promotes a consistent approach to dependency management within the project's build files.
    - Centralizes dependency versioning and management within the `third_party` directory.
    - Simplifies dependency updates and reduces the risk of version conflicts.