### PR TITLE
Refactor `StrategyManagerImplTest` to Remove Guice Bindings

### DIFF
--- a/src/test/java/com/verlumen/tradestream/strategies/StrategyManagerImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/StrategyManagerImplTest.java
@@ -6,9 +6,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
-import com.google.inject.Guice;
-import com.google.inject.testing.fieldbinder.Bind;
-import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.junit.Before;
@@ -24,121 +21,122 @@ import org.ta4j.core.Strategy;
 @RunWith(JUnit4.class)
 public class StrategyManagerImplTest {
 
-    @Bind
-    @Mock
-    private StrategyFactory<SmaRsiParameters> mockSmaRsiFactory;
+  @Mock private StrategyFactory<SmaRsiParameters> mockSmaRsiFactory;
 
-    @Bind
-    @Mock 
-    private StrategyFactory<EmaMacdParameters> mockEmaMacdFactory;
+  @Mock private StrategyFactory<EmaMacdParameters> mockEmaMacdFactory;
 
-    private StrategyManagerImpl strategyManager;
-    private Strategy mockStrategy;
-    private BarSeries barSeries;
+  private StrategyManagerImpl strategyManager;
+  private Strategy mockStrategy;
+  private BarSeries barSeries;
 
-    @Before
-    public void setUp() {
-        MockitoAnnotations.openMocks(this);
+  @Before
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
 
-        // Configure mock factories
-        when(mockSmaRsiFactory.getStrategyType()).thenReturn(StrategyType.SMA_RSI);
-        when(mockEmaMacdFactory.getStrategyType()).thenReturn(StrategyType.EMA_MACD);
+    // Configure mock factories
+    when(mockSmaRsiFactory.getStrategyType()).thenReturn(StrategyType.SMA_RSI);
+    when(mockEmaMacdFactory.getStrategyType()).thenReturn(StrategyType.EMA_MACD);
 
-        // Create config with mock factories
-        StrategyManagerImpl.Config config = StrategyManagerImpl.Config.create(
-            ImmutableList.of(mockSmaRsiFactory, mockEmaMacdFactory));
+    // Create config with mock factories
+    StrategyManagerImpl.Config config =
+        StrategyManagerImpl.Config.create(ImmutableList.of(mockSmaRsiFactory, mockEmaMacdFactory));
 
-        // Initialize strategy manager with mocked dependencies
-        strategyManager = new StrategyManagerImpl(config);
+    // Initialize strategy manager with mocked dependencies
+    strategyManager = new StrategyManagerImpl(config);
 
-        // Create mock strategy and bar series for testing
-        mockStrategy = mock(Strategy.class);
-        barSeries = new BaseBarSeries();
-    }
+    // Create mock strategy and bar series for testing
+    mockStrategy = mock(Strategy.class);
+    barSeries = new BaseBarSeries();
+  }
 
-    @Test
-    public void createStrategy_withValidSmaRsiParameters_returnsStrategy() 
-        throws InvalidProtocolBufferException {
-        // Arrange
-        SmaRsiParameters params = SmaRsiParameters.newBuilder()
+  @Test
+  public void createStrategy_withValidSmaRsiParameters_returnsStrategy()
+      throws InvalidProtocolBufferException {
+    // Arrange
+    SmaRsiParameters params =
+        SmaRsiParameters.newBuilder()
             .setMovingAveragePeriod(14)
             .setRsiPeriod(14)
             .setOverboughtThreshold(70)
             .setOversoldThreshold(30)
             .build();
-        Any packedParams = Any.pack(params);
+    Any packedParams = Any.pack(params);
 
-        when(mockSmaRsiFactory.createStrategy(barSeries, packedParams)).thenReturn(mockStrategy);
+    when(mockSmaRsiFactory.createStrategy(barSeries, packedParams)).thenReturn(mockStrategy);
 
-        // Act
-        Strategy result = strategyManager.createStrategy(barSeries, StrategyType.SMA_RSI, packedParams);
+    // Act
+    Strategy result = strategyManager.createStrategy(barSeries, StrategyType.SMA_RSI, packedParams);
 
-        // Assert
-        assertThat(result).isSameInstanceAs(mockStrategy);
-    }
+    // Assert
+    assertThat(result).isSameInstanceAs(mockStrategy);
+  }
 
