### PR TITLE
Add `fromString` Method to `RunMode` Enum

### DIFF
--- a/src/main/java/com/verlumen/tradestream/execution/RunMode.java
+++ b/src/main/java/com/verlumen/tradestream/execution/RunMode.java
@@ -1,6 +1,10 @@
 package com.verlumen.tradestream.execution;
 
 public enum RunMode {
+  public static RunMode fromString(String name) {
+    return RunMode.valueOf(name.toUpperCase());
+  }
+  
   WET,
   DRY;
 }

--- a/src/main/java/com/verlumen/tradestream/execution/RunMode.java
+++ b/src/main/java/com/verlumen/tradestream/execution/RunMode.java
@@ -1,10 +1,10 @@
 package com.verlumen.tradestream.execution;
 
 public enum RunMode {
+  WET,
+  DRY;
+
   public static RunMode fromString(String name) {
     return RunMode.valueOf(name.toUpperCase());
   }
-  
-  WET,
-  DRY;
 }


### PR DESCRIPTION
- **Context:** This change adds a static `fromString` method to the `RunMode` enum. This method allows creating a `RunMode` instance from a string, which is useful for parsing runtime arguments.
- **Changes:**
    - Added a static `fromString` method to the `RunMode` enum that converts a string to its corresponding `RunMode` enum value (case-insensitive).
- **Benefits:**
    - Provides a convenient way to parse string-based inputs for `RunMode` values.
    - Enhances the flexibility of configuring the application's `RunMode` using external inputs like command-line arguments or configuration files.