### PR TITLE
Make `MomentumSmaCrossoverStrategyFactory` Immutable and Create via Static Method

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/movingaverages/MomentumSmaCrossoverStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/movingaverages/MomentumSmaCrossoverStrategyFactory.java
@@ -18,11 +18,11 @@ import org.ta4j.core.rules.CrossedUpIndicatorRule;
 import org.ta4j.core.rules.OverIndicatorRule;
 import org.ta4j.core.rules.UnderIndicatorRule;
 
-public class MomentumSmaCrossoverStrategyFactory
+final class MomentumSmaCrossoverStrategyFactory
     implements StrategyFactory<MomentumSmaCrossoverParameters> {
-
-    @Inject
-    MomentumSmaCrossoverStrategyFactory() {}
+    static MomentumSmaCrossoverStrategyFactory create() {
+        return new MomentumSmaCrossoverStrategyFactory();
+    }
 
     @Override
     public Strategy createStrategy(BarSeries series, MomentumSmaCrossoverParameters params)
@@ -59,4 +59,6 @@ public class MomentumSmaCrossoverStrategyFactory
     public StrategyType getStrategyType() {
         return StrategyType.MOMENTUM_SMA_CROSSOVER;
     }
+
+    private MomentumSmaCrossoverStrategyFactory() {}
 }

--- a/src/main/java/com/verlumen/tradestream/strategies/movingaverages/MovingAverageStrategies.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/movingaverages/MovingAverageStrategies.java
@@ -13,7 +13,7 @@ public final class MovingAverageStrategies {
      */
     public static final ImmutableList<StrategyFactory<?>> ALL_FACTORIES = ImmutableList.of(
         DoubleEmaCrossoverStrategyFactory.create(),
-        new MomentumSmaCrossoverStrategyFactory(),
+        MomentumSmaCrossoverStrategyFactory.create(),
         new SmaEmaCrossoverStrategyFactory(),
         new TripleEmaCrossoverStrategyFactory()
     );

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/MomentumSmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/MomentumSmaCrossoverStrategyFactoryTest.java
@@ -35,7 +35,7 @@ public class MomentumSmaCrossoverStrategyFactoryTest {
 
   @Before
   public void setUp() throws InvalidProtocolBufferException {
-    factory = new MomentumSmaCrossoverStrategyFactory();
+    factory = MomentumSmaCrossoverStrategyFactory.create();
     params =
         MomentumSmaCrossoverParameters.newBuilder()
             .setMomentumPeriod(MOMENTUM_PERIOD)


### PR DESCRIPTION
- **Context:** This change modifies the `MomentumSmaCrossoverStrategyFactory` to be immutable and uses a static method (`create()`) for instantiation. This ensures proper construction and usage of the factory.
- **Changes:**
    - Modified `src/main/java/com/verlumen/tradestream/strategies/movingaverages/MomentumSmaCrossoverStrategyFactory.java`: Made the class `final` and the constructor `private`, and introduced a static `create()` method for object instantiation.
    - Modified `src/main/java/com/verlumen/tradestream/strategies/movingaverages/MovingAverageStrategies.java`: Updated how `MomentumSmaCrossoverStrategyFactory` is added to the list of strategy factories.
    - Modified `src/test/java/com/verlumen/tradestream/strategies/movingaverages/MomentumSmaCrossoverStrategyFactoryTest.java`: Updated the test class to use the `create()` method.
- **Benefits:**
    - Enforces immutability on the factory class, making it thread-safe.
    - Provides a clearer, controlled way to create instances of the factory.
    - Improves code consistency and maintainability.