### PR TITLE
Add `Strategy` Message to `strategies.proto` and Update Dependencies

### DIFF
--- a/protos/BUILD
+++ b/protos/BUILD
@@ -37,6 +37,9 @@ java_proto_library(
 proto_library(
     name = "strategies_proto",
     srcs = ["strategies.proto"],
+    deps = [
+        "@com_google_protobuf//:any_proto",
+    ],
 )
 
 java_proto_library(

--- a/protos/strategies.proto
+++ b/protos/strategies.proto
@@ -5,6 +5,11 @@ package strategies;
 option java_multiple_files = true;
 option java_package = "com.verlumen.tradestream.strategies";
 
+message StrategyParameters {
+  StrategyType type = 1;
+  google.protobuf.Any parameters = 2;
+}
+
 enum StrategyType {
   SMA_RSI = 0;
   EMA_MACD = 1;

--- a/protos/strategies.proto
+++ b/protos/strategies.proto
@@ -5,7 +5,7 @@ package strategies;
 option java_multiple_files = true;
 option java_package = "com.verlumen.tradestream.strategies";
 
-message StrategyParameters {
+message Strategy {
   StrategyType type = 1;
   google.protobuf.Any parameters = 2;
 }

--- a/protos/strategies.proto
+++ b/protos/strategies.proto
@@ -5,6 +5,8 @@ package strategies;
 option java_multiple_files = true;
 option java_package = "com.verlumen.tradestream.strategies";
 
+import "google/protobuf/any.proto";
+
 message Strategy {
   StrategyType type = 1;
   google.protobuf.Any parameters = 2;


### PR DESCRIPTION
- **Context:** This change adds a new `Strategy` message to `strategies.proto` and updates the `BUILD` file to include a dependency to `any_proto`. This new message will be used to represent a strategy and its parameters.
- **Changes:**
    - Added a `Strategy` message to `strategies.proto` that includes a `StrategyType` and a `google.protobuf.Any` field for the strategy parameters.
    - Updated the `strategies_proto` target in `protos/BUILD` to depend on `@com_google_protobuf//:any_proto`.
- **Benefits:**
    - Introduces a new message to represent trading strategies with their associated parameters.
    - Allows for more flexible and dynamic representation of strategy parameters, enabling different parameter types for different strategies without needing to define separate fields.