### PR TITLE
Add `toTimestamp(long)` Method to `Timestamps`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/time/Timestamps.java
+++ b/src/main/java/com/verlumen/tradestream/time/Timestamps.java
@@ -15,12 +15,21 @@ public final class Timestamps {
                 timestamp.getNanos()),
             ZoneId.systemDefault());
     }
-    
+
+    /** Convert an epoch timestamp (milliseconds) to Protobuf Timestamp. */
+    public static Timestamp toTimestamp(long epochMillis) {
+        return toTimestamp(Instant.ofEpochMilli(epochMillis));
+    }
+
     /** Convert a ZonedDateTime to Protobuf Timestamp. */
     public static Timestamp toTimestamp(ZonedDateTime dateTime) {
+        return toTimestamp(dateTime.toInstant());
+    }
+
+    private static Timestamp toTimestamp(Instant instant) {
         return Timestamp.newBuilder()
-            .setSeconds(dateTime.toInstant().getEpochSecond())
-            .setNanos(dateTime.toInstant().getNano())
+            .setSeconds(instant.getEpochSecond())
+            .setNanos(instant.getNano())
             .build();
     }
 

--- a/src/test/java/com/verlumen/tradestream/time/TimestampsTest.java
+++ b/src/test/java/com/verlumen/tradestream/time/TimestampsTest.java
@@ -16,6 +16,21 @@ public class TimestampsTest {
     private static final int TEST_NANOS = 123456789;
 
     @Test
+    public void toTimestamp_convertsEpochMillisCorrectly() {
+        // Arrange
+        long epochMillis = TEST_SECONDS * 1000 + TEST_NANOS / 1_000_000;
+        
+        // Act
+        Timestamp result = Timestamps.toTimestamp(epochMillis);
+        
+        // Assert
+        assertThat(result.getSeconds()).isEqualTo(TEST_SECONDS);
+        // Since we're converting from millis, we'll lose some precision
+        // Only the first 6 digits of nanos will match (millisecond precision)
+        assertThat(result.getNanos()).isEqualTo((TEST_NANOS / 1_000_000) * 1_000_000);
+    }
+
+    @Test
     public void toZonedDateTime_convertsTimestampCorrectly() {
         // Arrange
         Timestamp timestamp = Timestamp.newBuilder()


### PR DESCRIPTION
- **Context:** This change adds a new `toTimestamp(long)` method to the `Timestamps` utility class. This method allows converting an epoch timestamp (milliseconds) directly into a Protobuf `Timestamp` object.
- **Changes:**
    - Modified `src/main/java/com/verlumen/tradestream/time/Timestamps.java`: Added the static `toTimestamp(long)` method that creates a `Timestamp` from epoch milliseconds. Also added a private method to convert from `java.time.Instant` to `com.google.protobuf.Timestamp`.
    - Modified `src/test/java/com/verlumen/tradestream/time/TimestampsTest.java`: Added a test case to verify that `toTimestamp(long)` functions correctly.
- **Benefits:**
    - Provides a more convenient way to convert from epoch milliseconds to Protobuf Timestamps.
    - Reduces boilerplate code by providing the conversion logic as a static utility method.
    - Increases the utility and flexibility of the `Timestamps` class.