### PR TITLE
Simplify and improve pod readiness check in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,83 +95,43 @@ jobs:
 
       - name: Wait for All Pods to be Ready
         run: |
-          set -e  # Exit immediately if a command exits with a non-zero status
+          set -e
 
           namespace="tradestream-namespace"
           timeout_seconds=180
-          interval=10  # Interval between checks in seconds
-          end_time=$((SECONDS+timeout_seconds))
 
           echo "Waiting for pods in namespace '${namespace}' to become Ready (timeout: ${timeout_seconds}s)..."
 
-          while [ $SECONDS -lt $end_time ]; do
-            # Use kubectl wait with a short timeout for this iteration
-            if kubectl wait --for=condition=Ready pod --all -n "${namespace}" --timeout="${interval}s" 2>/dev/null; then
-              echo "All pods in namespace '${namespace}' are Ready."
-              exit 0
-            fi
-
-            # If we're here, some pods aren't ready yet
-            echo "Current pod statuses in namespace '${namespace}':"
+          # Directly use kubectl wait with the condition and timeout
+          if ! kubectl wait --for=condition=Ready pod --all -n "${namespace}" --timeout="${timeout_seconds}s"; then
+            echo "Timeout reached or some pods failed to become Ready."
+            echo -e "\nCurrent pod statuses in namespace '${namespace}':"
             kubectl get pods -n "${namespace}"
 
-            # Only show detailed status if we're close to timeout
-            time_left=$((end_time-SECONDS))
-            if [ $time_left -lt $((interval * 2)) ]; then
-              echo -e "\nGathering detailed status and logs for non-ready pods..."
+            echo -e "\nGathering detailed status and logs for non-ready pods..."
+            not_ready_pod_names=$(kubectl get pods -n "${namespace}" -o jsonpath='{range .items[?(@.status.conditions[?(@.type=="Ready")].status=="False")]}{.metadata.name}{"\n"}{end}')
 
-              # Get pods where the 'Ready' condition status is 'False'
-              not_ready_pod_names=$(kubectl get pods -n "${namespace}" -o jsonpath='{range .items[?(@.status.conditions[?(@.type=="Ready")].status=="False")]}{.metadata.name}{"\n"}{end}')
+            if [[ -n "$not_ready_pod_names" ]]; then
+              while IFS= read -r pod; do
+                echo -e "\nDetails for pod '$pod':"
+                kubectl describe pod "$pod" -n "${namespace}"
 
-              if [[ -n "$not_ready_pod_names" ]]; then
-                while IFS= read -r pod; do
-                  echo -e "\nDetails for pod '$pod':"
-                  kubectl describe pod "$pod" -n "${namespace}"
-
-                  # Get container statuses
-                  containers=$(kubectl get pod "$pod" -n "${namespace}" -o jsonpath='{.spec.containers[*].name}')
-                  if [[ -n "$containers" ]]; then
-                    for container in $containers; do
-                      echo -e "\nLogs for container '$container' in pod '$pod':"
-                      # Try to get previous logs first
-                      kubectl logs "$pod" -n "${namespace}" -c "$container" --previous 2>/dev/null || true
-                      # Get current logs
-                      kubectl logs "$pod" -n "${namespace}" -c "$container"
-                    done
-                  fi
-                done <<< "$not_ready_pod_names"
-              fi
+                containers=$(kubectl get pod "$pod" -n "${namespace}" -o jsonpath='{.spec.containers[*].name}')
+                if [[ -n "$containers" ]]; then
+                  for container in $containers; do
+                    echo -e "\nLogs for container '$container' in pod '$pod':"
+                    kubectl logs "$pod" -n "${namespace}" -c "$container" --previous 2>/dev/null || true
+                    kubectl logs "$pod" -n "${namespace}" -c "$container"
+                  done
+                fi
+              done <<< "$not_ready_pod_names"
             else
-              echo "Waiting ${interval} seconds before next check... (${time_left}s until timeout)"
+              echo "No pods found that are not in the Ready state."
             fi
