### PR TITLE
Move `RunMode` Enum to `execution` Package

### DIFF
--- a/src/main/java/com/verlumen/tradestream/execution/BUILD
+++ b/src/main/java/com/verlumen/tradestream/execution/BUILD
@@ -1,5 +1,7 @@
 load("@rules_java//java:defs.bzl", "java_library")
 
+package(default_visibility = ["//visibility:public"])
+
 java_library(
     name = "run_mode",
     srcs = ["RunMode.java"],

--- a/src/main/java/com/verlumen/tradestream/execution/BUILD
+++ b/src/main/java/com/verlumen/tradestream/execution/BUILD
@@ -1,0 +1,6 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
+java_library(
+    name = "run_mode",
+    srcs = ["RunMode.java"],
+)

--- a/src/main/java/com/verlumen/tradestream/execution/RunMode.java
+++ b/src/main/java/com/verlumen/tradestream/execution/RunMode.java
@@ -1,6 +1,6 @@
 package com.verlumen.tradestream.execution;
 
-enum RunMode {
+public enum RunMode {
   WET,
   DRY;
 }

--- a/src/main/java/com/verlumen/tradestream/execution/RunMode.java
+++ b/src/main/java/com/verlumen/tradestream/execution/RunMode.java
@@ -1,0 +1,6 @@
+package com.verlumen.tradestream.execution;
+
+enum RunMode {
+  WET,
+  DRY;
+}

--- a/src/main/java/com/verlumen/tradestream/ingestion/App.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/App.java
@@ -3,6 +3,7 @@ package com.verlumen.tradestream.ingestion;
 import com.google.common.flogger.FluentLogger;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
+import com.verlumen.tradestream.execution.RunMode;
 
 final class App {
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -17,7 +17,7 @@ java_binary(
         ":ingestion_module",
         ":real_time_data_ingestion",
         ":real_time_data_ingestion_impl",
-        ":run_mode",
+        "//src/main/java/com/verlumen/tradestream/mode:run_mode",
     ],
     runtime_deps = [
         "//third_party:flogger_system_backend",
@@ -284,7 +284,7 @@ java_library(
         ":kafka_producer_provider",
         ":real_time_data_ingestion",
         ":real_time_data_ingestion_impl",
-        ":run_mode",
+        "//src/main/java/com/verlumen/tradestream/mode:run_mode",
         ":thin_market_timer",
         ":thin_market_timer_impl",
         ":thin_market_timer_task",
@@ -358,11 +358,6 @@ java_library(
     runtime_deps = [
         "//third_party:flogger_system_backend",
     ],
-)
-
-java_library(
-    name = "run_mode",
-    srcs = ["RunMode.java"],
 )
 
 java_library(

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -17,7 +17,7 @@ java_binary(
         ":ingestion_module",
         ":real_time_data_ingestion",
         ":real_time_data_ingestion_impl",
-        "//src/main/java/com/verlumen/tradestream/mode:run_mode",
+        "//src/main/java/com/verlumen/tradestream/execution:run_mode",
     ],
     runtime_deps = [
         "//third_party:flogger_system_backend",
@@ -284,7 +284,7 @@ java_library(
         ":kafka_producer_provider",
         ":real_time_data_ingestion",
         ":real_time_data_ingestion_impl",
-        "//src/main/java/com/verlumen/tradestream/mode:run_mode",
+        "//src/main/java/com/verlumen/tradestream/execution:run_mode",
         ":thin_market_timer",
         ":thin_market_timer_impl",
         ":thin_market_timer_task",

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -1,4 +1,4 @@
-package com.verlumen.tradestream.execution;
+package com.verlumen.tradestream.ingestion;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
@@ -7,12 +7,12 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.TypeLiteral;
-import org.apache.kafka.clients.producer.KafkaProducer;
-import info.bitrich.xchangestream.core.StreamingExchange;
-import net.sourceforge.argparse4j.inf.Namespace;
-
+import com.verlumen.tradestream.execution.RunMode;
 import java.util.Properties;
 import java.util.Timer;
+import info.bitrich.xchangestream.core.StreamingExchange;
+import net.sourceforge.argparse4j.inf.Namespace;
+import org.apache.kafka.clients.producer.KafkaProducer;
 
 @AutoValue
 abstract class IngestionModule extends AbstractModule {

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -1,4 +1,4 @@
-package com.verlumen.tradestream.ingestion;
+package com.verlumen.tradestream.execution;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/com/verlumen/tradestream/ingestion/RunMode.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RunMode.java
@@ -1,6 +1,0 @@
-package com.verlumen.tradestream.ingestion;
-
-enum RunMode {
-  WET,
-  DRY;
-}

--- a/src/main/java/com/verlumen/tradestream/mode/RunMode.java
+++ b/src/main/java/com/verlumen/tradestream/mode/RunMode.java
@@ -1,6 +1,0 @@
-package com.verlumen.tradestream.mode;
-
-enum RunMode {
-  WET,
-  DRY;
-}

--- a/src/main/java/com/verlumen/tradestream/mode/RunMode.java
+++ b/src/main/java/com/verlumen/tradestream/mode/RunMode.java
@@ -1,0 +1,6 @@
+package com.verlumen.tradestream.mode;
+
+enum RunMode {
+  WET,
+  DRY;
+}

--- a/src/test/java/com/verlumen/tradestream/ingestion/AppTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/AppTest.java
@@ -6,6 +6,7 @@ import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
+import com.verlumen.tradestream.execution.RunMode;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -6,9 +6,9 @@ java_test(
       "AppTest.java"
     ],
     deps = [
+        "//src/main/java/com/verlumen/tradestream/execution:run_mode",
         "//src/main/java/com/verlumen/tradestream/ingestion:app",
         "//src/main/java/com/verlumen/tradestream/ingestion:real_time_data_ingestion",
-        "//src/main/java/com/verlumen/tradestream/ingestion:run_mode",
         "//third_party:guice",
         "//third_party:guice_testlib",
         "//third_party:junit",


### PR DESCRIPTION
- **Context:** This change relocates the `RunMode` enum from the `com.verlumen.tradestream.ingestion` package to a new `com.verlumen.tradestream.execution` package. This move is part of an effort to better organize the codebase.
- **Changes:**
    - Created `src/main/java/com/verlumen/tradestream/execution/BUILD`: Defines the build target for `run_mode`.
    - Created `src/main/java/com/verlumen/tradestream/execution/RunMode.java`: Defines the `RunMode` enum.
    - Modified `src/main/java/com/verlumen/tradestream/ingestion/BUILD`: Removed the `run_mode` target and updated the dependencies to use the new location of the `RunMode` enum.
    - Removed `src/main/java/com/verlumen/tradestream/ingestion/RunMode.java`.
    - Modified `src/test/java/com/verlumen/tradestream/ingestion/AppTest.java` to use the new package for `RunMode`.
    - Modified `src/test/java/com/verlumen/tradestream/ingestion/BUILD` to use the new package for `RunMode`.
- **Benefits:**
    - Improves code organization by grouping related enums into their specific package.
    - Provides a clearer separation of concerns between ingestion and execution modules.