### PR TITLE
Upgrade Java Toolchain to Version 21

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,10 +1,10 @@
 common --enable_bzlmod
 
 # Add Java toolchain platform configuration
-build --java_runtime_version=remotejdk_17
-build --java_language_version=17
-build --tool_java_runtime_version=remotejdk_17
-build --tool_java_language_version=17
+build --java_runtime_version=remotejdk_21
+build --java_language_version=21
+build --tool_java_runtime_version=remotejdk_21
+build --tool_java_language_version=21
 
 # Enable platform-based toolchain resolution
 build --incompatible_enable_cc_toolchain_resolution

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@ JAVA_LANGUAGE_LEVEL = "21"
 java = use_extension("@rules_java//java:extensions.bzl", "java")
 java.toolchain(
     name = "java",
-    java_runtime = "@rules_java//toolchains:remotejdk_17",
+    java_runtime = "@rules_java//toolchains:remotejdk_21",
     source_version = JAVA_LANGUAGE_LEVEL,
     target_version = JAVA_LANGUAGE_LEVEL,
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,7 +15,7 @@ bazel_dep(name = "rules_jvm_external", version = "6.5")
 bazel_dep(name = "rules_oci", version = "2.0.1")
 
 # Add Java toolchain configuration
-JAVA_LANGUAGE_LEVEL = "17"
+JAVA_LANGUAGE_LEVEL = "21"
 
 java = use_extension("@rules_java//java:extensions.bzl", "java")
 java.toolchain(


### PR DESCRIPTION
- **Context:** This change updates the Java Development Kit (JDK) version used for building the project to Java 21. This ensures that the project leverages the latest features and improvements in the Java ecosystem.
- **Changes:**
    - In `.bazelrc`, updated `java_runtime_version` and `tool_java_runtime_version` to `remotejdk_21`.
    - In `.bazelrc`, updated `java_language_version` and `tool_java_language_version` to `21`.
    - In `MODULE.bazel`, updated `JAVA_LANGUAGE_LEVEL` to `"21"`.
    - In `MODULE.bazel`, updated the `java.toolchain` to use `@rules_java//toolchains:remotejdk_21`.
- **Benefits:**
    - Leverages new language features and performance improvements in Java 21.
    - Keeps the project aligned with current Java standards and best practices.
    - Potentially improves build performance and developer experience.