### PR TITLE
Remove JAR path arguments from Helm chart

### DIFF
--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -20,8 +20,6 @@ kafkaUi:
     port: 8080
 dataIngestion:
   args:
-    - '-jar'
-    - '/src/main/java/com/verlumen/tradestream/ingestion/app_deploy.jar'
     - --candlePublisherTopic=candles
     - --kafka.acks=all
     - --kafka.retries=5
@@ -35,8 +33,6 @@ dataIngestion:
     port: 8080
 strategyEngine:
   args:
-    - '-jar'
-    - '/src/main/java/com/verlumen/tradestream/strategies/app_deploy.jar'
     - --candleTopic=candles
     - --runMode=wet
     - --tradeSignalTopic=tradeSignals


### PR DESCRIPTION
This PR removes the explicit `-jar` and jar file path arguments from the `dataIngestion` and `strategyEngine` deployments within the Helm chart's `values.yaml`. The JAR file is now being configured as the image's entry point so these arguments are no longer required.

#### Key Changes
- Removed `-jar` and `/src/main/java/com/verlumen/tradestream/ingestion/app_deploy.jar` from `dataIngestion.args`.
- Removed `-jar` and `/src/main/java/com/verlumen/tradestream/strategies/app_deploy.jar` from `strategyEngine.args`.

#### Testing
- N/A - This change is a configuration update. Verification will be done during deployment.

#### Dependencies/Impact
- This change affects the deployment configuration for `dataIngestion` and `strategyEngine` services.
- It simplifies the configuration by removing redundant JAR execution arguments.
- No breaking changes are expected, as the applications are now configured to run by default.