### PR TITLE
Remove Unused `guice` Dependency from Oscillator Strategy Tests

### DIFF
--- a/src/test/java/com/verlumen/tradestream/strategies/oscillators/BUILD
+++ b/src/test/java/com/verlumen/tradestream/strategies/oscillators/BUILD
@@ -9,7 +9,6 @@ java_test(
         "//src/main/java/com/verlumen/tradestream/strategies/oscillators:oscillators_lib",
         "//third_party:flogger",
         "//third_party:guava",
-        "//third_party:guice",
         "//third_party:junit",
         "//third_party:protobuf_java",
         "//third_party:mockito_core",


### PR DESCRIPTION
- **Context:** This change removes an unused dependency on `guice` from the oscillator strategy tests build file.
- **Changes:**
    - Modified `src/test/java/com/verlumen/tradestream/strategies/oscillators/BUILD`: Removed the dependency on `//third_party:guice`.
- **Benefits:**
    - Improves the accuracy of the dependency declaration.
    - Removes unnecessary dependencies.
    - Simplifies build configuration.