### PR TITLE
Relax Generic Type Constraint on `ChromosomeSpec` for Numeric Types

### DIFF
--- a/src/main/java/com/verlumen/tradestream/backtesting/params/ChromosomeSpec.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/params/ChromosomeSpec.java
@@ -8,7 +8,7 @@ import io.jenetics.NumericGene;
  * Specifies type and range constraints for a chromosome in parameter optimization.
  * @param <T> The type of value being optimized (e.g. Integer, Double)
  */
-public interface ChromosomeSpec<T extends Comparable<T>> {
+public interface ChromosomeSpec<T extends Number & Comparable<? super T>> {
     /**
      * Gets the valid range for this parameter.
      */

--- a/src/main/java/com/verlumen/tradestream/backtesting/params/ChromosomeSpec.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/params/ChromosomeSpec.java
@@ -1,8 +1,8 @@
 package com.verlumen.tradestream.backtesting.params;
 
 import com.google.common.collect.Range;
-import io.jenetics.Chromosome;
-import io.jenetics.Gene;
+import io.jenetics.NumericChromosome;
+import io.jenetics.NumericGene;
 
 /**
  * Specifies type and range constraints for a chromosome in parameter optimization.
@@ -17,7 +17,7 @@ public interface ChromosomeSpec<T extends Comparable<T>> {
     /**
      * Creates an initial chromosome according to this specification.
      */
-    Chromosome<? extends Gene<T, ?>> createChromosome();
+    NumericChromosome<T, ?> createChromosome();
 
     /**
      * Creates an integer-valued parameter specification.

--- a/src/main/java/com/verlumen/tradestream/backtesting/params/DoubleChromosomeSpec.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/params/DoubleChromosomeSpec.java
@@ -1,15 +1,13 @@
 package com.verlumen.tradestream.backtesting.params;
 
 import com.google.common.collect.Range;
-import io.jenetics.Chromosome;
 import io.jenetics.DoubleChromosome;
-import io.jenetics.DoubleGene;
-import io.jenetics.Gene;
+import io.jenetics.NumericChromosome;
 
 /**
  * Specification for double-valued chromosomes.
  */
-public final class DoubleChromosomeSpec implements ChromosomeSpec<Double> {
+final class DoubleChromosomeSpec implements ChromosomeSpec<Double> {
     private final Range<Double> range;
 
     DoubleChromosomeSpec(Range<Double> range) {
@@ -22,7 +20,7 @@ public final class DoubleChromosomeSpec implements ChromosomeSpec<Double> {
     }
 
     @Override
-    public Chromosome<DoubleGene> createChromosome() {
+    public NumericChromosome<Double, ?> createChromosome() {
         return DoubleChromosome.of(
             range.lowerEndpoint(),
             range.upperEndpoint());

--- a/src/main/java/com/verlumen/tradestream/backtesting/params/IntegerChromosomeSpec.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/params/IntegerChromosomeSpec.java
@@ -1,15 +1,13 @@
 package com.verlumen.tradestream.backtesting.params;
 
 import com.google.common.collect.Range;
-import io.jenetics.Chromosome;
 import io.jenetics.IntegerChromosome;
-import io.jenetics.IntegerGene;
-import io.jenetics.Gene;
+import io.jenetics.NumericChromosome;
 
 /**
  * Specification for integer-valued chromosomes.
  */
-public final class IntegerChromosomeSpec implements ChromosomeSpec<Integer> {
+final class IntegerChromosomeSpec implements ChromosomeSpec<Integer> {
     private final Range<Integer> range;
 
     IntegerChromosomeSpec(Range<Integer> range) {
@@ -22,7 +20,7 @@ public final class IntegerChromosomeSpec implements ChromosomeSpec<Integer> {
     }
 
     @Override
-    public Chromosome<IntegerGene> createChromosome() {
+    public NumericChromosome<Integer, ?> createChromosome() {
         return IntegerChromosome.of(
             range.lowerEndpoint(),
             range.upperEndpoint());


### PR DESCRIPTION
- **Context:** This change relaxes the generic type constraint on the `ChromosomeSpec` interface to better accommodate various numeric types supported by Jenetics.
- **Changes:**
    - Updated the generic type parameter `T` of `ChromosomeSpec` from `T extends Comparable<T>` to `T extends Number & Comparable<? super T>`. This allows `ChromosomeSpec` to work with subtypes of `Number`.
    - The `DoubleChromosomeSpec` and `IntegerChromosomeSpec` implementations are now `final` and have reduced visibility (package-private).
    - The `createChromosome()` method in `ChromosomeSpec` now returns `NumericChromosome<T, ?>` instead of `Chromosome<? extends Gene<T, ?>>`.
- **Benefits:**
    - Improves compatibility with Jenetics' `NumericChromosome` and `NumericGene` hierarchy.
    - Provides more flexibility in defining chromosome specifications for different numeric parameter types.
    - Enhances the type safety of parameter configuration by aligning with Jenetics' type system.