### PR TITLE
Refactor `CurrencyPairTest` Dependencies to Use `third_party`

### DIFF
--- a/src/test/java/com/verlumen/tradestream/instruments/BUILD
+++ b/src/test/java/com/verlumen/tradestream/instruments/BUILD
@@ -4,9 +4,9 @@ java_test(
     name = "CurrencyPairTest",
     srcs = ["CurrencyPairTest.java"],
     deps = [
-        "@maven//:com_google_truth_truth",
-        "@maven//:junit_junit",
         "//src/main/java/com/verlumen/tradestream/instruments:currency",
         "//src/main/java/com/verlumen/tradestream/instruments:currency_pair",
+        "//third_party:junit",
+        "//third_party:truth",
     ],
 )


### PR DESCRIPTION
- **Context:** This change updates the dependency declarations for `CurrencyPairTest` to use the project's standardized `third_party` library definitions. This ensures a consistent approach to dependency management throughout the project.
- **Changes:**
    - Replaced direct Maven dependencies for Truth and JUnit with their corresponding `third_party` declarations.
- **Benefits:**
    - Improves consistency in dependency management across the project's build files.
    - Centralizes dependency versioning and management within the `third_party` directory.
    - Simplifies dependency updates and reduces the risk of version conflicts.