### PR TITLE
Refactor Kafka Integration with Dedicated `KafkaModule`  

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -272,7 +272,6 @@ java_library(
         "//third_party:guava",
         "//third_party:guice_assistedinject",
         "//third_party:guice",
-        "//third_party:kafka_clients",
         "//third_party:xchange_stream_core",
         ":candle_manager",
         ":candle_manager_impl",

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -265,7 +265,7 @@ java_library(
     name = "ingestion_module",
     srcs = ["IngestionModule.java"],
     deps = [
-        "//src/main/java/com/verlumen/tradestream/kafka:kafka_producer_provider",
+        "//src/main/java/com/verlumen/tradestream/kafka:kafka_module",
         "//src/main/java/com/verlumen/tradestream/execution:run_mode",
         "//third_party:argparse4j",
         "//third_party:auto_value",

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -24,10 +24,7 @@ abstract class IngestionModule extends AbstractModule {
   
   @Override
   protected void configure() {
-    bind(new TypeLiteral<KafkaProducer<String, byte[]>>() {})
-        .toProvider(KafkaProducerProvider.class);
     bind(Namespace.class).toProvider(ConfigArguments.create(commandLineArgs()));
-
     bind(CurrencyPairSupply.class).toProvider(CurrencyPairSupplyProvider.class);
     bind(ExchangeStreamingClient.Factory.class).to(ExchangeStreamingClientFactory.class);
     bind(HttpClient.class).to(HttpClientImpl.class);

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -8,11 +8,11 @@ import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.TypeLiteral;
 import com.verlumen.tradestream.execution.RunMode;
+import com.verlumen.tradestream.kafka.KafkaModule;
 import java.util.Properties;
 import java.util.Timer;
 import info.bitrich.xchangestream.core.StreamingExchange;
 import net.sourceforge.argparse4j.inf.Namespace;
-import org.apache.kafka.clients.producer.KafkaProducer;
 
 @AutoValue
 abstract class IngestionModule extends AbstractModule {
@@ -41,6 +41,7 @@ abstract class IngestionModule extends AbstractModule {
     install(new FactoryModuleBuilder()
         .implement(CandlePublisher.class, CandlePublisherImpl.class)
         .build(CandlePublisher.Factory.class));
+    install(KafkaModule.create());
   }
 
   @Provides

--- a/src/main/java/com/verlumen/tradestream/kafka/BUILD
+++ b/src/main/java/com/verlumen/tradestream/kafka/BUILD
@@ -9,6 +9,7 @@ java_library(
         "//third_party:guice",
         "//third_party:guice_assistedinject",
         "//third_party:kafka_clients",
+        ":kafka_producer_provider",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/kafka/BUILD
+++ b/src/main/java/com/verlumen/tradestream/kafka/BUILD
@@ -3,6 +3,16 @@ load("@rules_java//java:defs.bzl", "java_library")
 package(default_visibility = ["//visibility:public"])
 
 java_library(
+    name = "kafka_module",
+    srcs = ["KafkaModule.java"],
+    deps = [
+        "//third_party:guice",
+        "//third_party:guice_assistedinject",
+        "//third_party:kafka_clients",
+    ],
+)
+
+java_library(
     name = "kafka_producer_provider",
     srcs = ["KafkaProducerProvider.java"],
     deps = [

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaModule.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaModule.java
@@ -1,4 +1,4 @@
-package com.verlumen.tradestream.ingestion;
+package com.verlumen.tradestream.kafka;
 
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.AbstractModule;

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaModule.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaModule.java
@@ -1,0 +1,20 @@
+package com.verlumen.tradestream.ingestion;
+
+import com.google.inject.assistedinject.FactoryModuleBuilder;
+import com.google.inject.AbstractModule;
+import com.google.inject.TypeLiteral;
+import org.apache.kafka.clients.producer.KafkaProducer;
+
+public final class KafkaModule extends AbstractModule {
+  public static KafkaModule create() {
+    return new KafkaModule();
+  }
+  
+  @Override
+  protected void configure() {
+    bind(new TypeLiteral<KafkaProducer<String, byte[]>>() {})
+        .toProvider(KafkaProducerProvider.class);
+  }
+
+  private KafkaModule() {}
+}

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaProducerProvider.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaProducerProvider.java
@@ -1,4 +1,4 @@
-package com.verlumen.tradestream.ingestion;
+package com.verlumen.tradestream.kafka;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaProducerProvider.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaProducerProvider.java
@@ -9,7 +9,7 @@ final class KafkaProducerProvider implements Provider<KafkaProducer<String, byte
   private final KafkaProperties properties;
 
   @Inject
-  public KafkaProducerProvider(KafkaProperties properties) {
+  KafkaProducerProvider(KafkaProperties properties) {
     this.properties = properties;
   }
 


### PR DESCRIPTION
- **Context:** The Kafka integration in the ingestion module was tightly coupled, requiring better modularization for maintainability and reusability.  
- **Changes Made:**  
  - Introduced a new `KafkaModule` in the `kafka` package to handle Kafka-specific bindings.  
  - Updated `IngestionModule` to install the `KafkaModule` and removed direct Kafka producer binding.  
  - Moved `KafkaProducerProvider` from the `ingestion` package to the `kafka` package to align with modular structure.  
  - Updated Bazel BUILD files to reflect the new dependencies and structure:  
    - Added a target for `kafka_module` in `kafka/BUILD`.  
    - Removed redundant Kafka dependencies from `ingestion/BUILD`.  
- **Benefits:**  
  - Decouples Kafka-specific logic, enhancing modularity and promoting code reuse.  
  - Simplifies `IngestionModule` by delegating Kafka-related bindings to a dedicated module.  
  - Improves clarity and maintainability by organizing Kafka-related components under the `kafka` package.  
- **Impact:**  
  - No functional changes introduced; this refactor is structural to improve code organization.  
  - Consumers of the ingestion module or Kafka producer should see no behavioral differences.  