### PR TITLE
Introduce `StrategiesModule` for Strategy Configuration

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -74,6 +74,16 @@ oci_push(
 )
 
 java_library(
+    name = "strategies_module",
+    srcs = ["StrategiesModule.java"],
+    deps = [
+        "//third_party:auto_value",
+        "//third_party:guava",
+        "//third_party:guice",
+    ],
+)
+
+java_library(
     name = "strategy_engine",
     srcs = ["StrategyEngine.java"],
     deps = [

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.java
@@ -1,0 +1,17 @@
+package com.verlumen.tradestream.strategies;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.AbstractModule;
+
+@AutoValue
+abstract class StrategiesModule extends AbstractModule {
+  static StrategiesModule create(String[] commandLineArgs) {
+    return new AutoValue_StrategiesModule(ImmutableList.copyOf(commandLineArgs));
+  }
+
+  abstract ImmutableList<String> commandLineArgs();
+  
+  @Override
+  protected void configure() {}
+}


### PR DESCRIPTION
- **Context:** This change introduces the `StrategiesModule`, a Guice module designed to handle the configuration of strategy-related components. This module provides a way to manage dependencies and settings required by strategies.
- **Changes:**
    - Created `src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.java`: This new class is a Guice module that provides a mechanism to pass command-line arguments to the strategy components, and potentially other strategy related dependency binding logic in the future.
    - Modified `src/main/java/com/verlumen/tradestream/strategies/BUILD`: Added a build target for the `strategies_module` library and its dependencies.
- **Benefits:**
    - Provides a standard way to configure and inject strategy-specific dependencies.
    - Improves the modularity and testability of strategy components by decoupling them from concrete implementations.
    - Enables command-line arguments to be passed and used to configure strategies.