### PR TITLE
Add `StrategyManager` Dependency to `StrategyEngineImpl`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -109,6 +109,7 @@ java_library(
         "//third_party:guice",
         "//third_party:ta4j_core",
         ":strategy_engine",
+        ":strategy_manager",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyEngineImpl.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyEngineImpl.java
@@ -5,25 +5,29 @@ import com.verlumen.tradestream.marketdata.Candle;
 import org.ta4j.core.Strategy;
 
 /**
- * Core implementation of the Strategy Engine that coordinates strategy optimization,
- * candlestick processing, and trade signal generation.
+ * Core implementation of the Strategy Engine that coordinates strategy optimization, candlestick
+ * processing, and trade signal generation.
  */
 final class StrategyEngineImpl implements StrategyEngine {
-    @Inject
-    StrategyEngineImpl() {}
+  private final StrategyManager strategyManager;
 
-    @Override
-    public synchronized void handleCandle(Candle candle) {
-        throw new UnsupportedOperationException();
-    }
+  @Inject
+  StrategyEngineImpl(StrategyManager strategyManager) {
+    this.strategyManager = strategyManager;
+  }
 
-    @Override
-    public synchronized void optimizeStrategy() {
-        throw new UnsupportedOperationException();
-    }
+  @Override
+  public synchronized void handleCandle(Candle candle) {
+    throw new UnsupportedOperationException();
+  }
 
-    @Override
-    public Strategy getCurrentStrategy() {
-        throw new UnsupportedOperationException();
-    }
+  @Override
+  public synchronized void optimizeStrategy() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Strategy getCurrentStrategy() {
+    throw new UnsupportedOperationException();
+  }
 }


### PR DESCRIPTION
- **Context:** This change adds a dependency on `StrategyManager` to `StrategyEngineImpl`. This dependency will be used by the Strategy Engine to manage and access the current active strategy.
- **Changes:**
    - Modified `src/main/java/com/verlumen/tradestream/strategies/StrategyEngineImpl.java`: Added a `StrategyManager` field and updated the constructor to inject it.
    - Modified `src/main/java/com/verlumen/tradestream/strategies/BUILD`: Added a dependency on `:strategy_manager` to the `strategy_engine_impl` target.
- **Benefits:**
    - Allows `StrategyEngineImpl` to interact with and manage the current strategy via the `StrategyManager`.
    - Sets up the dependency required for the implementation of strategy selection/management logic.