### PR TITLE
Bind `GAServiceClient` to `GAServiceClientImpl` in `BacktestingModule`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -71,6 +71,8 @@ java_library(
     srcs = ["BacktestingModule.java"],
     deps = [
         "//third_party:guice",
+        "ga_service_client",
+        "ga_service_client_impl",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/backtesting/BacktestingModule.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BacktestingModule.java
@@ -4,5 +4,7 @@ import com.google.inject.AbstractModule;
 
 final class BacktestingModule extends AbstractModule {
   @Override
-  protected void configure() {}
+  protected void configure() {
+    bind(GAServiceClient.class).to(GAServiceClientImpl.class);
+  }
 }


### PR DESCRIPTION
- **Context:** This change adds a binding for the `GAServiceClient` interface to its concrete implementation, `GAServiceClientImpl`, within the `BacktestingModule`. This allows dependency injection for the GA service client.
- **Changes:**
    - Modified `src/main/java/com/verlumen/tradestream/backtesting/BacktestingModule.java`: Added a binding for `GAServiceClient` to `GAServiceClientImpl`.
    - Modified `src/main/java/com/verlumen/tradestream/backtesting/BUILD`: Added dependencies for `ga_service_client` and `ga_service_client_impl` to the `backtesting_module` target.
- **Benefits:**
    - Enables the `GAServiceClientImpl` to be injected by Guice using its interface.
    - Sets up dependency injection for the GA service client for consuming classes.