-            sleep $interval
-          done
-
-          echo "Timeout reached while waiting for pods to be ready."
-          echo -e "\nFinal pod statuses in namespace '${namespace}':"
-          kubectl get pods -n "${namespace}"
-
-          # Final detailed status for failed pods
-          echo -e "\nGathering final detailed status and logs for non-ready pods..."
-          not_ready_pod_names=$(kubectl get pods -n "${namespace}" -o jsonpath='{range .items[?(@.status.conditions[?(@.type=="Ready")].status=="False")]}{.metadata.name}{"\n"}{end}')
-
-          if [[ -n "$not_ready_pod_names" ]]; then
-            while IFS= read -r pod; do
-              echo -e "\nDetails for pod '$pod':"
-              kubectl describe pod "$pod" -n "${namespace}"
-
-              containers=$(kubectl get pod "$pod" -n "${namespace}" -o jsonpath='{.spec.containers[*].name}')
-              if [[ -n "$containers" ]]; then
-                for container in $containers; do
-                  echo -e "\nLogs for container '$container' in pod '$pod':"
-                  kubectl logs "$pod" -n "${namespace}" -c "$container" --previous 2>/dev/null || true
-                  kubectl logs "$pod" -n "${namespace}" -c "$container"
-                done
-              fi
-            done <<< "$not_ready_pod_names"
+            exit 1
           fi
 
-          exit 1
+          echo "All pods in namespace '${namespace}' are Ready."
 
       - name: Verify Installations
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,27 +105,29 @@ jobs:
           # First attempt to wait for all pods
           if ! kubectl wait --for=condition=Ready pod --all -n "${namespace}" --timeout="${timeout_seconds}s"; then
             echo "Some pods failed to become ready. Getting details..."
-            
+
             # Get all pods that aren't ready using a simple field selector
             problem_pods=$(kubectl get pods -n "${namespace}" --field-selector status.phase!=Running,status.phase!=Succeeded -o name)
-            
+
             # Also get pods in Running state but not ready (like CrashLoopBackOff)
             running_but_not_ready=$(kubectl get pods -n "${namespace}" --field-selector status.phase=Running -o jsonpath='{range .items[?(@.status.containerStatuses[*].ready==false)]}{.metadata.name}{"\n"}{end}')
-            
+
             problem_pods="$problem_pods"$'\n'"$running_but_not_ready"
 
             if [[ -n "$problem_pods" ]]; then
               echo -e "\nProblem pods found:"
               echo "$problem_pods"
-              
-              while IFS= read -r pod; do
-                if [[ -n "$pod" ]]; then
-                  echo -e "\n--- Details for $pod ---"
-                  kubectl describe pod "$pod" -n "${namespace}"
-                  
-                  echo -e "\n--- Logs for $pod ---"
-                  kubectl logs "$pod" -n "${namespace}" --all-containers=true --previous=true 2>/dev/null || true
-                  kubectl logs "$pod" -n "${namespace}" --all-containers=true
+
+              while IFS= read -r pod_with_type; do
+                if [[ -n "$pod_with_type" ]]; then
+                  # Extract the pod name by removing the "pod/" prefix
+                  pod_name="${pod_with_type#*/}"
+                  echo -e "\n--- Details for $pod_name ---"
+                  kubectl describe pod "$pod_name" -n "${namespace}"
+
+                  echo -e "\n--- Logs for $pod_name ---"
+                  kubectl logs "$pod_name" -n "${namespace}" --all-containers=true --previous=true 2>/dev/null || true
+                  kubectl logs "$pod_name" -n "${namespace}" --all-containers=true
                 fi
               done <<< "$problem_pods"
             fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,83 +95,83 @@ jobs:
 
       - name: Wait for All Pods to be Ready
         run: |
-          set -e  # Exit immediately if a command exits with a non-zero status.
+          set -e  # Exit immediately if a command exits with a non-zero status
 
           namespace="tradestream-namespace"
           timeout_seconds=180
-          label_selector="${{ github.event.inputs.label_selector }}" # Example of how to get a label selector from a workflow input, default to empty if not set
+          interval=10  # Interval between checks in seconds
+          end_time=$((SECONDS+timeout_seconds))
 
           echo "Waiting for pods in namespace '${namespace}' to become Ready (timeout: ${timeout_seconds}s)..."
 
-          # Construct the kubectl wait command. Include the label selector if provided.
-          wait_command="kubectl wait --for=condition=Ready pod --all -n \"${namespace}\" --timeout=\"${timeout_seconds}s\""
-          if [[ -n "${label_selector}" ]]; then
-            wait_command="$wait_command -l \"${label_selector}\""
-            echo "Using label selector: ${label_selector}"
-          fi
-
-          # Execute the kubectl wait command and check for success.
-          if ! eval "$wait_command"; then
-            echo "Timeout reached or some pods failed to become Ready within ${timeout_seconds} seconds."
-            echo -e "\nCurrent pod statuses in namespace '${namespace}':"
-            # Use a separate variable for the label flag to improve readability
-            label_flag=""
-            if [[ -n "${label_selector}" ]]; then
-              label_flag="-l \"${label_selector}\""
+          while [ $SECONDS -lt $end_time ]; do
+            # Use kubectl wait with a short timeout for this iteration
+            if kubectl wait --for=condition=Ready pod --all -n "${namespace}" --timeout="${interval}s" 2>/dev/null; then
+              echo "All pods in namespace '${namespace}' are Ready."
+              exit 0
             fi
