### PR TITLE
Add Trade Signal Publishing Module with Kafka Integration and Unit Tests  

### DIFF
--- a/src/main/java/com/verlumen/tradestream/signals/BUILD
+++ b/src/main/java/com/verlumen/tradestream/signals/BUILD
@@ -1,5 +1,7 @@
 load("@rules_java//java:defs.bzl", "java_library")
 
+package(default_visibility = ["//visibility:public"])
+
 java_library(
     name = "signals_module",
     srcs = ["SignalsModule.java"],

--- a/src/main/java/com/verlumen/tradestream/signals/BUILD
+++ b/src/main/java/com/verlumen/tradestream/signals/BUILD
@@ -7,6 +7,7 @@ java_library(
     srcs = ["SignalsModule.java"],
     deps = [
         "//third_party:guice",
+        "//third_party:guice_assistedinject",
         ":trade_signal_publisher",
         ":trade_signal_publisher_impl",
     ],

--- a/src/main/java/com/verlumen/tradestream/signals/BUILD
+++ b/src/main/java/com/verlumen/tradestream/signals/BUILD
@@ -1,6 +1,16 @@
 load("@rules_java//java:defs.bzl", "java_library")
 
 java_library(
+    name = "signals_module",
+    srcs = ["SignalsModule.java"],
+    deps = [
+        "//third_party:guice",
+        ":trade_signal_publisher",
+        ":trade_signal_publisher_impl",
+    ],
+)
+
+java_library(
     name = "trade_signal_publisher",
     srcs = ["TradeSignalPublisher.java"],
     deps = [

--- a/src/main/java/com/verlumen/tradestream/signals/BUILD
+++ b/src/main/java/com/verlumen/tradestream/signals/BUILD
@@ -7,3 +7,20 @@ java_library(
         "//protos:trade_signals_java_proto",
     ],
 )
+
+java_library(
+    name = "trade_signal_publisher_impl",
+    srcs = ["TradeSignalPublisherImpl.java"],
+    deps = [
+        "//protos:trade_signals_java_proto",
+        "//third_party:flogger",
+        "//third_party:guice",
+        "//third_party:guice_assistedinject",
+        "//third_party:kafka_clients",
+        "//third_party:protobuf_java_util",
+        ":trade_signal_publisher",
+    ],
+    runtime_deps = [
+        "//third_party:flogger_system_backend",
+    ],
+)

--- a/src/main/java/com/verlumen/tradestream/signals/SignalsModule.java
+++ b/src/main/java/com/verlumen/tradestream/signals/SignalsModule.java
@@ -1,0 +1,12 @@
+package com.verlumen.tradestream.signals;
+
+import com.google.inject.AbstractModule;
+
+final class SignalsModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        install(new FactoryModuleBuilder()
+            .implement(TradeSignalPublisher.class, TradeSignalPublisherImpl.class)
+            .build(TradeSignalPublisher.Factory.class));
+    }
+}

--- a/src/main/java/com/verlumen/tradestream/signals/SignalsModule.java
+++ b/src/main/java/com/verlumen/tradestream/signals/SignalsModule.java
@@ -1,6 +1,7 @@
 package com.verlumen.tradestream.signals;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.assistedinject.FactoryModuleBuilder;
 
 final class SignalsModule extends AbstractModule {
     @Override

--- a/src/main/java/com/verlumen/tradestream/signals/TradeSignalPublisher.java
+++ b/src/main/java/com/verlumen/tradestream/signals/TradeSignalPublisher.java
@@ -3,6 +3,8 @@ package com.verlumen.tradestream.signals;
 interface TradeSignalPublisher {
     void publish(TradeSignal signal);
 
+    void close();
+
         /**
      * Factory interface for creating TradeSignalPublisher instances.
      */

--- a/src/main/java/com/verlumen/tradestream/signals/TradeSignalPublisher.java
+++ b/src/main/java/com/verlumen/tradestream/signals/TradeSignalPublisher.java
@@ -2,4 +2,11 @@ package com.verlumen.tradestream.signals;
 
 interface TradeSignalPublisher {
     void publish(TradeSignal signal);
+
+        /**
+     * Factory interface for creating TradeSignalPublisher instances.
+     */
+    interface Factory {
+        TradeSignalPublisher create(String topic);
+    }
 }

--- a/src/main/java/com/verlumen/tradestream/signals/TradeSignalPublisher.java
+++ b/src/main/java/com/verlumen/tradestream/signals/TradeSignalPublisher.java
@@ -1,6 +1,6 @@
 package com.verlumen.tradestream.signals;
 
-interface TradeSignalPublisher {
+public interface TradeSignalPublisher {
     void publish(TradeSignal signal);
 
     void close();

--- a/src/main/java/com/verlumen/tradestream/signals/TradeSignalPublisherImpl.java
+++ b/src/main/java/com/verlumen/tradestream/signals/TradeSignalPublisherImpl.java
@@ -76,11 +76,4 @@ final class TradeSignalPublisherImpl implements TradeSignalPublisher {
             throw e;
         }
     }
-
-    /**
-     * Factory interface for creating TradeSignalPublisher instances.
-     */
-    interface Factory {
-        TradeSignalPublisher create(String topic);
-    }
 }

--- a/src/main/java/com/verlumen/tradestream/signals/TradeSignalPublisherImpl.java
+++ b/src/main/java/com/verlumen/tradestream/signals/TradeSignalPublisherImpl.java
@@ -1,0 +1,86 @@
+package com.verlumen.tradestream.signals;
+
+import com.google.common.flogger.FluentLogger;
+import com.google.inject.assistedinject.Assisted;
+import com.google.inject.Inject;
+import com.google.protobuf.util.Timestamps;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import java.time.Duration;
+
+/**
+ * Kafka-based implementation of TradeSignalPublisher that publishes trade signals to a specified topic.
+ */
+final class TradeSignalPublisherImpl implements TradeSignalPublisher {
+    private static final FluentLogger logger = FluentLogger.forEnclosingClass();
+    private final KafkaProducer<String, byte[]> kafkaProducer;
+    private final String topic;
+
+    @Inject
+    TradeSignalPublisherImpl(
+        KafkaProducer<String, byte[]> kafkaProducer,
+        @Assisted String topic
+    ) {
+        logger.atInfo().log("Initializing TradeSignalPublisher for topic: %s", topic);
+        this.kafkaProducer = kafkaProducer;
+        this.topic = topic;
+        logger.atInfo().log("TradeSignalPublisher initialization complete");
+    }
+
+    @Override
+    public void publish(TradeSignal signal) {
+        logger.atInfo().log("Publishing trade signal to topic %s. Type=%s, Timestamp=%s, Price=%f", 
+            topic,
+            signal.getType(),
+            Timestamps.toString(Timestamps.fromMillis(signal.getTimestamp())),
+            signal.getPrice());
+
+        byte[] signalBytes = signal.toByteArray();
+        logger.atFine().log("Serialized signal data size: %d bytes", signalBytes.length);
+
+        // Use the strategy type as the key for partitioning
+        String key = signal.getStrategy().getType().name();
+
+        ProducerRecord<String, byte[]> record = new ProducerRecord<>(
+            topic,
+            key,
+            signalBytes
+        );
+
+        kafkaProducer.send(record, (metadata, exception) -> {
+            if (exception != null) {
+                logger.atSevere().withCause(exception)
+                    .log("Failed to publish trade signal for %s to topic %s", 
+                        signal.getStrategy().getType(), topic);
+            } else {
+                logger.atInfo().log("Successfully published signal: topic=%s, partition=%d, offset=%d, timestamp=%d",
+                    metadata.topic(), 
+                    metadata.partition(), 
+                    metadata.offset(),
+                    metadata.timestamp());
+            }
+        });
+    }
+
+    @Override
+    public void close() {
+        logger.atInfo().log("Initiating Kafka producer shutdown");
+        try {
+            logger.atInfo().log("Flushing any pending messages...");
+            kafkaProducer.flush();
+            logger.atInfo().log("Starting graceful shutdown with 5 second timeout");
+            kafkaProducer.close(Duration.ofSeconds(5));
+            logger.atInfo().log("Kafka producer closed successfully");
+        } catch (Exception e) {
+            logger.atSevere().withCause(e).log("Error during Kafka producer shutdown");
+            throw e;
+        }
+    }
+
+    /**
+     * Factory interface for creating TradeSignalPublisher instances.
+     */
+    interface Factory {
+        TradeSignalPublisher create(String topic);
+    }
+}

--- a/src/test/java/com/verlumen/tradestream/signals/BUILD
+++ b/src/test/java/com/verlumen/tradestream/signals/BUILD
@@ -1,0 +1,19 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
+java_test(
+    name = "trade_signal_publisher_impl_test",
+    srcs = ["TradeSignalPublisherImplTest.java"],
+    deps = [
+        "//protos:trade_signals_java_proto",
+        "//protos:strategies_java_proto",
+        "//third_party:guice",
+        "//third_party:guice_assistedinject",
+        "//third_party:guice_testlib",
+        "//third_party:junit",
+        "//third_party:kafka_clients",
+        "//third_party:mockito_core",
+        "//third_party:truth",
+        ":trade_signal_publisher",
+        ":trade_signal_publisher_impl",
+    ],
+)

--- a/src/test/java/com/verlumen/tradestream/signals/BUILD
+++ b/src/test/java/com/verlumen/tradestream/signals/BUILD
@@ -13,7 +13,7 @@ java_test(
         "//third_party:kafka_clients",
         "//third_party:mockito_core",
         "//third_party:truth",
-        ":trade_signal_publisher",
-        ":trade_signal_publisher_impl",
+        "//src/main/java/com/verlumen/tradestream/signals:trade_signal_publisher",
+        "//src/main/java/com/verlumen/tradestream/signals:trade_signal_publisher_impl",
     ],
 )

--- a/src/test/java/com/verlumen/tradestream/signals/BUILD
+++ b/src/test/java/com/verlumen/tradestream/signals/BUILD
@@ -1,7 +1,7 @@
 load("@rules_java//java:defs.bzl", "java_test")
 
 java_test(
-    name = "trade_signal_publisher_impl_test",
+    name = "TradeSignalPublisherImplTest",
     srcs = ["TradeSignalPublisherImplTest.java"],
     deps = [
         "//protos:trade_signals_java_proto",

--- a/src/test/java/com/verlumen/tradestream/signals/TradeSignalPublisherImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/signals/TradeSignalPublisherImplTest.java
@@ -1,0 +1,97 @@
+package com.verlumen.tradestream.signals;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.testing.fieldbinder.Bind;
+import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import com.verlumen.tradestream.strategies.Strategy;
+import com.verlumen.tradestream.strategies.StrategyType;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.time.Duration;
+
+@RunWith(JUnit4.class)
+public class TradeSignalPublisherImplTest {
+    @Rule public MockitoRule mocks = MockitoJUnit.rule();
+
+    private static final String TOPIC = "test-topic";
+    
+    @Mock @Bind private KafkaProducer<String, byte[]> mockProducer;
+    @Inject private TradeSignalPublisher.Factory factory;
+
+    @Before
+    public void setUp() {
+        Guice
+            .createInjector(
+                BoundFieldModule.of(this), 
+                new FactoryModuleBuilder()
+                     .implement(TradeSignalPublisher.class, TradeSignalPublisherImpl.class)
+                     .build(TradeSignalPublisher.Factory.class)
+            )
+            .injectMembers(this);
+    }
+
+    @Test
+    public void publish_sendsToKafka() {
+        // Arrange
+        TradeSignal signal = createTestSignal();
+
+        // Act
+        factory.create(TOPIC).publish(signal);
+
+        // Assert
+        verify(mockProducer).send(any(ProducerRecord.class), any());
+    }
+
+    @Test
+    public void publish_usesStrategyTypeAsKey() {
+        // Arrange
+        ArgumentCaptor<ProducerRecord<String, byte[]>> recordCaptor = 
+            ArgumentCaptor.forClass(ProducerRecord.class);
+        TradeSignal signal = createTestSignal();
+
+        // Act
+        factory.create(TOPIC).publish(signal);
+
+        // Assert
+        verify(mockProducer).send(recordCaptor.capture(), any());
+        ProducerRecord<String, byte[]> record = recordCaptor.getValue();
+        assertThat(record.key()).isEqualTo(signal.getStrategy().getType().name());
+    }
+
+    @Test
+    public void close_closesProducer() {
+        // Act
+        factory.create(TOPIC).close();
+
+        // Assert
+        verify(mockProducer).flush();
+        verify(mockProducer).close(any(Duration.class));
+    }
+
+    private TradeSignal createTestSignal() {
+        return TradeSignal.newBuilder()
+            .setType(TradeSignal.TradeSignalType.BUY)
+            .setTimestamp(System.currentTimeMillis())
+            .setPrice(50000.0)
+            .setStrategy(Strategy.newBuilder()
+                .setType(StrategyType.SMA_RSI)
+                .build())
+            .build();
+    }
+}

--- a/src/test/java/com/verlumen/tradestream/signals/TradeSignalPublisherImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/signals/TradeSignalPublisherImplTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.inject.Guice;
 import com.google.inject.Inject;
+import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import com.verlumen.tradestream.strategies.Strategy;


### PR DESCRIPTION
- **Feature Introduction:**  
  - Introduced a new `SignalsModule` to manage trade signal publishing via Kafka.  
  - Added a Kafka-based implementation of `TradeSignalPublisher` for publishing trade signals to a specified Kafka topic.  

- **Implementation Details:**  
  - **TradeSignalPublisher Interface:**  
    - Defines methods `publish` and `close`.  
    - Includes a factory interface for creating instances with specified topics.  
  - **TradeSignalPublisherImpl:**  
    - Uses `KafkaProducer` to publish serialized trade signals to a Kafka topic.  
    - Logs publishing details, including strategy type and metadata.  
    - Ensures graceful producer shutdown with a flush and close mechanism.  
  - **SignalsModule:**  
    - Configures factory-based DI for `TradeSignalPublisher` using Guice.  

- **Testing:**  
  - Added `TradeSignalPublisherImplTest` to validate behavior:  
    - Ensures `publish` sends signals to Kafka and uses the strategy type as the key.  
    - Validates proper shutdown of Kafka producer via `close`.  
  - Integrated unit tests with Mockito and Guice for dependency injection.  

- **Bazel Updates:**  
  - Added new targets in `signals/BUILD` for `signals_module`, `trade_signal_publisher`, and `trade_signal_publisher_impl`.  
  - Added a new test target in `signals/BUILD` for `TradeSignalPublisherImplTest`.  

- **Impact:**  
  - Provides modular and reusable trade signal publishing capabilities.  
  - Simplifies integration with Kafka for signal processing.  
  - Ensures robustness and test coverage for trade signal publishing logic.  