### PR TITLE
Configure gRPC Clients in Backtesting Module and Install in Strategies Module

### DIFF
--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -70,6 +70,7 @@ java_library(
     name = "backtesting_module",
     srcs = ["BacktestingModule.java"],
     deps = [
+        "//protos:backtesting_java_grpc",
         "//third_party:guice",
         "ga_service_client",
         "ga_service_client_impl",

--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -71,6 +71,7 @@ java_library(
     srcs = ["BacktestingModule.java"],
     deps = [
         "//protos:backtesting_java_grpc",
+        "//third_party:grpc_java_api",
         "//third_party:guice",
         "ga_service_client",
         "ga_service_client_impl",

--- a/src/main/java/com/verlumen/tradestream/backtesting/BacktestingModule.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BacktestingModule.java
@@ -3,7 +3,7 @@ package com.verlumen.tradestream.backtesting;
 import com.google.inject.AbstractModule;
 
 public final class BacktestingModule extends AbstractModule {
-  static BacktestingModule create() {
+  public static BacktestingModule create() {
     return new BacktestingModule();
   }
 

--- a/src/main/java/com/verlumen/tradestream/backtesting/BacktestingModule.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BacktestingModule.java
@@ -2,9 +2,15 @@ package com.verlumen.tradestream.backtesting;
 
 import com.google.inject.AbstractModule;
 
-final class BacktestingModule extends AbstractModule {
+public final class BacktestingModule extends AbstractModule {
+  static BacktestingModule create() {
+    return new BacktestingModule();
+  }
+
   @Override
   protected void configure() {
     bind(GAServiceClient.class).to(GAServiceClientImpl.class);
   }
+
+  private BacktestingModule() {}
 }

--- a/src/main/java/com/verlumen/tradestream/backtesting/BacktestingModule.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BacktestingModule.java
@@ -18,7 +18,6 @@ public final class BacktestingModule extends AbstractModule {
 
   @Override
   protected void configure() {
-    bind(BacktestServiceClient.class).to(BacktestServiceClientImpl.class);
     bind(GAServiceClient.class).to(GAServiceClientImpl.class);
   }
 

--- a/src/main/java/com/verlumen/tradestream/backtesting/BacktestingModule.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BacktestingModule.java
@@ -1,15 +1,47 @@
 package com.verlumen.tradestream.backtesting;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
 
 public final class BacktestingModule extends AbstractModule {
+  private static final String DEFAULT_BACKTEST_SERVICE_HOST = "backtest-service";
+  private static final int DEFAULT_BACKTEST_SERVICE_PORT = 50051;
+  private static final String DEFAULT_GA_SERVICE_HOST = "ga-service";
+  private static final int DEFAULT_GA_SERVICE_PORT = 50052;
+
   public static BacktestingModule create() {
     return new BacktestingModule();
   }
 
   @Override
   protected void configure() {
+    bind(BacktestServiceClient.class).to(BacktestServiceClientImpl.class);
     bind(GAServiceClient.class).to(GAServiceClientImpl.class);
+  }
+
+  @Provides 
+  @Singleton
+  BacktestServiceGrpc.BacktestServiceBlockingStub provideBacktestServiceStub() {
+    ManagedChannel channel = ManagedChannelBuilder.forAddress(
+            DEFAULT_BACKTEST_SERVICE_HOST, 
+            DEFAULT_BACKTEST_SERVICE_PORT)
+        .usePlaintext()
+        .build();
+    return BacktestServiceGrpc.newBlockingStub(channel);
+  }
+
+  @Provides
+  @Singleton
+  GAServiceGrpc.GAServiceBlockingStub provideGAServiceStub() {
+    ManagedChannel channel = ManagedChannelBuilder.forAddress(
+            DEFAULT_GA_SERVICE_HOST, 
+            DEFAULT_GA_SERVICE_PORT)
+        .usePlaintext()
+        .build();
+    return GAServiceGrpc.newBlockingStub(channel);
   }
 
   private BacktestingModule() {}

--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -100,6 +100,7 @@ java_library(
     name = "strategies_module",
     srcs = ["StrategiesModule.java"],
     deps = [
+        "//src/main/java/com/verlumen/tradestream/backtesting:backtesting_module",
         "//third_party:guava",
         "//third_party:guice",
         ":market_data_consumer",

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.java
@@ -3,6 +3,7 @@ package com.verlumen.tradestream.strategies;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 import com.google.inject.TypeLiteral;
+import com.verlumen.tradestream.backtesting.BacktestingModule;
 
 final class StrategiesModule extends AbstractModule {
   static StrategiesModule create() {
@@ -15,5 +16,7 @@ final class StrategiesModule extends AbstractModule {
     bind(new TypeLiteral<ImmutableList<StrategyFactory<?>>>() {})
         .toInstance(StrategyFactories.ALL_FACTORIES);
     bind(StrategyManager.class).to(StrategyManagerImpl.class);
+
+    install(BacktestingModule.create());
   }
 }


### PR DESCRIPTION
- **Context:** This change configures the gRPC clients in the `BacktestingModule` and installs the module into `StrategiesModule`. This enables access to gRPC stubs to communicate with the backtesting service from within strategy logic.
- **Changes:**
    - Modified `src/main/java/com/verlumen/tradestream/backtesting/BacktestingModule.java`: Configured the gRPC client by adding methods to create and provide the `BacktestServiceBlockingStub` and `GAServiceBlockingStub`.
    - Modified `src/main/java/com/verlumen/tradestream/backtesting/BUILD`: Added a dependency on the gRPC API to the `backtesting_module` target.
     - Modified `src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.java`: Installed the `BacktestingModule` to make the stubs available through injection.
    - Modified `src/main/java/com/verlumen/tradestream/strategies/BUILD` to include the dependency on the backtesting module.
- **Benefits:**
    - Configures gRPC clients by using the Guice provider pattern.
    - Provides a central configuration for all gRPC clients used by backtesting.
    - Allows classes within the strategies package to access the stubs.