-            kubectl get pods -n "${namespace}" $label_flag # Use label_flag
 
-            echo -e "\nGathering detailed status and logs for non-ready pods..."
-
-            # This command gets pods where the 'Ready' condition status is 'False'.
-            not_ready_pod_names=$(kubectl get pods -n "${namespace}" $label_flag -o jsonpath='{range .items[?(@.status.conditions[?(@.type=="Ready")].status=="False")]}{.metadata.name}{"\n"}{end}') # CHANGED
-
-            echo -e "\nPods identified as not Ready via JSONPath:\n$not_ready_pod_names" # CHANGED
-
-            if [[ -n "$not_ready_pod_names" ]]; then
-              while IFS= read -r pod; do
-                echo -e "\nDetails for pod '$pod':"
-                kubectl describe pod "$pod" -n "${namespace}"
-
-                # Get detailed status of containers within the pod. # CHANGED
-                container_statuses=$(kubectl get pod "$pod" -n "${namespace}" -o go-template='{{range .status.containerStatuses}}{{.name}}={{.state.waiting.reason}}={{.state.terminated.reason}}{{"\n"}}{{end}}')
-
-                containers=$(kubectl get pod "$pod" -n "${namespace}" -o jsonpath='{.spec.containers[*].name}')
-                if [[ -n "$containers" ]]; then
-                  for container in $containers; do
-                    log_this_container=false # Default to not logging unless criteria are met # CHANGED
-
-                    # We are focusing on the pod's Ready condition, not just container states.
-                    # Even if a container is "Running", a failing readiness probe means the pod isn't Ready.
-                    # We gather logs for all containers in pods that are not Ready.
-                    log_this_container=true
-
-                    if "$log_this_container"; then
+            # If we're here, some pods aren't ready yet
+            echo "Current pod statuses in namespace '${namespace}':"
+            kubectl get pods -n "${namespace}"
+            
+            # Only show detailed status if we're close to timeout
+            time_left=$((end_time-SECONDS))
+            if [ $time_left -lt $((interval * 2)) ]; then
+              echo -e "\nGathering detailed status and logs for non-ready pods..."
+              
+              # Get pods where the 'Ready' condition status is 'False'
+              not_ready_pod_names=$(kubectl get pods -n "${namespace}" -o jsonpath='{range .items[?(@.status.conditions[?(@.type=="Ready")].status=="False")]}{.metadata.name}{"\n"}{end}')
+              
+              if [[ -n "$not_ready_pod_names" ]]; then
+                while IFS= read -r pod; do
+                  echo -e "\nDetails for pod '$pod':"
+                  kubectl describe pod "$pod" -n "${namespace}"
+                  
+                  # Get container statuses
+                  containers=$(kubectl get pod "$pod" -n "${namespace}" -o jsonpath='{.spec.containers[*].name}')
+                  if [[ -n "$containers" ]]; then
+                    for container in $containers; do
                       echo -e "\nLogs for container '$container' in pod '$pod':"
-                      # We capture both --previous and current logs to provide a more complete picture.
-                      # --previous logs can contain information about why a container restarted or failed.
-                      kubectl logs "$pod" -n "${namespace}" -c "$container" --previous 2>/dev/null || true # Attempt to get previous logs, ignore errors if not available
+                      # Try to get previous logs first
+                      kubectl logs "$pod" -n "${namespace}" -c "$container" --previous 2>/dev/null || true
+                      # Get current logs
                       kubectl logs "$pod" -n "${namespace}" -c "$container"
-                    fi
-                  done
-                else
-                  echo "No containers found in pod '$pod'."
-                fi
-              done <<< "$not_ready_pod_names"
+                    done
+                  fi
+                done <<< "$not_ready_pod_names"
+              fi
             else
-              echo "No pods found that are not in the Ready state."
+              echo "Waiting ${interval} seconds before next check... (${time_left}s until timeout)"
+              sleep $interval
             fi
+          done
 
