### PR TITLE
Introduce `BacktestingModule` for Backtesting Configuration

### DIFF
--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -67,6 +67,14 @@ java_library(
 )
 
 java_library(
+    name = "backtesting_module",
+    srcs = ["BacktestingModule.java"],
+    deps = [
+        "//third_party:guice",
+    ],
+)
+
+java_library(
     name = "ga_service_client",
     srcs = ["GAServiceClient.java"],
     deps = [

--- a/src/main/java/com/verlumen/tradestream/backtesting/BacktestingModule.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BacktestingModule.java
@@ -1,0 +1,8 @@
+package com.verlumen.tradestream.backtesting;
+
+import com.google.inject.AbstractModule;
+
+final class BacktestingModule implements AbstractModule {
+  @Override
+  protected void configure() {}
+}

--- a/src/main/java/com/verlumen/tradestream/backtesting/BacktestingModule.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BacktestingModule.java
@@ -2,7 +2,7 @@ package com.verlumen.tradestream.backtesting;
 
 import com.google.inject.AbstractModule;
 
-final class BacktestingModule implements AbstractModule {
+final class BacktestingModule extends AbstractModule {
   @Override
   protected void configure() {}
 }


### PR DESCRIPTION
- **Context:** This change introduces the `BacktestingModule`, a Guice module, intended to handle configuration of the backtesting module.
- **Changes:**
    - Created `src/main/java/com/verlumen/tradestream/backtesting/BacktestingModule.java`: This new class is a Guice module with an empty `configure()` method.
    - Modified `src/main/java/com/verlumen/tradestream/backtesting/BUILD`: Added a build target for the `backtesting_module`.
- **Benefits:**
    - Provides a centralized place to configure components within the `backtesting` package.
    - Allows for cleaner dependency injection within the module.
    - Sets the foundation for future module configurations.