### PR TITLE
Make `SmaEmaCrossoverStrategyFactory` Immutable and Create via Static Method

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/movingaverages/MovingAverageStrategies.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/movingaverages/MovingAverageStrategies.java
@@ -14,7 +14,7 @@ public final class MovingAverageStrategies {
     public static final ImmutableList<StrategyFactory<?>> ALL_FACTORIES = ImmutableList.of(
         DoubleEmaCrossoverStrategyFactory.create(),
         new MomentumSmaCrossoverStrategyFactory(),
-        new SmaEmaCrossoverStrategyFactory(),
+        SmaEmaCrossoverStrategyFactory.create(),
         new TripleEmaCrossoverStrategyFactory()
     );
 

--- a/src/main/java/com/verlumen/tradestream/strategies/movingaverages/SmaEmaCrossoverStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/movingaverages/SmaEmaCrossoverStrategyFactory.java
@@ -18,8 +18,9 @@ import org.ta4j.core.rules.CrossedDownIndicatorRule;
 import org.ta4j.core.rules.CrossedUpIndicatorRule;
 
 final class SmaEmaCrossoverStrategyFactory implements StrategyFactory<SmaEmaCrossoverParameters> {
-  @Inject
-  SmaEmaCrossoverStrategyFactory() {}
+  static SmaEmaCrossoverStrategyFactory create() {
+    return new SmaEmaCrossoverStrategyFactory();
+  }
 
   @Override
   public Strategy createStrategy(BarSeries series, SmaEmaCrossoverParameters params)
@@ -47,4 +48,6 @@ final class SmaEmaCrossoverStrategyFactory implements StrategyFactory<SmaEmaCros
   public StrategyType getStrategyType() {
     return StrategyType.SMA_EMA_CROSSOVER;
   }
+
+  private SmaEmaCrossoverStrategyFactory() {}
 }

--- a/src/main/java/com/verlumen/tradestream/strategies/movingaverages/SmaEmaCrossoverStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/movingaverages/SmaEmaCrossoverStrategyFactory.java
@@ -2,7 +2,6 @@ package com.verlumen.tradestream.strategies.movingaverages;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.google.inject.Inject;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.verlumen.tradestream.strategies.SmaEmaCrossoverParameters;
 import com.verlumen.tradestream.strategies.StrategyFactory;

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/SmaEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/SmaEmaCrossoverStrategyFactoryTest.java
@@ -37,7 +37,7 @@ public class SmaEmaCrossoverStrategyFactoryTest {
 
   @Before
   public void setUp() throws InvalidProtocolBufferException {
-    factory = new SmaEmaCrossoverStrategyFactory();
+    factory = SmaEmaCrossoverStrategyFactory.create();
     params = SmaEmaCrossoverParameters.newBuilder()
         .setSmaPeriod(SMA_PERIOD)
         .setEmaPeriod(EMA_PERIOD)


### PR DESCRIPTION
- **Context:** This change modifies the `SmaEmaCrossoverStrategyFactory` to be immutable and uses a static method (`create()`) for instantiation. This enforces proper construction of the class and improves thread safety.
- **Changes:**
    - Modified `src/main/java/com/verlumen/tradestream/strategies/movingaverages/SmaEmaCrossoverStrategyFactory.java`: Made the class `final` and the constructor `private`, and introduced a static `create()` method for object instantiation.
    - Modified `src/main/java/com/verlumen/tradestream/strategies/movingaverages/MovingAverageStrategies.java`: Updated how `SmaEmaCrossoverStrategyFactory` is added to the list of strategy factories.
    - Modified `src/test/java/com/verlumen/tradestream/strategies/movingaverages/SmaEmaCrossoverStrategyFactoryTest.java`: Updated the test class to use the `create()` method.
- **Benefits:**
    - Enforces immutability on the factory class, making it thread-safe.
    - Provides a clearer, controlled way to create instances of the factory.
    - Improves code consistency and maintainability.