-            exit 1
-          else
-            echo "All targeted pods in namespace '${namespace}' are Ready."
+          echo "Timeout reached while waiting for pods to be ready."
+          echo -e "\nFinal pod statuses in namespace '${namespace}':"
+          kubectl get pods -n "${namespace}"
+          
+          # Final detailed status for failed pods
+          echo -e "\nGathering final detailed status and logs for non-ready pods..."
+          not_ready_pod_names=$(kubectl get pods -n "${namespace}" -o jsonpath='{range .items[?(@.status.conditions[?(@.type=="Ready")].status=="False")]}{.metadata.name}{"\n"}{end}')
+          
+          if [[ -n "$not_ready_pod_names" ]]; then
+            while IFS= read -r pod; do
+              echo -e "\nDetails for pod '$pod':"
+              kubectl describe pod "$pod" -n "${namespace}"
+              
+              containers=$(kubectl get pod "$pod" -n "${namespace}" -o jsonpath='{.spec.containers[*].name}')
+              if [[ -n "$containers" ]]; then
+                for container in $containers; do
+                  echo -e "\nLogs for container '$container' in pod '$pod':"
+                  kubectl logs "$pod" -n "${namespace}" -c "$container" --previous 2>/dev/null || true
+                  kubectl logs "$pod" -n "${namespace}" -c "$container"
+                done
+              fi
+            done <<< "$not_ready_pod_names"
           fi
-          # We are focusing on the 'Ready' condition of the pods because this indicates
-          # whether the application within the pod is ready to serve traffic.
-          # A pod can be in the 'Running' phase but still not 'Ready' if its readiness
-          # probes are failing.
-
-
+          
+          exit 1
 
       - name: Verify Installations
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,20 +114,20 @@ jobs:
             # If we're here, some pods aren't ready yet
             echo "Current pod statuses in namespace '${namespace}':"
             kubectl get pods -n "${namespace}"
-            
+
             # Only show detailed status if we're close to timeout
             time_left=$((end_time-SECONDS))
             if [ $time_left -lt $((interval * 2)) ]; then
               echo -e "\nGathering detailed status and logs for non-ready pods..."
-              
+
               # Get pods where the 'Ready' condition status is 'False'
               not_ready_pod_names=$(kubectl get pods -n "${namespace}" -o jsonpath='{range .items[?(@.status.conditions[?(@.type=="Ready")].status=="False")]}{.metadata.name}{"\n"}{end}')
-              
+
               if [[ -n "$not_ready_pod_names" ]]; then
                 while IFS= read -r pod; do
                   echo -e "\nDetails for pod '$pod':"
                   kubectl describe pod "$pod" -n "${namespace}"
-                  
+
                   # Get container statuses
                   containers=$(kubectl get pod "$pod" -n "${namespace}" -o jsonpath='{.spec.containers[*].name}')
                   if [[ -n "$containers" ]]; then
@@ -143,23 +143,23 @@ jobs:
               fi
             else
               echo "Waiting ${interval} seconds before next check... (${time_left}s until timeout)"
-              sleep $interval
             fi
+            sleep $interval
           done
 
           echo "Timeout reached while waiting for pods to be ready."
           echo -e "\nFinal pod statuses in namespace '${namespace}':"
           kubectl get pods -n "${namespace}"
-          
+
           # Final detailed status for failed pods
           echo -e "\nGathering final detailed status and logs for non-ready pods..."
           not_ready_pod_names=$(kubectl get pods -n "${namespace}" -o jsonpath='{range .items[?(@.status.conditions[?(@.type=="Ready")].status=="False")]}{.metadata.name}{"\n"}{end}')
-          
+
           if [[ -n "$not_ready_pod_names" ]]; then
             while IFS= read -r pod; do
               echo -e "\nDetails for pod '$pod':"
               kubectl describe pod "$pod" -n "${namespace}"
-              
+
               containers=$(kubectl get pod "$pod" -n "${namespace}" -o jsonpath='{.spec.containers[*].name}')
               if [[ -n "$containers" ]]; then
                 for container in $containers; do
@@ -170,7 +170,7 @@ jobs:
               fi
             done <<< "$not_ready_pod_names"
           fi
-          
+
           exit 1
 
       - name: Verify Installations

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,31 +102,32 @@ jobs:
 
           echo "Waiting for pods in namespace '${namespace}' to become Ready (timeout: ${timeout_seconds}s)..."
 
-          # Directly use kubectl wait with the condition and timeout
+          # First attempt to wait for all pods
           if ! kubectl wait --for=condition=Ready pod --all -n "${namespace}" --timeout="${timeout_seconds}s"; then
