### PR TITLE
Simplify Initialization of `IngestionModule` in `App` 

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/App.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/App.java
@@ -4,6 +4,7 @@ import com.google.common.flogger.FluentLogger;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.verlumen.tradestream.execution.RunMode;
+import com.verlumen.tradestream.kafka.KafkaProperties;
 import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.Namespace;
@@ -62,7 +63,7 @@ final class App {
         candleIntervalMillis,
         runMode,
         kafkaProperties);
-      App app = Guice.createInjector(IngestionModule.create(namespace)).getInstance(App.class);
+      App app = Guice.createInjector(module).getInstance(App.class);
       logger.atInfo().log("Guice initialization complete, running application");
       app.run();
     } catch (Exception e) {

--- a/src/main/java/com/verlumen/tradestream/ingestion/App.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/App.java
@@ -45,6 +45,23 @@ final class App {
     try {
       logger.atInfo().log("Initializing Guice injector with IngestionModule");
       Namespace namespace = createParser().parseArgs(args);
+      String candlePublisherTopic = namespace.getString("candlePublisherTopic");
+      String coinMarketCapApiKey = namespace.getString("coinmarketcap.apiKey");
+      int topNCryptocurrencies = namespace.getInt("coinmarketcap.topN");
+      String exchangeName = namespace.getString("exchangeName");
+      long candleIntervalMillis = namespace.getInt("candleIntervalSeconds") * 1000L;
+      String runModeName = namespace.getString("runMode").toUpperCase();
+      RunMode runMode = RunMode.valueOf(runModeName);
+      KafkaProperties kafkaProperties =
+          KafkaProperties.createFromKafkaPrefixedProperties(namespace.getAttrs());
+      IngestionModule module = IngestionModule.create(
+        candlePublisherTopic,
+        coinMarketCapApiKey,
+        topNCryptocurrencies,
+        exchangeName,
+        candleIntervalMillis,
+        runMode,
+        kafkaProperties);
       App app = Guice.createInjector(IngestionModule.create(namespace)).getInstance(App.class);
       logger.atInfo().log("Guice initialization complete, running application");
       app.run();

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -257,7 +257,6 @@ java_library(
         "//src/main/java/com/verlumen/tradestream/kafka:kafka_module",
         "//src/main/java/com/verlumen/tradestream/kafka:kafka_properties",
         "//src/main/java/com/verlumen/tradestream/execution:run_mode",
-        "//third_party:argparse4j",
         "//third_party:auto_value",
         "//third_party:guava",
         "//third_party:guice_assistedinject",

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -12,6 +12,7 @@ java_binary(
     main_class = "com.verlumen.tradestream.ingestion.App",
     deps = [
         "//src/main/java/com/verlumen/tradestream/execution:run_mode",
+        "//src/main/java/com/verlumen/tradestream/kafka:kafka_properties",
         "//third_party:argparse4j",
         "//third_party:flogger",
         "//third_party:guice",

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -9,7 +9,6 @@ import com.verlumen.tradestream.kafka.KafkaModule;
 import com.verlumen.tradestream.kafka.KafkaProperties;
 import info.bitrich.xchangestream.core.StreamingExchange;
 import java.util.Timer;
-import net.sourceforge.argparse4j.inf.Namespace;
 
 @AutoValue
 abstract class IngestionModule extends AbstractModule {
@@ -22,27 +21,6 @@ abstract class IngestionModule extends AbstractModule {
       RunMode runMode,
       KafkaProperties kafkaProperties) {
     return new AutoValue_IngestionModule(
-        candlePublisherTopic,
-        coinMarketCapApiKey,
-        topNCryptocurrencies,
-        exchangeName,
-        candleIntervalMillis,
-        runMode,
-        kafkaProperties);
-  }
-
-  static IngestionModule create(Namespace namespace) {
-    String candlePublisherTopic = namespace.getString("candlePublisherTopic");
-    String coinMarketCapApiKey = namespace.getString("coinmarketcap.apiKey");
-    int topNCryptocurrencies = namespace.getInt("coinmarketcap.topN");
-    String exchangeName = namespace.getString("exchangeName");
-    long candleIntervalMillis = namespace.getInt("candleIntervalSeconds") * 1000L;
-    String runModeName = namespace.getString("runMode").toUpperCase();
-    RunMode runMode = RunMode.valueOf(runModeName);
-    KafkaProperties kafkaProperties =
-        KafkaProperties.createFromKafkaPrefixedProperties(namespace.getAttrs());
-
-    return create(
         candlePublisherTopic,
         coinMarketCapApiKey,
         topNCryptocurrencies,


### PR DESCRIPTION
Refactored `App` initialization and `IngestionModule` creation to streamline argument parsing and dependency injection.  

### Key Changes:
1. **App.java:**
   - Replaced the indirect `Namespace`-based `IngestionModule.create()` with direct parameterized initialization in `App`.
   - Parsed key arguments (`candlePublisherTopic`, `coinMarketCapApiKey`, `topNCryptocurrencies`, `exchangeName`, etc.) in `App` and passed them to `IngestionModule.create()`.  

2. **IngestionModule.java:**
   - Removed redundant `Namespace`-based `create()` method to simplify module construction.
   - Updated the API to enforce direct dependencies for `IngestionModule` parameters.  

3. **BUILD File Updates:**
   - Adjusted dependencies for `App` and `IngestionModule` to remove `Namespace` dependency (`argparse4j`) and centralize Kafka-related dependencies.

### Benefits:
- **Improved Clarity:** Parameters are explicitly passed, reducing reliance on `Namespace` and making argument requirements more apparent.
- **Better Separation of Concerns:** Parsing logic resides solely in `App`, while `IngestionModule` focuses on dependency injection.
- **Easier Maintenance:** Centralized parameter handling simplifies debugging and future modifications.