### PR TITLE
Remove Command-Line Args from `StrategiesModule` and Update App

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/App.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/App.java
@@ -48,7 +48,7 @@ final class App {
     Namespace namespace = argumentParser.parseArgs(args);
     String runModeName = namespace.getString("runMode");
     App app =
-        Guice.createInjector(ExecutionModule.create(runModeName), StrategiesModule.create(args))
+        Guice.createInjector(ExecutionModule.create(runModeName), StrategiesModule.create())
             .getInstance(App.class);
 
     // Start the service

--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -100,7 +100,6 @@ java_library(
     name = "strategies_module",
     srcs = ["StrategiesModule.java"],
     deps = [
-        "//third_party:auto_value",
         "//third_party:guava",
         "//third_party:guice",
         ":market_data_consumer",

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.java
@@ -1,5 +1,6 @@
 package com.verlumen.tradestream.strategies;
 
+import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 import com.google.inject.TypeLiteral;
 

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.java
@@ -4,7 +4,7 @@ import com.google.auto.value.AutoValue;
 import com.google.inject.AbstractModule;
 
 @AutoValue
-abstract class StrategiesModule extends AbstractModule {
+final class StrategiesModule extends AbstractModule {
   static StrategiesModule create() {
     return new StrategiesModule();
   }

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.java
@@ -1,16 +1,13 @@
 package com.verlumen.tradestream.strategies;
 
 import com.google.auto.value.AutoValue;
-import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 
 @AutoValue
 abstract class StrategiesModule extends AbstractModule {
-  static StrategiesModule create(String[] commandLineArgs) {
-    return new AutoValue_StrategiesModule(ImmutableList.copyOf(commandLineArgs));
+  static StrategiesModule create() {
+    return new StrategiesModule();
   }
-
-  abstract ImmutableList<String> commandLineArgs();
   
   @Override
   protected void configure() {

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.java
@@ -1,6 +1,5 @@
 package com.verlumen.tradestream.strategies;
 
-import com.google.auto.value.AutoValue;
 import com.google.inject.AbstractModule;
 
 @AutoValue

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.java
@@ -2,7 +2,6 @@ package com.verlumen.tradestream.strategies;
 
 import com.google.inject.AbstractModule;
 
-@AutoValue
 final class StrategiesModule extends AbstractModule {
   static StrategiesModule create() {
     return new StrategiesModule();


### PR DESCRIPTION
- **Context:** This change removes the command-line argument handling from `StrategiesModule` and updates the `App` class to no longer require command-line args when creating the `StrategiesModule`. The `StrategiesModule` is no longer auto value.
- **Changes:**
    - Modified `src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.java`: Removed the field for command line args, and the `create` method no longer accepts args.
    - Modified `src/main/java/com/verlumen/tradestream/strategies/App.java`: Updated Guice injector creation to no longer pass args into the create method.
    - Modified `src/main/java/com/verlumen/tradestream/strategies/BUILD`: Removed the dependency on `auto_value` for the `strategies_module`.
- **Benefits:**
    - Simplifies `StrategiesModule` by removing unnecessary functionality.
    - Allows for a simpler Guice setup.
    - Removes the dependency on `auto_value` from the module.