### PR TITLE
Revert Accidental Version Updates in `MODULE.bazel`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,14 +5,14 @@ module(
 )
 
 # Existing dependencies
-bazel_dep(name = "aspect_bazel_lib", version = "v0.0.443-develop")
-bazel_dep(name = "bazel_skylib", version = "v0.0.443-develop")
-bazel_dep(name = "container_structure_test", version = "v0.0.443-develop")
-bazel_dep(name = "grpc-java", repo_name = "io_grpc_grpc_java", version = "v0.0.443-develop")
-bazel_dep(name = "protobuf", repo_name = "com_google_protobuf", version = "v0.0.443-develop")
-bazel_dep(name = "rules_java", version = "v0.0.443-develop")
-bazel_dep(name = "rules_jvm_external", version = "v0.0.443-develop")
-bazel_dep(name = "rules_oci", version = "v0.0.443-develop")
+bazel_dep(name = "aspect_bazel_lib", version = "2.8.1")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "container_structure_test", version = "1.16.0")
+bazel_dep(name = "grpc-java", repo_name = "io_grpc_grpc_java", version = "1.68.1")
+bazel_dep(name = "protobuf", repo_name = "com_google_protobuf", version = "29.1")
+bazel_dep(name = "rules_java", version = "8.5.1")
+bazel_dep(name = "rules_jvm_external", version = "6.5")
+bazel_dep(name = "rules_oci", version = "2.0.1")
 
 # Add Java toolchain configuration
 JAVA_LANGUAGE_LEVEL = "17"
@@ -52,8 +52,6 @@ maven.install(
         "com.ryanharter.auto.value:auto-value-gson:1.3.1",
         "com.ryanharter.auto.value:auto-value-gson-annotations:0.8.0",
         "com.ryanharter.auto.value:auto-value-gson-factory:1.3.1",
-        "io.grpc:grpc-api:1.69.0",
-        "io.grpc:grpc-stub:1.69.0",
         "io.grpc:grpc-testing:1.69.0",
         "io.jenetics:jenetics:8.1.0",
         "io.reactivex.rxjava3:rxjava:3.1.6",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -52,6 +52,8 @@ maven.install(
         "com.ryanharter.auto.value:auto-value-gson:1.3.1",
         "com.ryanharter.auto.value:auto-value-gson-annotations:0.8.0",
         "com.ryanharter.auto.value:auto-value-gson-factory:1.3.1",
+        "io.grpc:grpc-api:1.69.0",
+        "io.grpc:grpc-stub:1.69.0",
         "io.grpc:grpc-testing:1.69.0",
         "io.jenetics:jenetics:8.1.0",
         "io.reactivex.rxjava3:rxjava:3.1.6",


### PR DESCRIPTION
- **Context:** This change reverts unintended version updates in `MODULE.bazel`. These updates were a side effect of a previous issue where the version replacement logic in the release workflow was too broad, as described in [bazel-contrib/rules_jvm_external#916](https://github.com/bazel-contrib/rules_jvm_external/issues/916).
- **Changes:**
    - The versions for the following `bazel_dep` entries have been reverted to their intended values:
        - `aspect_bazel_lib`
        - `bazel_skylib`
        - `container_structure_test`
        - `grpc-java`
        - `protobuf`
        - `rules_java`
        - `rules_jvm_external`
        - `rules_oci`
- **Benefits:**
    - Corrects the declared versions of dependencies in `MODULE.bazel`.
    - Ensures that the project uses the intended versions of its dependencies.