### PR TITLE
Introduce gRPC InProcess Dependency for Enhanced Testing

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -53,6 +53,7 @@ maven.install(
         "com.ryanharter.auto.value:auto-value-gson-annotations:0.8.0",
         "com.ryanharter.auto.value:auto-value-gson-factory:1.3.1",
         "io.grpc:grpc-api:1.69.0",
+        "io.grpc:grpc-inprocess:1.69.0",
         "io.grpc:grpc-stub:1.69.0",
         "io.grpc:grpc-testing:1.69.0",
         "io.jenetics:jenetics:8.1.0",

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -102,6 +102,13 @@ java_library(
 )
 
 java_library(
+    name = "grpc_java_inprocess",
+    exports = [
+        "@tradestream_maven//:io_grpc_grpc_inprocess",
+    ],
+)
+
+java_library(
     name = "grpc_java_stub",
     visibility = ["//visibility:public"],
     exports = [

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -103,9 +103,11 @@ java_library(
 
 java_library(
     name = "grpc_java_inprocess",
+    visibility = ["//visibility:public"],
     exports = [
         "@tradestream_maven//:io_grpc_grpc_inprocess",
     ],
+    testonly = True,
 )
 
 java_library(


### PR DESCRIPTION
- **Context:** This change adds the `grpc-inprocess` dependency to facilitate more efficient and isolated testing of gRPC services. This builds upon the previously added `grpc-api` and `grpc-stub` dependencies, providing a comprehensive set of gRPC tools.
- **Changes:**
    - Added `io.grpc:grpc-inprocess:1.69.0` to the `maven.install` block in `MODULE.bazel`.
    - Created a new `java_library` target named `grpc_java_inprocess` in `third_party/BUILD` to wrap the `grpc-inprocess` Maven dependency.
- **Benefits:**
    - Enables in-process testing of gRPC services, eliminating network overhead and simplifying test setup.
    - Allows for more reliable and faster unit and integration tests for gRPC components.