### PR TITLE
 Inject `MarketDataConsumer` into `App`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/App.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/App.java
@@ -11,8 +11,12 @@ import com.google.inject.Inject;
 final class App {
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
+  private final MarketDataConsumer marketDataConsumer;
+
   @Inject
-  App() {}
+  App(MarketDataConsumer marketDataConsumer) {
+    this.marketDataConsumer = marketDataConsumer;
+  }
 
   /** Starts all strategy module components */
   public void start() {

--- a/src/main/java/com/verlumen/tradestream/strategies/App.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/App.java
@@ -21,7 +21,7 @@ final class App {
   private final RunMode runMode;
 
   @Inject
-  App(MarketDataConsumer marketDataConsumer) {
+  App(MarketDataConsumer marketDataConsumer, RunMode runMode) {
     this.marketDataConsumer = marketDataConsumer;
     this.runMode = runMode;
   }

--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -13,6 +13,7 @@ java_binary(
     deps = [
         "//third_party:flogger",
         "//third_party:guice",
+        ":market_data_consumer",
     ],
     runtime_deps = [
         "//third_party:flogger_system_backend",


### PR DESCRIPTION
- **Context:** This change adds a dependency on `MarketDataConsumer` to the `App` class. This enables the `App` to utilize the market data consumption functionality.
- **Changes:**
    - Modified `src/main/java/com/verlumen/tradestream/strategies/App.java`: Added a `MarketDataConsumer` field and updated the constructor to inject it.
    - Modified `src/main/java/com/verlumen/tradestream/strategies/BUILD`: Added a dependency on `:market_data_consumer` to the `app` target.
- **Benefits:**
    - Enables the `App` to use the `MarketDataConsumer` for consuming and processing market data.
    - Sets up the dependency required for future initialization logic of `MarketDataConsumer`.