-    @Test
-    public void createStrategy_withValidEmaMacdParameters_returnsStrategy() 
-        throws InvalidProtocolBufferException {
-        // Arrange
-        EmaMacdParameters params = EmaMacdParameters.newBuilder()
+  @Test
+  public void createStrategy_withValidEmaMacdParameters_returnsStrategy()
+      throws InvalidProtocolBufferException {
+    // Arrange
+    EmaMacdParameters params =
+        EmaMacdParameters.newBuilder()
             .setShortEmaPeriod(12)
             .setLongEmaPeriod(26)
             .setSignalPeriod(9)
             .build();
-        Any packedParams = Any.pack(params);
+    Any packedParams = Any.pack(params);
 
-        when(mockEmaMacdFactory.createStrategy(barSeries, packedParams)).thenReturn(mockStrategy);
+    when(mockEmaMacdFactory.createStrategy(barSeries, packedParams)).thenReturn(mockStrategy);
 
-        // Act
-        Strategy result = strategyManager.createStrategy(barSeries, StrategyType.EMA_MACD, packedParams);
+    // Act
+    Strategy result = strategyManager.createStrategy(barSeries, StrategyType.EMA_MACD, packedParams);
 
-        // Assert
-        assertThat(result).isSameInstanceAs(mockStrategy);
-    }
+    // Assert
+    assertThat(result).isSameInstanceAs(mockStrategy);
+  }
 
-    @Test
-    public void createStrategy_withUnsupportedStrategyType_throwsIllegalArgumentException() {
-        // Arrange
-        SmaRsiParameters params = SmaRsiParameters.newBuilder()
+  @Test
+  public void createStrategy_withUnsupportedStrategyType_throwsIllegalArgumentException() {
+    // Arrange
+    SmaRsiParameters params =
+        SmaRsiParameters.newBuilder()
             .setMovingAveragePeriod(14)
             .setRsiPeriod(14)
             .setOverboughtThreshold(70)
             .setOversoldThreshold(30)
             .build();
-        Any packedParams = Any.pack(params);
+    Any packedParams = Any.pack(params);
 
-        // Act & Assert
-        IllegalArgumentException thrown = assertThrows(
+    // Act & Assert
+    IllegalArgumentException thrown =
+        assertThrows(
             IllegalArgumentException.class,
-            () -> strategyManager.createStrategy(barSeries, StrategyType.ADX_STOCHASTIC, packedParams));
-        
-        assertThat(thrown).hasMessageThat()
-            .contains("Unsupported strategy type: ADX_STOCHASTIC");
-    }
+            () ->
+                strategyManager.createStrategy(
+                    barSeries, StrategyType.ADX_STOCHASTIC, packedParams));
 
-    @Test
-    public void createStrategy_whenFactoryThrowsException_propagatesException() 
-        throws InvalidProtocolBufferException {
-        // Arrange
-        SmaRsiParameters params = SmaRsiParameters.newBuilder()
+    assertThat(thrown).hasMessageThat().contains("Unsupported strategy type: ADX_STOCHASTIC");
+  }
+
+  @Test
+  public void createStrategy_whenFactoryThrowsException_propagatesException()
+      throws InvalidProtocolBufferException {
+    // Arrange
+    SmaRsiParameters params =
+        SmaRsiParameters.newBuilder()
             .setMovingAveragePeriod(14)
             .setRsiPeriod(14)
             .setOverboughtThreshold(70)
             .setOversoldThreshold(30)
             .build();
-        Any packedParams = Any.pack(params);
+    Any packedParams = Any.pack(params);
 
-        InvalidProtocolBufferException expectedException = 
-            new InvalidProtocolBufferException("Test exception");
-        when(mockSmaRsiFactory.createStrategy(barSeries, packedParams))
-            .thenThrow(expectedException);
+    InvalidProtocolBufferException expectedException = new InvalidProtocolBufferException("Test exception");
+    when(mockSmaRsiFactory.createStrategy(barSeries, packedParams)).thenThrow(expectedException);
 
-        // Act & Assert
-        InvalidProtocolBufferException thrown = assertThrows(
+    // Act & Assert
+    InvalidProtocolBufferException thrown =
+        assertThrows(
             InvalidProtocolBufferException.class,
             () -> strategyManager.createStrategy(barSeries, StrategyType.SMA_RSI, packedParams));
-        
-        assertThat(thrown).isSameInstanceAs(expectedException);
-    }
+
+    assertThat(thrown).isSameInstanceAs(expectedException);
+  }
 }


### PR DESCRIPTION
- **Context:** This change refactors `StrategyManagerImplTest` to remove the Guice field binder. This simplifies the test setup and removes the dependency on Guice's testing extensions.
- **Changes:**
    - Removed the Guice `@Bind` annotations and `BoundFieldModule` usage.
    - Updated the test setup to directly initialize the `StrategyManagerImpl` with mocked dependencies.
- **Benefits:**
    - Simplifies the test setup and removes unnecessary dependencies on Guice's testing framework.
    - Improves the readability of the test by having simpler dependency declarations.
    - Makes the test less coupled to a specific dependency injection framework.