### PR TITLE
Refactor `BacktestRunnerImplTest` Dependencies: Move to Top of List

### DIFF
--- a/src/test/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/test/java/com/verlumen/tradestream/backtesting/BUILD
@@ -6,6 +6,8 @@ java_test(
     deps = [
         "//protos:backtesting_java_proto",
         "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/backtesting:backtest_runner",
+        "//src/main/java/com/verlumen/tradestream/backtesting:backtest_runner_impl",
         "//third_party:guava",
         "//third_party:guice",
         "//third_party:guice_testlib",
@@ -13,8 +15,6 @@ java_test(
         "//third_party:mockito_core",
         "//third_party:ta4j_core",
         "//third_party:truth",
-        "//src/main/java/com/verlumen/tradestream/backtesting:backtest_runner",
-        "//src/main/java/com/verlumen/tradestream/backtesting:backtest_runner_impl",
     ],
 )
 


### PR DESCRIPTION
- **Context:** This change reorganizes the dependencies in the `BacktestRunnerImplTest` target. Moving the dependencies on the project's own modules (`backtest_runner` and `backtest_runner_impl`) to the top of the `deps` list improves readability and clarifies the primary dependencies of the test.
- **Changes:**
    - Moved `//src/main/java/com/verlumen/tradestream/backtesting:backtest_runner` from the end of the `deps` list to the beginning.
    - Moved `//src/main/java/com/verlumen/tradestream/backtesting:backtest_runner_impl` from the end of the `deps` list to follow the `backtest_runner` dependency.
- **Benefits:**
    - Enhances the readability of the `BUILD` file by grouping the test's direct dependencies on project modules.
    - Makes it easier to quickly identify the key components being tested.
    - Maintains a consistent structure in dependency declarations across different `BUILD` files.