### PR TITLE
Move `TradeSignalPublisher` Interface to the `signals` Package

### DIFF
--- a/src/main/java/com/verlumen/tradestream/signals/BUILD
+++ b/src/main/java/com/verlumen/tradestream/signals/BUILD
@@ -1,0 +1,9 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
+java_library(
+    name = "trade_signal_publisher",
+    srcs = ["TradeSignalPublisher.java"],
+    deps = [
+        "//protos:trade_signals_java_proto",
+    ],
+)

--- a/src/main/java/com/verlumen/tradestream/signals/TradeSignalPublisher.java
+++ b/src/main/java/com/verlumen/tradestream/signals/TradeSignalPublisher.java
@@ -1,0 +1,5 @@
+package com.verlumen.tradestream.signals;
+
+interface TradeSignalPublisher {
+    void publish(TradeSignal signal);
+}

--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -148,11 +148,3 @@ java_library(
         ":strategy_manager",
     ],
 )
-
-java_library(
-    name = "trade_signal_publisher",
-    srcs = ["TradeSignalPublisher.java"],
-    deps = [
-        "//protos:trade_signals_java_proto",
-    ],
-)

--- a/src/main/java/com/verlumen/tradestream/strategies/TradeSignalPublisher.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/TradeSignalPublisher.java
@@ -1,7 +1,0 @@
-package com.verlumen.tradestream.strategies;
-
-import com.verlumen.tradestream.signals.TradeSignal;
-
-interface TradeSignalPublisher {
-    void publish(TradeSignal signal);
-}


### PR DESCRIPTION
- **Context:** This change reorganizes the location of the `TradeSignalPublisher` interface. Since it's primarily related to signal processing, it is more appropriate to move it to the `com.verlumen.tradestream.signals` package.
- **Changes:**
    - Created `src/main/java/com/verlumen/tradestream/signals/BUILD`: This new `BUILD` file defines the target for `trade_signal_publisher`.
    - Created `src/main/java/com/verlumen/tradestream/signals/TradeSignalPublisher.java`: Moved the `TradeSignalPublisher` interface from `com.verlumen.tradestream.strategies`.
    - Modified `src/main/java/com/verlumen/tradestream/strategies/BUILD`: Removed the `trade_signal_publisher` library.
    - Removed `src/main/java/com/verlumen/tradestream/strategies/TradeSignalPublisher.java`.
- **Benefits:**
    - Improves code organization by grouping related interfaces within their respective packages.
    - Aligns the location of the `TradeSignalPublisher` with its primary usage and concern, namely, signal publication.
    - Maintains a clearer separation of concerns between the `strategies` and `signals` packages.