### PR TITLE
Update `dataIngestion` and `strategyEngine` args in Helm chart

### DIFF
--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -20,6 +20,8 @@ kafkaUi:
     port: 8080
 dataIngestion:
   args:
+    - '-jar'
+    - '/src/main/java/com/verlumen/tradestream/ingestion/app_deploy.jar'
     - --candlePublisherTopic=candles
     - --kafka.acks=all
     - --kafka.retries=5
@@ -33,6 +35,8 @@ dataIngestion:
     port: 8080
 strategyEngine:
   args:
+    - '-jar'
+    - '/src/main/java/com/verlumen/tradestream/strategies/app_deploy.jar'
     - --runMode=wet
   image:
     repository: "tradestreamhq/tradestream-strategy-engine"


### PR DESCRIPTION
This PR updates the Helm chart `values.yaml` file to include the `-jar` and path to the executable jar file in the `args` for both the `dataIngestion` and `strategyEngine` deployments. This ensures the correct jar files are executed when deploying these services.

#### Key Changes
- Added `-jar` and `/src/main/java/com/verlumen/tradestream/ingestion/app_deploy.jar` to `dataIngestion.args`.
- Added `-jar` and `/src/main/java/com/verlumen/tradestream/strategies/app_deploy.jar` to `strategyEngine.args`.

#### Testing
- N/A - This is a configuration change. Testing will be done by deploying the updated helm chart.

#### Dependencies/Impact
- This change affects the deployment configuration for the `dataIngestion` and `strategyEngine` services.
- No breaking changes to existing code or other components are expected.