### PR TITLE
Remove Unused `guice` Dependency from Moving Average Strategies

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/movingaverages/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/movingaverages/BUILD
@@ -9,7 +9,6 @@ java_library(
         "//protos:strategies_java_proto",
         "//src/main/java/com/verlumen/tradestream/strategies:strategy_factory",
         "//third_party:guava",
-        "//third_party:guice",
         "//third_party:protobuf_java",
         "//third_party:ta4j_core",
     ],

--- a/src/main/java/com/verlumen/tradestream/strategies/movingaverages/MomentumSmaCrossoverStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/movingaverages/MomentumSmaCrossoverStrategyFactory.java
@@ -2,7 +2,6 @@ package com.verlumen.tradestream.strategies.movingaverages;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.google.inject.Inject;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.verlumen.tradestream.strategies.MomentumSmaCrossoverParameters;
 import com.verlumen.tradestream.strategies.StrategyFactory;


### PR DESCRIPTION
- **Context:** This change removes the unused dependency on `guice` from the moving average strategies build file and updates the `MomentumSmaCrossoverStrategyFactory` to remove the inject annotation.
- **Changes:**
    - Modified `src/main/java/com/verlumen/tradestream/strategies/movingaverages/BUILD`: Removed the dependency on `//third_party:guice`.
    - Modified `src/main/java/com/verlumen/tradestream/strategies/movingaverages/MomentumSmaCrossoverStrategyFactory.java`: Removed the `@Inject` annotation.
- **Benefits:**
    - Improves the accuracy of the dependency declaration.
    - Removes unnecessary dependencies.
    - Simplifies build configuration.