-            echo "Timeout reached or some pods failed to become Ready."
-            echo -e "\nCurrent pod statuses in namespace '${namespace}':"
-            kubectl get pods -n "${namespace}"
+            echo "Some pods failed to become ready. Getting details..."
+            
+            # Get all pods that aren't ready using a simple field selector
+            problem_pods=$(kubectl get pods -n "${namespace}" --field-selector status.phase!=Running,status.phase!=Succeeded -o name)
+            
+            # Also get pods in Running state but not ready (like CrashLoopBackOff)
+            running_but_not_ready=$(kubectl get pods -n "${namespace}" --field-selector status.phase=Running -o jsonpath='{range .items[?(@.status.containerStatuses[*].ready==false)]}{.metadata.name}{"\n"}{end}')
+            
+            problem_pods="$problem_pods"$'\n'"$running_but_not_ready"
 
-            echo -e "\nGathering detailed status and logs for non-ready pods..."
-            not_ready_pod_names=$(kubectl get pods -n "${namespace}" -o jsonpath='{range .items[?(@.status.conditions[?(@.type=="Ready")].status=="False")]}{.metadata.name}{"\n"}{end}')
-
-            if [[ -n "$not_ready_pod_names" ]]; then
+            if [[ -n "$problem_pods" ]]; then
+              echo -e "\nProblem pods found:"
+              echo "$problem_pods"
+              
               while IFS= read -r pod; do
-                echo -e "\nDetails for pod '$pod':"
-                kubectl describe pod "$pod" -n "${namespace}"
-
-                containers=$(kubectl get pod "$pod" -n "${namespace}" -o jsonpath='{.spec.containers[*].name}')
-                if [[ -n "$containers" ]]; then
-                  for container in $containers; do
-                    echo -e "\nLogs for container '$container' in pod '$pod':"
-                    kubectl logs "$pod" -n "${namespace}" -c "$container" --previous 2>/dev/null || true
-                    kubectl logs "$pod" -n "${namespace}" -c "$container"
-                  done
+                if [[ -n "$pod" ]]; then
+                  echo -e "\n--- Details for $pod ---"
+                  kubectl describe pod "$pod" -n "${namespace}"
+                  
+                  echo -e "\n--- Logs for $pod ---"
+                  kubectl logs "$pod" -n "${namespace}" --all-containers=true --previous=true 2>/dev/null || true
+                  kubectl logs "$pod" -n "${namespace}" --all-containers=true
                 fi
-              done <<< "$not_ready_pod_names"
-            else
-              echo "No pods found that are not in the Ready state."
+              done <<< "$problem_pods"
             fi
             exit 1
           fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,7 +98,7 @@ jobs:
           set -e
 
           namespace="tradestream-namespace"
-          timeout_seconds=10
+          timeout_seconds=180
 
           echo "Waiting for pods in namespace '${namespace}' to become Ready (timeout: ${timeout_seconds}s)..."
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,7 +98,7 @@ jobs:
           set -e
 
           namespace="tradestream-namespace"
-          timeout_seconds=180
+          timeout_seconds=10
 
           echo "Waiting for pods in namespace '${namespace}' to become Ready (timeout: ${timeout_seconds}s)..."
 


### PR DESCRIPTION
This PR simplifies and improves the pod readiness check in the CI workflow. It removes the label selector complexity and streamlines the logic to focus on checking for pods that are not in a `Ready` or `Running` state or that are in a `Running` state but have failing readiness probes. It provides detailed logs and descriptions for failed pods, making it easier to diagnose deployment issues.

#### Key Changes
- Removed the `label_selector` input and associated logic.
- Uses a simpler `kubectl wait` command to check for pod readiness.
- If `kubectl wait` fails, it retrieves pods that are not `Running` or `Succeeded` using a field selector.
- It also gets pods that are in the `Running` state but not `Ready` by inspecting the container statuses.
- Combines these lists of problem pods and iterates through them to provide detailed descriptions and logs.
- Uses `--all-containers=true` to ensure logs from all containers are collected.
- Tries to retrieve previous logs as well, to provide more context.

#### Testing
- This was tested by triggering workflow runs with and without intentionally breaking the deployment to verify the logs and descriptions are being captured correctly.

#### Dependencies/Impact
- This change only impacts the CI workflow.
- No dependencies, breaking changes, or impacts on other components.
- The change provides a simpler yet robust mechanism for diagnosing pod deployment failures in the CI workflow.