### PR TITLE
Introduce `GAServiceClientImpl` and Test for GA Service Interaction

### DIFF
--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -83,6 +83,15 @@ java_library(
 )
 
 java_library(
+    name = "ga_service_client",
+    srcs = ["GAServiceClient.java"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//protos:backtesting_java_proto",
+    ],
+)
+
+java_library(
     name = "ga_service_impl",
     srcs = ["GAServiceImpl.java"],
     deps = [

--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -83,11 +83,16 @@ java_library(
 )
 
 java_library(
-    name = "ga_service_client",
-    srcs = ["GAServiceClient.java"],
+    name = "ga_service_client_impl",
+    srcs = ["GAServiceClientImpl.java"],
     visibility = ["//visibility:public"],
     deps = [
+        "//protos:backtesting_java_grpc",
         "//protos:backtesting_java_proto",
+        "//third_party:guice",
+        "//third_party:grpc_java_api",
+        "//third_party:grpc_java_stub",
+        ":ga_service_client",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/backtesting/GAServiceClientImpl.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/GAServiceClientImpl.java
@@ -1,0 +1,19 @@
+package com.verlumen.tradestream.backtesting;
+
+import com.google.inject.Inject;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+
+public final class GAServiceClientImpl implements GAServiceClient {
+  private final GAServiceGrpc.GAServiceBlockingStub stub;
+
+  @Inject
+  GAServiceClientImpl(GAServiceGrpc.GAServiceBlockingStub stub) {
+    this.stub = stub;
+  }
+
+  @Override
+  public BestStrategyResponse requestOptimization(GAOptimizationRequest request) {
+    return stub.requestOptimization(request);
+  }
+}

--- a/src/test/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/test/java/com/verlumen/tradestream/backtesting/BUILD
@@ -68,22 +68,6 @@ java_test(
     ],
 )
 
-load("@rules_java//java:defs.bzl", "java_library", "java_test")
-
-java_library(
-    name = "ga_service_client_impl",
-    srcs = ["GAServiceClientImpl.java"],
-    visibility = ["//visibility:public"],
-    deps = [
-        "//protos:backtesting_java_grpc",
-        "//protos:backtesting_java_proto",
-        "//third_party:guice",
-        "//third_party:grpc_java_api",
-        "//third_party:grpc_java_stub",
-        ":ga_service_client",
-    ],
-)
-
 java_test(
     name = "GAServiceClientImplTest",
     size = "small",

--- a/src/test/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/test/java/com/verlumen/tradestream/backtesting/BUILD
@@ -68,6 +68,43 @@ java_test(
     ],
 )
 
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
+
+java_library(
+    name = "ga_service_client_impl",
+    srcs = ["GAServiceClientImpl.java"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//protos:backtesting_java_grpc",
+        "//protos:backtesting_java_proto",
+        "//third_party:guice",
+        "//third_party:grpc_java_api",
+        "//third_party:grpc_java_stub",
+        ":ga_service_client",
+    ],
+)
+
+java_test(
+    name = "GAServiceClientImplTest",
+    size = "small",
+    srcs = ["GAServiceClientImplTest.java"],
+    deps = [
+        "//protos:backtesting_java_grpc",
+        "//protos:backtesting_java_proto",
+        "//src/main/java/com/verlumen/tradestream/backtesting:ga_service_client",
+        "//src/main/java/com/verlumen/tradestream/backtesting:ga_service_client_impl",
+        "//third_party:grpc_java_api",
+        "//third_party:grpc_java_inprocess",
+        "//third_party:grpc_java_stub",
+        "//third_party:grpc_testing",
+        "//third_party:guice",
+        "//third_party:guice_testlib",
+        "//third_party:junit",
+        "//third_party:mockito_core",
+        "//third_party:truth",
+    ],
+)
+
 java_test(
     name = "GAServiceImplTest",
     size = "small",

--- a/src/test/java/com/verlumen/tradestream/backtesting/GAServiceClientImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/backtesting/GAServiceClientImplTest.java
@@ -1,0 +1,82 @@
+package com.verlumen.tradestream.backtesting;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.testing.fieldbinder.Bind;
+import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import com.verlumen.tradestream.backtesting.GAOptimizationRequest;
+import com.verlumen.tradestream.backtesting.GAServiceGrpc;
+import com.verlumen.tradestream.backtesting.BestStrategyResponse;
+import io.grpc.ManagedChannel;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.GrpcCleanupRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class GAServiceClientImplTest {
+  @Rule public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+  private GAServiceGrpc.GAServiceImplBase fakeService =
+      new GAServiceGrpc.GAServiceImplBase() {
+        @Override
+        public void requestOptimization(GAOptimizationRequest request,
+                                        StreamObserver<BestStrategyResponse> responseObserver) {
+          // Provide a real or fake response
+          if (request == null) {
+            responseObserver.onError(new NullPointerException("Request is null"));
+          } else {
+            BestStrategyResponse result = BestStrategyResponse.newBuilder()
+                .setBestScore(0.95)
+                .build();
+            responseObserver.onNext(result);
+            responseObserver.onCompleted();
+          }
+        }
+      };
+
+  @Bind GAServiceGrpc.GAServiceBlockingStub stub;
+
+  @Inject
+  private GAServiceClientImpl client;
+
+  @Before
+  public void setUp() throws Exception {
+    String serverName = InProcessServerBuilder.generateName();
+
+    // Build the in-process server with the fakeService
+    grpcCleanup.register(
+        InProcessServerBuilder.forName(serverName)
+            .directExecutor()
+            .addService(fakeService)
+            .build()
+            .start());
+
+    // Create an in-process channel
+    ManagedChannel channel = grpcCleanup.register(
+        InProcessChannelBuilder.forName(serverName).directExecutor().build());
+
+    // Construct the real stub from the channel
+    this.stub = GAServiceGrpc.newBlockingStub(channel);
+
+    // Now inject that realStub into your client
+    Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+  }
+
+  @Test
+  public void requestOptimization_returnsExpectedResult() {
+    GAOptimizationRequest request = GAOptimizationRequest.newBuilder().build();
+    BestStrategyResponse actual = client.requestOptimization(request);
+
+    // The fakeService returns 0.95
+    assertThat(actual.getBestScore()).isWithin(1e-6).of(0.95);
+  }
+}


### PR DESCRIPTION
- **Context:** This change introduces `GAServiceClientImpl`, a concrete implementation of the `GAServiceClient` interface. It also introduces a test class for the new implementation.
- **Changes:**
    - Created `src/main/java/com/verlumen/tradestream/backtesting/GAServiceClientImpl.java`: This new class provides an implementation of the `GAServiceClient` using gRPC blocking stub.
    - Modified `src/main/java/com/verlumen/tradestream/backtesting/BUILD`: Created a build target for `ga_service_client_impl`.
    - Created `src/test/java/com/verlumen/tradestream/backtesting/GAServiceClientImplTest.java`: Contains unit tests for the `GAServiceClientImpl`, verifying the connection with the fake gRPC server, and verifies that correct values are returned from the server.
    - Modified `src/test/java/com/verlumen/tradestream/backtesting/BUILD`: Added the `GAServiceClientImplTest` build target.
- **Benefits:**
    - Provides a concrete implementation of the `GAServiceClient` that can be injected.
    - Introduces unit tests to ensure the `GAServiceClientImpl` is working correctly.