### PR TITLE
Introduce `StrategyEngine` Interface for Trading Strategies

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -78,7 +78,7 @@ java_library(
     srcs = ["StrategyEngine.java"],
     deps = [
         "//protos:marketdata_java_proto",
-        "//protos:strategies_java_proto",
+        "//third_party:ta4j_core",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -74,6 +74,15 @@ oci_push(
 )
 
 java_library(
+    name = "strategy_engine",
+    srcs = ["StrategyEngine.java"],
+    deps = [
+        "//protos:marketdata_java_proto",
+        "//protos:strategies_java_proto",
+    ],
+)
+
+java_library(
     name = "strategy_factory",
     srcs = ["StrategyFactory.java"],
     deps = [

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyEngine.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyEngine.java
@@ -1,0 +1,20 @@
+package com.verlumen.tradestream.strategies;
+
+import com.google.tradestream.marketdata.Candle;
+
+interface StrategyEngine {
+    /**
+     * Handles new candle data from the market
+     */
+    void handleCandle(Candle candle);
+    
+    /**
+     * Requests optimization of strategy parameters
+     */
+    void optimizeStrategy();
+    
+    /**
+     * Gets the current active strategy
+     */
+    Strategy getCurrentStrategy();
+}

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyEngine.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyEngine.java
@@ -1,6 +1,7 @@
 package com.verlumen.tradestream.strategies;
 
 import com.verlumen.tradestream.marketdata.Candle;
+import org.ta4j.core.Strategy;
 
 interface StrategyEngine {
     /**

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyEngine.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyEngine.java
@@ -1,6 +1,6 @@
 package com.verlumen.tradestream.strategies;
 
-import com.google.tradestream.marketdata.Candle;
+import com.verlumen.tradestream.marketdata.Candle;
 
 interface StrategyEngine {
     /**


### PR DESCRIPTION
- **Context:** This change introduces the `StrategyEngine` interface, which defines the core functionality of a trading strategy engine. This includes handling incoming candle data, optimizing strategy parameters, and accessing the current active strategy.
- **Changes:**
    - Created `src/main/java/com/verlumen/tradestream/strategies/StrategyEngine.java`: This new interface defines methods for `handleCandle`, `optimizeStrategy`, and `getCurrentStrategy`.
    - Modified `src/main/java/com/verlumen/tradestream/strategies/BUILD`: Added a build target for the `strategy_engine` library and its dependencies.
- **Benefits:**
    - Provides a standardized interface for various strategy implementations.
    - Decouples the strategy implementations from specific trading logic.
    - Enables easier management and testing of different trading strategies.