### PR TITLE
Implement `getStrategyTypes()` in `StrategyManager` and Test

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -163,6 +163,7 @@ java_library(
     srcs = ["StrategyManager.java"],
     deps = [
         "//protos:strategies_java_proto",
+        "//third_party:guava",
         "//third_party:protobuf_java",
         "//third_party:ta4j_core",
         ":strategy_factory",

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManager.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManager.java
@@ -1,5 +1,6 @@
 package com.verlumen.tradestream.strategies;
 
+import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.verlumen.tradestream.strategies.StrategyType;
@@ -7,6 +8,22 @@ import org.ta4j.core.BarSeries;
 import org.ta4j.core.Strategy;
 
 public interface StrategyManager {
+  /**
+   * Creates a Ta4j Strategy object from the provided parameters.
+   *
+   * @param barSeries The bar series to associate with the created strategy
+   * @param strategyType The type of strategy to create
+   * @param strategyParameters The parameters for configuring the strategy 
+   * @return The created Strategy object
+   * @throws InvalidProtocolBufferException If there is an error unpacking the parameters
+   */
   Strategy createStrategy(BarSeries barSeries, StrategyType strategyType, Any strategyParameters)
-    throws InvalidProtocolBufferException;
+      throws InvalidProtocolBufferException;
+
+  /**
+   * Returns an immutable list of all supported strategy types.
+   *
+   * @return List of available strategy types
+   */
+  ImmutableList<StrategyType> getStrategyTypes();
 }

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java
@@ -31,4 +31,9 @@ final class StrategyManagerImpl implements StrategyManager {
 
     return factory.createStrategy(barSeries, parameters);
   }
+
+  @Override
+  public ImmutableList<StrategyType> getStrategyTypes() {
+    return ImmutableList.copyOf(factoryMap.keySet());
+  }
 }

--- a/src/test/java/com/verlumen/tradestream/strategies/StrategyManagerImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/StrategyManagerImplTest.java
@@ -154,7 +154,7 @@ public class StrategyManagerImplTest {
     ImmutableList<StrategyType> expected = ImmutableList.of(StrategyType.EMA_MACD, StrategyType.SMA_RSI);
 
     // Act
-    ImmutableList<Strategy> actual = strategyManager.getStrategyTypes();
+    ImmutableList<StrategyType> actual = strategyManager.getStrategyTypes();
 
     // Assert
     assertThat(actual).containsExactlyElementsIn(expected);

--- a/src/test/java/com/verlumen/tradestream/strategies/StrategyManagerImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/StrategyManagerImplTest.java
@@ -150,11 +150,13 @@ public class StrategyManagerImplTest {
   @Test
   public void getStrategyTypes_returnsExpectedStrategyTypes()
       throws InvalidProtocolBufferException {
+    // Arrange
+    ImmutableList<StrategyType> expected = ImmutableList.of(StrategyType.EMA_MACD, StrategyType.SMA_RSI);
+
     // Act
-    ImmutableList<Strategy> actual =
-        strategyManager.getStrategies();
+    ImmutableList<Strategy> actual = strategyManager.getStrategyTypes();
 
     // Assert
-    assertThat(result).containsExactly(StrategyType.EMA_MACD, StrategyType.SMA_RSI);
+    assertThat(actual).containsExactlyElementsIn(expected);
   }
 }

--- a/src/test/java/com/verlumen/tradestream/strategies/StrategyManagerImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/StrategyManagerImplTest.java
@@ -146,4 +146,15 @@ public class StrategyManagerImplTest {
 
     assertThat(thrown).isSameInstanceAs(expectedException);
   }
+
+  @Test
+  public void getStrategyTypes_returnsExpectedStrategyTypes()
+      throws InvalidProtocolBufferException {
+    // Act
+    ImmutableList<Strategy> actual =
+        strategyManager.getStrategies();
+
+    // Assert
+    assertThat(result).containsExactly(StrategyType.EMA_MACD, StrategyType.SMA_RSI);
+  }
 }


### PR DESCRIPTION
- **Context:** This change adds a `getStrategyTypes()` method to the `StrategyManager` interface and its implementation, `StrategyManagerImpl`. This allows access to the supported strategy types in the system.
- **Changes:**
    - Modified `src/main/java/com/verlumen/tradestream/strategies/StrategyManager.java`: Added a `getStrategyTypes()` method.
    - Modified `src/main/java/com/verlumen/tradestream/strategies/StrategyManagerImpl.java`: Implemented the `getStrategyTypes()` method.
    - Modified `src/main/java/com/verlumen/tradestream/strategies/BUILD`: Added guava to the dependencies of `strategy_manager` target.
    - Modified `src/test/java/com/verlumen/tradestream/strategies/StrategyManagerImplTest.java`: Added a test case to verify correct operation of `getStrategyTypes()`.
- **Benefits:**
    - Provides a way to get a list of all supported strategy types.
    - Enables flexibility for other components needing a list of strategies without hardcoding.