### PR TITLE
Inject `StrategiesModule` into `App`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/App.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/App.java
@@ -24,7 +24,7 @@ final class App {
 
   public static void main(String[] args) throws Exception {
     logger.atInfo().log("TradeStream application starting up with %d arguments", args.length);
-    App app = Guice.createInjector(StrategiesModule.create()).getInstance(App.class);
+    App app = Guice.createInjector(StrategiesModule.create(args)).getInstance(App.class);
 
     // Start the service
     app.start();

--- a/src/main/java/com/verlumen/tradestream/strategies/App.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/App.java
@@ -24,7 +24,7 @@ final class App {
 
   public static void main(String[] args) throws Exception {
     logger.atInfo().log("TradeStream application starting up with %d arguments", args.length);
-    App app = Guice.createInjector().getInstance(App.class);
+    App app = Guice.createInjector(StrategiesModule.create()).getInstance(App.class);
 
     // Start the service
     app.start();

--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -13,6 +13,7 @@ java_binary(
     deps = [
         "//third_party:flogger",
         "//third_party:guice",
+        ":strategies_module",
     ],
     runtime_deps = [
         "//third_party:flogger_system_backend",


### PR DESCRIPTION
- **Context:** This change updates the `App` class to use `StrategiesModule` when creating the Guice injector, so that command line arguments are available for binding logic in the future.
- **Changes:**
    - Modified `src/main/java/com/verlumen/tradestream/strategies/App.java` to pass `StrategiesModule.create(args)` to `Guice.createInjector(...)`.
    - Modified `src/main/java/com/verlumen/tradestream/strategies/BUILD` to add a dependency on `:strategies_module` to the `app` target.
- **Benefits:**
    - Enables the use of command-line arguments within the Guice dependency injection context.
    - Provides a centralized way to pass arguments and control the configuration of the application.