### PR TITLE
Introduce `OscillatorStrategies` for Centralized Oscillator Strategy Factory Access

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/oscillators/OscillatorStrategies.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/oscillators/OscillatorStrategies.java
@@ -1,0 +1,22 @@
+package com.verlumen.tradestream.strategies.oscillators;
+
+import com.google.common.collect.ImmutableList;
+import com.verlumen.tradestream.strategies.StrategyFactory;
+
+/**
+ * Provides a centralized collection of all available oscillator-based strategy factories.
+ * This class is immutable and thread-safe. As more oscillator strategies are added,
+ * they should be included in ALL_FACTORIES.
+ */
+public final class OscillatorStrategies {
+    /**
+     * An immutable list of all oscillator strategy factories.
+     */
+    public static final ImmutableList<StrategyFactory<?>> ALL_FACTORIES = ImmutableList.of(
+        new SmaRsiStrategyFactory()
+        // Additional oscillator strategies will be added here as they are implemented
+    );
+
+    // Prevent instantiation
+    private OscillatorStrategies() {}
+}


### PR DESCRIPTION
- **Context:** This change introduces the `OscillatorStrategies` class. This class centralizes the collection of all oscillator-based strategy factories and provides a single point of access for them.
- **Changes:**
    - Created `src/main/java/com/verlumen/tradestream/strategies/oscillators/OscillatorStrategies.java`: This new class contains a public static immutable list called `ALL_FACTORIES` that provides access to the available oscillator strategy factories.
- **Benefits:**
    - Provides a central location for all oscillator strategy factories, improving code organization.
    - Simplifies access to all oscillator strategy factories by making them available through a single immutable list.