### PR TITLE
Introduce `MarketDataConsumer` Interface for Handling Market Data

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -66,6 +66,14 @@ tar(
     srcs = [":app_deploy.jar"],
 )
 
+java_library(
+    name = "market_data_consumer",
+    srcs = ["MarketDataConsumer.java"],
+    deps = [
+        "//protos:marketdata_java_proto",
+    ],
+)
+
 oci_push(
     name = "push_image",
     image = ":index",

--- a/src/main/java/com/verlumen/tradestream/strategies/MarketDataConsumer.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/MarketDataConsumer.java
@@ -1,0 +1,22 @@
+package com.verlumen.tradestream.strategies;
+
+import com.verlumen.tradestream.marketdata.Candle;
+import java.util.function.Consumer;
+
+/**
+ * Interface for consuming market data from Kafka and forwarding it to
+ * registered handlers.
+ */
+interface MarketDataConsumer {
+    /**
+     * Starts consuming market data and forwards it to the provided handler.
+     *
+     * @param handler Consumer that will process each candle
+     */
+    void startConsuming(Consumer<Candle> handler);
+
+    /**
+     * Stops consuming market data and performs cleanup.
+     */
+    void stopConsuming();
+}


### PR DESCRIPTION
- **Context:** This change introduces the `MarketDataConsumer` interface, which defines how market data (specifically candles) is consumed and processed. This abstraction is intended to decouple the consumption logic from the strategy engine.
- **Changes:**
    - Created `src/main/java/com/verlumen/tradestream/strategies/MarketDataConsumer.java`: This new interface defines methods `startConsuming` and `stopConsuming` for handling the market data stream.
    - Modified `src/main/java/com/verlumen/tradestream/strategies/BUILD`: Added a build target for the `market_data_consumer` library, and its dependencies.
- **Benefits:**
    - Provides a standard way to consume and process market data within the strategy engine.
    - Decouples the strategy engine from the specific data source.
    - Enables easier testing and switching between different market data sources.