### PR TITLE
 Introduce Chromosome Specifications for Backtesting Parameter Optimization

### DIFF
--- a/src/main/java/com/verlumen/tradestream/backtesting/params/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/params/BUILD
@@ -1,8 +1,8 @@
 load("@rules_java//java:defs.bzl", "java_library")
 
 java_library(
-    name = "param_config",
-    srcs = ["ParamConfig.java"],
+    name = "params_lib",
+    srcs = glob(["*.java"]),
     deps = [
         "//third_party:guava",
         "//third_party:jenetics",

--- a/src/main/java/com/verlumen/tradestream/backtesting/params/ChromosomeSpec.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/params/ChromosomeSpec.java
@@ -1,0 +1,35 @@
+package com.verlumen.tradestream.backtesting.params;
+
+import com.google.common.collect.Range;
+import io.jenetics.Chromosome;
+import io.jenetics.Gene;
+
+/**
+ * Specifies type and range constraints for a chromosome in parameter optimization.
+ * @param <T> The type of value being optimized (e.g. Integer, Double)
+ */
+public interface ChromosomeSpec<T extends Comparable<T>> {
+    /**
+     * Gets the valid range for this parameter.
+     */
+    Range<T> getRange();
+
+    /**
+     * Creates an initial chromosome according to this specification.
+     */
+    Chromosome<? extends Gene<T, ?>> createChromosome();
+
+    /**
+     * Creates an integer-valued parameter specification.
+     */
+    static ChromosomeSpec<Integer> ofInteger(int min, int max) {
+        return new IntegerChromosomeSpec(Range.closed(min, max));
+    }
+
+    /**
+     * Creates a double-valued parameter specification.
+     */
+    static ChromosomeSpec<Double> ofDouble(double min, double max) {
+        return new DoubleChromosomeSpec(Range.closed(min, max));
+    }
+}

--- a/src/main/java/com/verlumen/tradestream/backtesting/params/DoubleChromosomeSpec.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/params/DoubleChromosomeSpec.java
@@ -1,0 +1,30 @@
+package com.verlumen.tradestream.backtesting.params;
+
+import com.google.common.collect.Range;
+import io.jenetics.Chromosome;
+import io.jenetics.DoubleChromosome;
+import io.jenetics.DoubleGene;
+import io.jenetics.Gene;
+
+/**
+ * Specification for double-valued chromosomes.
+ */
+public final class DoubleChromosomeSpec implements ChromosomeSpec<Double> {
+    private final Range<Double> range;
+
+    DoubleChromosomeSpec(Range<Double> range) {
+        this.range = range;
+    }
+
+    @Override
+    public Range<Double> getRange() {
+        return range;
+    }
+
+    @Override
+    public Chromosome<DoubleGene> createChromosome() {
+        return DoubleChromosome.of(
+            range.lowerEndpoint(),
+            range.upperEndpoint());
+    }
+}

--- a/src/main/java/com/verlumen/tradestream/backtesting/params/IntegerChromosomeSpec.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/params/IntegerChromosomeSpec.java
@@ -1,0 +1,30 @@
+package com.verlumen.tradestream.backtesting.params;
+
+import com.google.common.collect.Range;
+import io.jenetics.Chromosome;
+import io.jenetics.IntegerChromosome;
+import io.jenetics.IntegerGene;
+import io.jenetics.Gene;
+
+/**
+ * Specification for integer-valued chromosomes.
+ */
+public final class IntegerChromosomeSpec implements ChromosomeSpec<Integer> {
+    private final Range<Integer> range;
+
+    IntegerChromosomeSpec(Range<Integer> range) {
+        this.range = range;
+    }
+
+    @Override
+    public Range<Integer> getRange() {
+        return range;
+    }
+
+    @Override
+    public Chromosome<IntegerGene> createChromosome() {
+        return IntegerChromosome.of(
+            range.lowerEndpoint(),
+            range.upperEndpoint());
+    }
+}


### PR DESCRIPTION
- **Context:** This change introduces a new mechanism for specifying chromosome constraints used in backtesting parameter optimization. This provides a structured way to define the types and valid ranges for optimizable parameters.
- **Changes:**
    - Created new files:
        - `ChromosomeSpec.java`: Defines the interface for chromosome specifications, including methods for getting the valid range and creating a chromosome.
        - `IntegerChromosomeSpec.java`: Implementation of `ChromosomeSpec` for integer-valued parameters.
        - `DoubleChromosomeSpec.java`: Implementation of `ChromosomeSpec` for double-valued parameters.
    - Modified `src/main/java/com/verlumen/tradestream/backtesting/params/BUILD`:
        - Renamed the `java_library` from `param_config` to `params_lib`.
        - Updated `srcs` to use `glob(["*.java"])` to automatically include all Java files in the directory.
- **Benefits:**
    - Provides a clear and type-safe way to define parameter constraints for backtesting.
    - Enhances the flexibility and configurability of parameter optimization processes.
    - Improves code organization by separating parameter specification logic into dedicated classes.