### PR TITLE
Introduce `ExecutionModule` for Runtime Configuration

### DIFF
--- a/src/main/java/com/verlumen/tradestream/execution/BUILD
+++ b/src/main/java/com/verlumen/tradestream/execution/BUILD
@@ -7,6 +7,7 @@ java_library(
     srcs = ["ExecutionModule.java"],
     deps = [
         "//third_party:auto_value",
+        "//third_party:guice",
         ":run_mode",
     ],
 )

--- a/src/main/java/com/verlumen/tradestream/execution/BUILD
+++ b/src/main/java/com/verlumen/tradestream/execution/BUILD
@@ -3,6 +3,15 @@ load("@rules_java//java:defs.bzl", "java_library")
 package(default_visibility = ["//visibility:public"])
 
 java_library(
+    name = "execution_module",
+    srcs = ["ExecutionModule.java"],
+    deps = [
+        "//third_party:auto_value",
+        ":run_mode",
+    ],
+)
+
+java_library(
     name = "run_mode",
     srcs = ["RunMode.java"],
 )

--- a/src/main/java/com/verlumen/tradestream/execution/ExecutionModule.java
+++ b/src/main/java/com/verlumen/tradestream/execution/ExecutionModule.java
@@ -1,0 +1,19 @@
+package com.verlumen.tradestream.execution;
+
+import com.google.auto.value.AutoValue;
+import com.google.inject.AbstractModule;
+
+@AutoValue
+abstract class ExecutionModule extends AbstractModule {
+  static ExecutionModule create(String runModeName) {
+    RunMode runMode = RunMode.valueOf(runModeName.toUpperCase());
+    return new AutoValue_ExecutionModule(runMode);
+  }
+
+  abstract RunMode runMode();
+  
+  @Override
+  protected void configure() {
+    bind(RunMode.class).toInstance(runMode());
+  }
+}


### PR DESCRIPTION
- **Context:** This change introduces the `ExecutionModule`, a Guice module for configuring execution-related settings, such as the `RunMode`. This allows for runtime configuration of the application.
- **Changes:**
    - Created `src/main/java/com/verlumen/tradestream/execution/ExecutionModule.java`: This new class is a Guice module that allows to bind a specific `RunMode` instance.
    - Modified `src/main/java/com/verlumen/tradestream/execution/BUILD`: Added a build target for the `execution_module` and its dependencies.
- **Benefits:**
    - Provides a way to configure the application's `RunMode` via dependency injection.
    - Facilitates runtime configuration of the application behavior.
    - Enhances modularity and testability by decoupling the `RunMode` from the application logic.