### PR TITLE
Add `getStrategyType()` to `ParamConfig` and Implement in `SmaRsiParamConfig`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/backtesting/params/ParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/params/ParamConfig.java
@@ -2,6 +2,7 @@ package com.verlumen.tradestream.backtesting.params;
 
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;
+import com.verlumen.tradestream.strategies.StrategyType;
 import io.jenetics.Gene;
 import io.jenetics.NumericChromosome;
 import io.jenetics.NumericGene;
@@ -28,4 +29,10 @@ public interface ParamConfig {
      * @return List of initial chromosomes for optimization
      */
     ImmutableList<? extends NumericChromosome<?, ?>> initialChromosomes();
+
+    /**
+     * Returns the strategy type that this parameter configuration is for.
+     * @return The strategy type associated with these parameters
+     */
+    StrategyType getStrategyType();
 }

--- a/src/main/java/com/verlumen/tradestream/backtesting/params/SmaRsiParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/params/SmaRsiParamConfig.java
@@ -2,15 +2,13 @@ package com.verlumen.tradestream.backtesting.params;
 
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;
+import com.verlumen.tradestream.strategies.SmaRsiParameters;
+import com.verlumen.tradestream.strategies.StrategyType;
 import io.jenetics.IntegerChromosome;
 import io.jenetics.DoubleChromosome;
 import io.jenetics.NumericChromosome;
-import com.verlumen.tradestream.strategies.SmaRsiParameters;
 
-/**
- * Parameter configuration for SMA/RSI strategy with proper integer and double parameters.
- */
-public final class SmaRsiParamConfig implements ParamConfig {
+final class SmaRsiParamConfig implements ParamConfig {
     private static final ImmutableList<ChromosomeSpec<?>> SPECS = ImmutableList.of(
         // Integer parameters
         ChromosomeSpec.ofInteger(5, 50),    // Moving Average Period
@@ -54,5 +52,10 @@ public final class SmaRsiParamConfig implements ParamConfig {
         return SPECS.stream()
             .map(ChromosomeSpec::createChromosome)
             .collect(ImmutableList.toImmutableList());
+    }
+
+    @Override
+    public StrategyType getStrategyType() {
+        return StrategyType.SMA_RSI;
     }
 }


### PR DESCRIPTION
- **Context:** This change introduces a `getStrategyType()` method to the `ParamConfig` interface. This allows associating a given parameter configuration with a specific trading strategy, which is needed for identifying the right configuration for a given strategy during optimization.
- **Changes:**
    - Added the `getStrategyType()` method to the `ParamConfig` interface, returning a `StrategyType` enum.
    - Implemented the `getStrategyType()` method in `SmaRsiParamConfig`, returning `StrategyType.SMA_RSI`.
- **Benefits:**
    - Allows the system to programmatically identify the trading strategy that a given `ParamConfig` applies to.
    - Facilitates better management and organization of strategy-specific parameter configurations during backtesting.