### PR TITLE
Update `grpc-java` Bazel Dependency to Version 1.69.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,7 @@ module(
 bazel_dep(name = "aspect_bazel_lib", version = "2.8.1")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "container_structure_test", version = "1.16.0")
-bazel_dep(name = "grpc-java", repo_name = "io_grpc_grpc_java", version = "1.68.1")
+bazel_dep(name = "grpc-java", repo_name = "io_grpc_grpc_java", version = "1.69.0")
 bazel_dep(name = "protobuf", repo_name = "com_google_protobuf", version = "29.1")
 bazel_dep(name = "rules_java", version = "8.5.1")
 bazel_dep(name = "rules_jvm_external", version = "6.5")


### PR DESCRIPTION
- **Context:** This change updates the specified version of the `grpc-java` Bazel dependency.
- **Changes:**
    - The `version` attribute for the `grpc-java` bazel_dep is updated from "1.68.1" to "1.69.0".
- **Benefits:**
    - Ensures the project is using the desired version of the `grpc-java` library.