### PR TITLE
Make `DoubleEmaCrossoverStrategyFactory` Immutable and Create via Static Method

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactory.java
@@ -16,9 +16,10 @@ import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.rules.CrossedDownIndicatorRule;
 import org.ta4j.core.rules.CrossedUpIndicatorRule;
 
-public class DoubleEmaCrossoverStrategyFactory implements StrategyFactory<DoubleEmaCrossoverParameters> {
-    @Inject
-    DoubleEmaCrossoverStrategyFactory() {}
+final class DoubleEmaCrossoverStrategyFactory implements StrategyFactory<DoubleEmaCrossoverParameters> {
+    static DoubleEmaCrossoverStrategyFactory create() {
+        return new DoubleEmaCrossoverStrategyFactory();
+    }
 
     @Override
     public Strategy createStrategy(BarSeries series, DoubleEmaCrossoverParameters params)
@@ -53,4 +54,6 @@ public class DoubleEmaCrossoverStrategyFactory implements StrategyFactory<Double
     public StrategyType getStrategyType() {
         return StrategyType.DOUBLE_EMA_CROSSOVER;
     }
+
+    private DoubleEmaCrossoverStrategyFactory() {}
 }

--- a/src/main/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactory.java
@@ -2,7 +2,6 @@ package com.verlumen.tradestream.strategies.movingaverages;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.google.inject.Inject;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.verlumen.tradestream.strategies.DoubleEmaCrossoverParameters;
 import com.verlumen.tradestream.strategies.StrategyFactory;

--- a/src/main/java/com/verlumen/tradestream/strategies/movingaverages/MovingAverageStrategies.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/movingaverages/MovingAverageStrategies.java
@@ -12,7 +12,7 @@ public final class MovingAverageStrategies {
      * An immutable list of all moving average strategy factories.
      */
     public static final ImmutableList<StrategyFactory<?>> ALL_FACTORIES = ImmutableList.of(
-        new DoubleEmaCrossoverStrategyFactory(),
+        DoubleEmaCrossoverStrategyFactory.create(),
         new MomentumSmaCrossoverStrategyFactory(),
         new SmaEmaCrossoverStrategyFactory(),
         new TripleEmaCrossoverStrategyFactory()

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -35,7 +35,7 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
 
     @Before
     public void setUp() throws InvalidProtocolBufferException {
-        factory = new DoubleEmaCrossoverStrategyFactory();
+        factory = DoubleEmaCrossoverStrategyFactory.create();
 
         // Standard parameters
         params = DoubleEmaCrossoverParameters.newBuilder()


### PR DESCRIPTION
- **Context:** This change modifies the `DoubleEmaCrossoverStrategyFactory` to be immutable and uses a static method (`create()`) for instantiation. This ensures proper construction and usage of the factory.
- **Changes:**
    - Modified `src/main/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactory.java`: Made the class `final` and the constructor `private`, and introduced a static `create()` method for object instantiation.
    - Modified `src/main/java/com/verlumen/tradestream/strategies/movingaverages/MovingAverageStrategies.java`: Updated how `DoubleEmaCrossoverStrategyFactory` is added to the list of strategy factories.
    - Modified `src/test/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactoryTest.java`: Updated the test class to use the `create()` method.
- **Benefits:**
    - Enforces immutability on the factory class, making it thread-safe.
    - Provides a clearer, controlled way to create instances of the factory.
    - Improves code consistency and maintainability.