### PR TITLE
Introduce `StrategyFactories` for Centralized Access to All Strategy Factories

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -132,6 +132,17 @@ java_library(
 )
 
 java_library(
+    name = "strategy_factories",
+    srcs = ["StrategyFactories.java"],
+    deps = [
+        ":strategy_factory",
+        "//src/main/java/com/verlumen/tradestream/strategies/movingaverages:movingaverages_lib",
+        "//src/main/java/com/verlumen/tradestream/strategies/oscillators:oscillators_lib",
+        "//third_party:guava",
+    ],
+)
+
+java_library(
     name = "strategy_factory",
     srcs = ["StrategyFactory.java"],
     deps = [

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyFactories.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyFactories.java
@@ -1,0 +1,24 @@
+package com.verlumen.tradestream.strategies;
+
+import com.google.common.collect.ImmutableList;
+import com.verlumen.tradestream.strategies.movingaverages.MovingAverageStrategies;
+import com.verlumen.tradestream.strategies.oscillators.OscillatorStrategies;
+
+/**
+ * Provides a centralized collection of all available strategy factories across all categories.
+ * This class aggregates factories from child packages (moving averages, oscillators, etc.)
+ * and is immutable and thread-safe.
+ */
+public final class StrategyFactories {
+    /**
+     * An immutable list of all strategy factories across all categories.
+     */
+    public static final ImmutableList<StrategyFactory<?>> ALL_FACTORIES = 
+        ImmutableList.<StrategyFactory<?>>builder()
+            .addAll(MovingAverageStrategies.ALL_FACTORIES)
+            .addAll(OscillatorStrategies.ALL_FACTORIES)
+            .build();
+
+    // Prevent instantiation
+    private StrategyFactories() {}
+}


### PR DESCRIPTION
- **Context:** This change introduces the `StrategyFactories` class. This class serves as a central registry, providing a single point of access to all strategy factories across different categories (e.g., moving averages, oscillators). It aggregates strategy factories from child packages.
- **Changes:**
    - Created `src/main/java/com/verlumen/tradestream/strategies/StrategyFactories.java`: This new class contains a public static immutable list `ALL_FACTORIES` that aggregates all strategy factories across all categories.
    - Modified `src/main/java/com/verlumen/tradestream/strategies/BUILD`: Added a build target for the `strategy_factories` library and its dependencies.
- **Benefits:**
    - Provides a centralized and easily accessible way to manage all strategy factories.
    - Simplifies the process of obtaining and managing different strategy types in the application.
    - Promotes modularity and code organization by keeping the responsibility of aggregating the strategy factories in one place.