### PR TITLE
Refactor `StrategyManagerImpl` and Test for Immutable Factory List

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -168,7 +168,6 @@ java_library(
     srcs = ["StrategyManagerImpl.java"],
     deps = [
         "//protos:strategies_java_proto",
-        "//third_party:auto_value",
         "//third_party:guava",
         "//third_party:guice",
         "//third_party:mug",

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
@@ -2,6 +2,7 @@ package com.verlumen.tradestream.strategies;
 
 import static java.util.function.Function.identity;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.google.mu.util.stream.BiStream;

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
@@ -14,7 +14,7 @@ final class StrategyManagerImpl implements StrategyManager {
   private final ImmutableMap<StrategyType, StrategyFactory<?>> factoryMap;
 
   @Inject
-  StrategyManagerImpl(ImmutableMap<StrategyType, StrategyFactory<?>> factoryMap) {
+  StrategyManagerImpl(ImmutableList<StrategyFactory<?> factories) {
     this.factoryMap =
         BiStream.from(factories, StrategyFactory::getStrategyType, identity())
             .collect(ImmutableMap::toImmutableMap);

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
@@ -2,8 +2,6 @@ package com.verlumen.tradestream.strategies;
 
 import static java.util.function.Function.identity;
 
-import com.google.auto.value.AutoValue;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.google.mu.util.stream.BiStream;
@@ -13,11 +11,13 @@ import org.ta4j.core.BarSeries;
 import org.ta4j.core.Strategy;
 
 final class StrategyManagerImpl implements StrategyManager {
-  private final Config config;
+  private final ImmutableMap<StrategyType, StrategyFactory<?>> factoryMap;
 
   @Inject
-  StrategyManagerImpl(Config config) {
-    this.config = config;
+  StrategyManagerImpl(ImmutableMap<StrategyType, StrategyFactory<?>> factoryMap) {
+    this.factoryMap =
+        BiStream.from(factories, StrategyFactory::getStrategyType, identity())
+            .collect(ImmutableMap::toImmutableMap);
   }
 
   @Override
@@ -27,19 +27,7 @@ final class StrategyManagerImpl implements StrategyManager {
     if (factory == null) {
       throw new IllegalArgumentException("Unsupported strategy type: " + strategyType);
     }
-  
+
     return factory.createStrategy(barSeries, parameters);
-  }
-
-  @AutoValue
-  abstract static class Config {
-    static Config create(ImmutableList<StrategyFactory<?>> factories) {
-      ImmutableMap<StrategyType, StrategyFactory<?>> factoryMap =
-          BiStream.from(factories, StrategyFactory::getStrategyType, identity())
-              .collect(ImmutableMap::toImmutableMap);
-      return new AutoValue_StrategyManagerImpl_Config(factoryMap);
-    }
-
-    abstract ImmutableMap<StrategyType, StrategyFactory<?>> factoryMap();
   }
 }

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
@@ -15,7 +15,7 @@ final class StrategyManagerImpl implements StrategyManager {
   private final ImmutableMap<StrategyType, StrategyFactory<?>> factoryMap;
 
   @Inject
-  StrategyManagerImpl(ImmutableList<StrategyFactory<?> factories) {
+  StrategyManagerImpl(ImmutableList<StrategyFactory<?>> factories) {
     this.factoryMap =
         BiStream.from(factories, StrategyFactory::getStrategyType, identity())
             .collect(ImmutableMap::toImmutableMap);
@@ -24,7 +24,7 @@ final class StrategyManagerImpl implements StrategyManager {
   @Override
   public Strategy createStrategy(BarSeries barSeries, StrategyType strategyType, Any parameters)
       throws InvalidProtocolBufferException {
-    StrategyFactory<?> factory = config.factoryMap().get(strategyType);
+    StrategyFactory<?> factory = factoryMap.get(strategyType);
     if (factory == null) {
       throw new IllegalArgumentException("Unsupported strategy type: " + strategyType);
     }

--- a/src/test/java/com/verlumen/tradestream/strategies/StrategyManagerImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/StrategyManagerImplTest.java
@@ -23,12 +23,9 @@ import org.ta4j.core.Strategy;
 
 @RunWith(JUnit4.class)
 public class StrategyManagerImplTest {
-
-    @Bind
     @Mock
     private StrategyFactory<SmaRsiParameters> mockSmaRsiFactory;
 
-    @Bind
     @Mock 
     private StrategyFactory<EmaMacdParameters> mockEmaMacdFactory;
 
@@ -44,12 +41,8 @@ public class StrategyManagerImplTest {
         when(mockSmaRsiFactory.getStrategyType()).thenReturn(StrategyType.SMA_RSI);
         when(mockEmaMacdFactory.getStrategyType()).thenReturn(StrategyType.EMA_MACD);
 
-        // Create config with mock factories
-        StrategyManagerImpl.Config config = StrategyManagerImpl.Config.create(
-            ImmutableList.of(mockSmaRsiFactory, mockEmaMacdFactory));
-
         // Initialize strategy manager with mocked dependencies
-        strategyManager = new StrategyManagerImpl(config);
+        strategyManager = new StrategyManagerImpl(ImmutableList.of(mockSmaRsiFactory, mockEmaMacdFactory));
 
         // Create mock strategy and bar series for testing
         mockStrategy = mock(Strategy.class);

--- a/src/test/java/com/verlumen/tradestream/strategies/StrategyManagerImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/StrategyManagerImplTest.java
@@ -6,6 +6,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
+import com.google.inject.Guice;
+import com.google.inject.testing.fieldbinder.Bind;
+import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.junit.Before;

--- a/src/test/java/com/verlumen/tradestream/strategies/StrategyManagerImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/StrategyManagerImplTest.java
@@ -23,115 +23,121 @@ import org.ta4j.core.Strategy;
 
 @RunWith(JUnit4.class)
 public class StrategyManagerImplTest {
-    @Mock
-    private StrategyFactory<SmaRsiParameters> mockSmaRsiFactory;
+  @Mock private StrategyFactory<SmaRsiParameters> mockSmaRsiFactory;
 
-    @Mock 
-    private StrategyFactory<EmaMacdParameters> mockEmaMacdFactory;
+  @Mock private StrategyFactory<EmaMacdParameters> mockEmaMacdFactory;
 
-    private StrategyManagerImpl strategyManager;
-    private Strategy mockStrategy;
-    private BarSeries barSeries;
+  private StrategyManagerImpl strategyManager;
+  private Strategy mockStrategy;
+  private BarSeries barSeries;
 
-    @Before
-    public void setUp() {
-        MockitoAnnotations.openMocks(this);
+  @Before
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
 
-        // Configure mock factories
-        when(mockSmaRsiFactory.getStrategyType()).thenReturn(StrategyType.SMA_RSI);
-        when(mockEmaMacdFactory.getStrategyType()).thenReturn(StrategyType.EMA_MACD);
+    // Configure mock factories
+    when(mockSmaRsiFactory.getStrategyType()).thenReturn(StrategyType.SMA_RSI);
+    when(mockEmaMacdFactory.getStrategyType()).thenReturn(StrategyType.EMA_MACD);
 
-        // Initialize strategy manager with mocked dependencies
-        strategyManager = new StrategyManagerImpl(ImmutableList.of(mockSmaRsiFactory, mockEmaMacdFactory));
+    // Initialize strategy manager with mocked dependencies
+    strategyManager =
+        new StrategyManagerImpl(ImmutableList.of(mockSmaRsiFactory, mockEmaMacdFactory));
 
-        // Create mock strategy and bar series for testing
-        mockStrategy = mock(Strategy.class);
-        barSeries = new BaseBarSeries();
-    }
+    // Create mock strategy and bar series for testing
+    mockStrategy = mock(Strategy.class);
+    barSeries = new BaseBarSeries();
+  }
 
-    @Test
-    public void createStrategy_withValidSmaRsiParameters_returnsStrategy() 
-        throws InvalidProtocolBufferException {
-        // Arrange
-        SmaRsiParameters params = SmaRsiParameters.newBuilder()
+  @Test
+  public void createStrategy_withValidSmaRsiParameters_returnsStrategy()
+      throws InvalidProtocolBufferException {
+    // Arrange
+    SmaRsiParameters params =
+        SmaRsiParameters.newBuilder()
             .setMovingAveragePeriod(14)
             .setRsiPeriod(14)
             .setOverboughtThreshold(70)
             .setOversoldThreshold(30)
             .build();
-        Any packedParams = Any.pack(params);
+    Any packedParams = Any.pack(params);
 
-        when(mockSmaRsiFactory.createStrategy(barSeries, packedParams)).thenReturn(mockStrategy);
+    when(mockSmaRsiFactory.createStrategy(barSeries, packedParams)).thenReturn(mockStrategy);
 
-        // Act
-        Strategy result = strategyManager.createStrategy(barSeries, StrategyType.SMA_RSI, packedParams);
+    // Act
+    Strategy result =
+        strategyManager.createStrategy(barSeries, StrategyType.SMA_RSI, packedParams);
 
-        // Assert
-        assertThat(result).isSameInstanceAs(mockStrategy);
-    }
+    // Assert
+    assertThat(result).isSameInstanceAs(mockStrategy);
+  }
 
-    @Test
-    public void createStrategy_withValidEmaMacdParameters_returnsStrategy() 
-        throws InvalidProtocolBufferException {
-        // Arrange
-        EmaMacdParameters params = EmaMacdParameters.newBuilder()
+  @Test
+  public void createStrategy_withValidEmaMacdParameters_returnsStrategy()
+      throws InvalidProtocolBufferException {
+    // Arrange
+    EmaMacdParameters params =
+        EmaMacdParameters.newBuilder()
             .setShortEmaPeriod(12)
             .setLongEmaPeriod(26)
             .setSignalPeriod(9)
             .build();
-        Any packedParams = Any.pack(params);
+    Any packedParams = Any.pack(params);
 
-        when(mockEmaMacdFactory.createStrategy(barSeries, packedParams)).thenReturn(mockStrategy);
+    when(mockEmaMacdFactory.createStrategy(barSeries, packedParams)).thenReturn(mockStrategy);
 
-        // Act
-        Strategy result = strategyManager.createStrategy(barSeries, StrategyType.EMA_MACD, packedParams);
+    // Act
+    Strategy result =
+        strategyManager.createStrategy(barSeries, StrategyType.EMA_MACD, packedParams);
 
-        // Assert
-        assertThat(result).isSameInstanceAs(mockStrategy);
-    }
+    // Assert
+    assertThat(result).isSameInstanceAs(mockStrategy);
+  }
 
-    @Test
-    public void createStrategy_withUnsupportedStrategyType_throwsIllegalArgumentException() {
-        // Arrange
-        SmaRsiParameters params = SmaRsiParameters.newBuilder()
+  @Test
+  public void createStrategy_withUnsupportedStrategyType_throwsIllegalArgumentException() {
+    // Arrange
+    SmaRsiParameters params =
+        SmaRsiParameters.newBuilder()
             .setMovingAveragePeriod(14)
             .setRsiPeriod(14)
             .setOverboughtThreshold(70)
             .setOversoldThreshold(30)
             .build();
-        Any packedParams = Any.pack(params);
+    Any packedParams = Any.pack(params);
 
-        // Act & Assert
-        IllegalArgumentException thrown = assertThrows(
+    // Act & Assert
+    IllegalArgumentException thrown =
+        assertThrows(
             IllegalArgumentException.class,
-            () -> strategyManager.createStrategy(barSeries, StrategyType.ADX_STOCHASTIC, packedParams));
-        
-        assertThat(thrown).hasMessageThat()
-            .contains("Unsupported strategy type: ADX_STOCHASTIC");
-    }
+            () ->
+                strategyManager.createStrategy(
+                    barSeries, StrategyType.ADX_STOCHASTIC, packedParams));
 
-    @Test
-    public void createStrategy_whenFactoryThrowsException_propagatesException() 
-        throws InvalidProtocolBufferException {
-        // Arrange
-        SmaRsiParameters params = SmaRsiParameters.newBuilder()
+    assertThat(thrown).hasMessageThat().contains("Unsupported strategy type: ADX_STOCHASTIC");
+  }
+
+  @Test
+  public void createStrategy_whenFactoryThrowsException_propagatesException()
+      throws InvalidProtocolBufferException {
+    // Arrange
+    SmaRsiParameters params =
+        SmaRsiParameters.newBuilder()
             .setMovingAveragePeriod(14)
             .setRsiPeriod(14)
             .setOverboughtThreshold(70)
             .setOversoldThreshold(30)
             .build();
-        Any packedParams = Any.pack(params);
+    Any packedParams = Any.pack(params);
 
-        InvalidProtocolBufferException expectedException = 
-            new InvalidProtocolBufferException("Test exception");
-        when(mockSmaRsiFactory.createStrategy(barSeries, packedParams))
-            .thenThrow(expectedException);
+    InvalidProtocolBufferException expectedException = new InvalidProtocolBufferException("Test exception");
+    when(mockSmaRsiFactory.createStrategy(barSeries, packedParams)).thenThrow(expectedException);
 
-        // Act & Assert
-        InvalidProtocolBufferException thrown = assertThrows(
+    // Act & Assert
+    InvalidProtocolBufferException thrown =
+        assertThrows(
             InvalidProtocolBufferException.class,
             () -> strategyManager.createStrategy(barSeries, StrategyType.SMA_RSI, packedParams));
-        
-        assertThat(thrown).isSameInstanceAs(expectedException);
-    }
+
+    assertThat(thrown).isSameInstanceAs(expectedException);
+  }
 }

--- a/src/test/java/com/verlumen/tradestream/strategies/StrategyManagerImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/StrategyManagerImplTest.java
@@ -27,6 +27,8 @@ public class StrategyManagerImplTest {
 
   @Mock private StrategyFactory<EmaMacdParameters> mockEmaMacdFactory;
 
+  @Bind private ImmutableList<StrategyFactory<?>> strategyFactories;
+
   private StrategyManagerImpl strategyManager;
   private Strategy mockStrategy;
   private BarSeries barSeries;
@@ -39,9 +41,10 @@ public class StrategyManagerImplTest {
     when(mockSmaRsiFactory.getStrategyType()).thenReturn(StrategyType.SMA_RSI);
     when(mockEmaMacdFactory.getStrategyType()).thenReturn(StrategyType.EMA_MACD);
 
-    // Initialize strategy manager with mocked dependencies
-    strategyManager =
-        new StrategyManagerImpl(ImmutableList.of(mockSmaRsiFactory, mockEmaMacdFactory));
+    // Initialize strategy factories field with mocked dependencies
+    strategyFactories = ImmutableList.of(mockSmaRsiFactory, mockEmaMacdFactory);
+
+    Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
 
     // Create mock strategy and bar series for testing
     mockStrategy = mock(Strategy.class);

--- a/src/test/java/com/verlumen/tradestream/strategies/StrategyManagerImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/StrategyManagerImplTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Guice;
+import com.google.inject.Inject;
 import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import com.google.protobuf.Any;
@@ -29,7 +30,9 @@ public class StrategyManagerImplTest {
 
   @Bind private ImmutableList<StrategyFactory<?>> strategyFactories;
 
+  @Inject
   private StrategyManagerImpl strategyManager;
+
   private Strategy mockStrategy;
   private BarSeries barSeries;
 


### PR DESCRIPTION
- **Context:** This change refactors `StrategyManagerImpl` to directly use a list of strategy factories passed via constructor injection instead of using a separate config object.
- **Changes:**
    - Modified `src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java`: Removed the inner `Config` class and updated the constructor to receive an `ImmutableList<StrategyFactory<?>>`. The field `factoryMap` is now initialized directly in the constructor.
    - Modified `src/test/java/com/verlumen/tradestream/strategies/StrategyManagerImplTest.java`: Updated the test to use Guice field binding to provide an immutable list of factories, rather than creating a config object.
    - Modified `src/main/java/com/verlumen/tradestream/strategies/BUILD`: Removed the dependency on `auto_value`.
- **Benefits:**
    - Simplifies the `StrategyManagerImpl` class by removing the unnecessary config object.
    - Improves the test by using Guice field injection instead of manually creating a config object.
    - Enhances code clarity by using constructor injection directly for the list of strategy factories.