### PR TITLE
Remove Unused `guice` Dependency from Oscillator Strategies

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/oscillators/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/oscillators/BUILD
@@ -9,7 +9,6 @@ java_library(
         "//protos:strategies_java_proto",
         "//src/main/java/com/verlumen/tradestream/strategies:strategy_factory",
         "//third_party:guava",
-        "//third_party:guice",
         "//third_party:protobuf_java",
         "//third_party:ta4j_core",
     ],


### PR DESCRIPTION
- **Context:** This change removes the unused dependency on `guice` from the oscillator strategies build file.
- **Changes:**
    - Modified `src/main/java/com/verlumen/tradestream/strategies/oscillators/BUILD`: Removed the dependency on `//third_party:guice`.
- **Benefits:**
    - Improves the accuracy of the dependency declaration.
    - Removes unnecessary dependencies.
    - Simplifies build configuration.