### PR TITLE
Introduce `MovingAverageStrategies` for Centralized Strategy Factory Access

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/movingaverages/MovingAverageStrategies.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/movingaverages/MovingAverageStrategies.java
@@ -1,0 +1,23 @@
+package com.verlumen.tradestream.strategies.movingaverages;
+
+import com.google.common.collect.ImmutableList;
+import com.verlumen.tradestream.strategies.StrategyFactory;
+
+/**
+ * Provides a centralized collection of all available moving average-based strategy factories.
+ * This class is immutable and thread-safe.
+ */
+public final class MovingAverageStrategies {
+    /**
+     * An immutable list of all moving average strategy factories.
+     */
+    public static final ImmutableList<StrategyFactory<?>> ALL_FACTORIES = ImmutableList.of(
+        new DoubleEmaCrossoverStrategyFactory(),
+        new MomentumSmaCrossoverStrategyFactory(),
+        new SmaEmaCrossoverStrategyFactory(),
+        new TripleEmaCrossoverStrategyFactory()
+    );
+
+    // Prevent instantiation
+    private MovingAverageStrategies() {}
+}


### PR DESCRIPTION
- **Context:** This change introduces the `MovingAverageStrategies` class. This class centralizes the collection of all moving average-based strategy factories and provides a single point of access for them.
- **Changes:**
    - Created `src/main/java/com/verlumen/tradestream/strategies/movingaverages/MovingAverageStrategies.java`: This new class contains a public static immutable list called `ALL_FACTORIES` that provides access to the available moving average strategy factories.
- **Benefits:**
    - Provides a central location for all moving average strategy factories, improving code organization.
    - Simplifies access to all moving average strategy factories by making them available through a single immutable list.