### PR TITLE
Bind `BacktestServiceClient` to `BacktestServiceClientImpl` in `BacktestingModule`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -71,6 +71,8 @@ java_library(
     srcs = ["BacktestingModule.java"],
     deps = [
         "//third_party:guice",
+        "backtest_service_client",
+        "backtest_service_client_impl",
         "ga_service_client",
         "ga_service_client_impl",
     ],

--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -71,10 +71,10 @@ java_library(
     srcs = ["BacktestingModule.java"],
     deps = [
         "//third_party:guice",
-        "backtest_service_client",
-        "backtest_service_client_impl",
-        "ga_service_client",
-        "ga_service_client_impl",
+        ":backtest_service_client",
+        ":backtest_service_client_impl",
+        ":ga_service_client",
+        ":ga_service_client_impl",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/backtesting/BacktestingModule.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BacktestingModule.java
@@ -5,6 +5,7 @@ import com.google.inject.AbstractModule;
 final class BacktestingModule extends AbstractModule {
   @Override
   protected void configure() {
+    bind(BacktestServiceClient.class).to(BacktestServiceClientImpl.class);
     bind(GAServiceClient.class).to(GAServiceClientImpl.class);
   }
 }


### PR DESCRIPTION
- **Context:** This change adds a binding for the `BacktestServiceClient` interface to its concrete implementation, `BacktestServiceClientImpl`, within the `BacktestingModule`. This enables dependency injection for the backtest service client.
- **Changes:**
    - Modified `src/main/java/com/verlumen/tradestream/backtesting/BacktestingModule.java`: Added a binding for `BacktestServiceClient` to `BacktestServiceClientImpl`.
    - Modified `src/main/java/com/verlumen/tradestream/backtesting/BUILD`: Added dependencies for `backtest_service_client` and `backtest_service_client_impl` to the `backtesting_module` target.
- **Benefits:**
    - Enables the `BacktestServiceClientImpl` to be injected by Guice using its interface.
    - Sets up dependency injection for the backtest service client for consuming classes.