### PR TITLE
Bind `StrategyFactory` List in `StrategiesModule`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -105,6 +105,8 @@ java_library(
         "//third_party:guice",
         ":market_data_consumer",
         ":market_data_consumer_impl",
+        ":strategy_factories",
+        ":strategy_factory",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.java
@@ -3,6 +3,7 @@ package com.verlumen.tradestream.strategies;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
+import com.google.inject.TypeLiteral;
 
 @AutoValue
 abstract class StrategiesModule extends AbstractModule {
@@ -15,5 +16,7 @@ abstract class StrategiesModule extends AbstractModule {
   @Override
   protected void configure() {
     bind(MarketDataConsumer.class).to(MarketDataConsumerImpl.class);
+    bind(new TypeLiteral<ImmutableList<StrategyFactory<?>>>() {})
+        .toInstance(StrategyFactories.ALL_FACTORIES);
   }
 }


### PR DESCRIPTION
- **Context:** This change modifies `StrategiesModule` to provide a binding for a list of all `StrategyFactory` instances. This allows dependency injection of the full list of strategy factories in classes that need it.
- **Changes:**
    - Modified `src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.java`: Added a binding for an `ImmutableList<StrategyFactory<?>>` to `StrategyFactories.ALL_FACTORIES`.
    - Modified `src/main/java/com/verlumen/tradestream/strategies/BUILD`: Added `strategy_factories` and `strategy_factory` to the dependencies of `strategies_module`.
- **Benefits:**
    - Makes the list of all available strategy factories easily accessible via dependency injection.
    - Improves the flexibility and modularity of the application.
    - Enables the usage of all strategy factories in other components that need to create or manage strategies.