### PR TITLE
Bind `StrategyManager` to `StrategyManagerImpl` in `StrategiesModule`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -105,6 +105,8 @@ java_library(
         "//third_party:guice",
         ":market_data_consumer",
         ":market_data_consumer_impl",
+        ":strategy_manager",
+        ":strategy_manager_impl",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.java
@@ -15,5 +15,6 @@ abstract class StrategiesModule extends AbstractModule {
   @Override
   protected void configure() {
     bind(MarketDataConsumer.class).to(MarketDataConsumerImpl.class);
+    bind(StrategyManager.class).to(StrategyManagerImpl.class);
   }
 }


### PR DESCRIPTION
- **Context:** This change adds a binding for the `StrategyManager` interface to its concrete implementation, `StrategyManagerImpl`, within the `StrategiesModule`. This enables dependency injection for the strategy manager.
- **Changes:**
    - Modified `src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.java`: Added a binding for `StrategyManager` to `StrategyManagerImpl`.
    - Modified `src/main/java/com/verlumen/tradestream/strategies/BUILD`: Added `strategy_manager` and `strategy_manager_impl` to the dependencies of `strategies_module`.
- **Benefits:**
    - Allows the `StrategyManagerImpl` to be injected by Guice using its interface.
    - Sets up dependency injection for the strategy manager for consuming classes.