### PR TITLE
Add `KafkaConsumerProvider` and test

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -91,6 +91,16 @@ oci_image_index(
     ],
 )
 
+java_library(
+    name = "kafka_consumer_provider",
+    srcs = ["KafkaConsumerProvider.java"],
+    deps = [
+        "//src/main/java/com/verlumen/tradestream/kafka:kafka_properties",
+        "//third_party:guice",
+        "//third_party:kafka_clients",
+    ],
+)
+
 tar(
     name = "layer",
     srcs = [":app_deploy.jar"],
@@ -134,6 +144,7 @@ java_library(
         "//third_party:guice_assistedinject",
         ":candle_buffer",
         ":candle_buffer_impl",
+        ":kafka_consumer_provider",
         ":market_data_consumer",
         ":market_data_consumer_impl",
         ":strategy_engine",

--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -142,6 +142,7 @@ java_library(
         "//third_party:guava",
         "//third_party:guice",
         "//third_party:guice_assistedinject",
+        "//third_party:kafka_clients",
         ":candle_buffer",
         ":candle_buffer_impl",
         ":kafka_consumer_provider",

--- a/src/main/java/com/verlumen/tradestream/strategies/KafkaConsumerProvider.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/KafkaConsumerProvider.java
@@ -1,4 +1,5 @@
 package com.verlumen.tradestream.strategies;
+// KafkaConsumerProvider.java
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
@@ -12,6 +13,7 @@ import java.util.Properties;
 
 final class KafkaConsumerProvider implements Provider<KafkaConsumer<byte[], byte[]>> {
     private static final String GROUP_ID = "strategy-engine-consumer-group";
+    private static final String DEFAULT_SECURITY_PROTOCOL = "PLAINTEXT"; // Add this
 
     private final KafkaProperties kafkaProperties;
 
@@ -22,23 +24,24 @@ final class KafkaConsumerProvider implements Provider<KafkaConsumer<byte[], byte
 
     @Override
     public KafkaConsumer<byte[], byte[]> get() {
-        Properties props = kafkaProperties.get(); // Get base properties
+        Properties props = kafkaProperties.get();
 
         // Add consumer-specific properties
         props.put(ConsumerConfig.GROUP_ID_CONFIG, GROUP_ID);
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
         props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
-        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false"); // Since we use commitSync
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
         props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "500");
-        props.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "300000"); // 5 minutes
-        props.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "30000"); // 30 seconds
-        props.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, "10000"); // 10 seconds
+        props.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "300000");
+        props.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "30000");
+        props.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, "10000");
 
-        // SASL configuration (if enabled)
-        if (!kafkaProperties.securityProtocol().isEmpty()) {
-            props.put("security.protocol", kafkaProperties.securityProtocol());
-        }
+        // SASL configuration 
+        String securityProtocol = kafkaProperties.securityProtocol().isEmpty() ? 
+            DEFAULT_SECURITY_PROTOCOL : kafkaProperties.securityProtocol();
+        props.put("security.protocol", securityProtocol);
+        
         if (!kafkaProperties.saslMechanism().isEmpty()) {
             props.put("sasl.mechanism", kafkaProperties.saslMechanism());
         }

--- a/src/main/java/com/verlumen/tradestream/strategies/KafkaConsumerProvider.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/KafkaConsumerProvider.java
@@ -1,0 +1,51 @@
+package com.verlumen.tradestream.strategies;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.verlumen.tradestream.kafka.KafkaProperties;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+
+import java.util.Properties;
+
+final class KafkaConsumerProvider implements Provider<KafkaConsumer<byte[], byte[]>> {
+    private static final String GROUP_ID = "strategy-engine-consumer-group";
+
+    private final KafkaProperties kafkaProperties;
+
+    @Inject
+    KafkaConsumerProvider(KafkaProperties kafkaProperties) {
+        this.kafkaProperties = kafkaProperties;
+    }
+
+    @Override
+    public KafkaConsumer<byte[], byte[]> get() {
+        Properties props = kafkaProperties.get(); // Get base properties
+
+        // Add consumer-specific properties
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, GROUP_ID);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false"); // Since we use commitSync
+        props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "500");
+        props.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "300000"); // 5 minutes
+        props.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "30000"); // 30 seconds
+        props.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, "10000"); // 10 seconds
+
+        // SASL configuration (if enabled)
+        if (!kafkaProperties.securityProtocol().isEmpty()) {
+            props.put("security.protocol", kafkaProperties.securityProtocol());
+        }
+        if (!kafkaProperties.saslMechanism().isEmpty()) {
+            props.put("sasl.mechanism", kafkaProperties.saslMechanism());
+        }
+        if (!kafkaProperties.saslJaasConfig().isEmpty()) {
+            props.put("sasl.jaas.config", kafkaProperties.saslJaasConfig());
+        }
+
+        return new KafkaConsumer<>(props);
+    }
+}

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.java
@@ -9,6 +9,7 @@ import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.verlumen.tradestream.backtesting.BacktestingModule;
 import com.verlumen.tradestream.signals.SignalsModule;
 import com.verlumen.tradestream.signals.TradeSignalPublisher;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 
 @AutoValue
 abstract class StrategiesModule extends AbstractModule {

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.java
@@ -4,6 +4,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
+import com.google.inject.Singleton;
 import com.google.inject.TypeLiteral;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.verlumen.tradestream.backtesting.BacktestingModule;

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.java
@@ -22,6 +22,9 @@ abstract class StrategiesModule extends AbstractModule {
   @Override
   protected void configure() {
     bind(CandleBuffer.class).to(CandleBufferImpl.class);
+    bind(new TypeLiteral<Provider<KafkaConsumer<byte[], byte[]>>>() {})
+        .toProvider(KafkaConsumerProvider.class)
+        .in(Singleton.class);
     bind(MarketDataConsumer.class).to(MarketDataConsumerImpl.class);
     bind(new TypeLiteral<ImmutableList<StrategyFactory<?>>>() {})
         .toInstance(StrategyFactories.ALL_FACTORIES);

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.java
@@ -23,7 +23,7 @@ abstract class StrategiesModule extends AbstractModule {
   @Override
   protected void configure() {
     bind(CandleBuffer.class).to(CandleBufferImpl.class);
-    bind(new TypeLiteral<Provider<KafkaConsumer<byte[], byte[]>>>() {})
+    bind(new TypeLiteral<KafkaConsumer<byte[], byte[]>>() {})
         .toProvider(KafkaConsumerProvider.class)
         .in(Singleton.class);
     bind(MarketDataConsumer.class).to(MarketDataConsumerImpl.class);

--- a/src/test/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/test/java/com/verlumen/tradestream/strategies/BUILD
@@ -1,6 +1,20 @@
 load("@rules_java//java:defs.bzl", "java_test")
 
 java_test(
+    name = "KafkaConsumerProviderTest",
+    srcs = ["KafkaConsumerProviderTest.java"],
+    deps = [
+        "//src/main/java/com/verlumen/tradestream/kafka:kafka_properties",
+        "//src/main/java/com/verlumen/tradestream/strategies:kafka_consumer_provider",
+        "//third_party:guice",
+        "//third_party:guice_testlib",
+        "//third_party:junit",
+        "//third_party:kafka_clients", 
+        "//third_party:mockito_core",
+    ],
+)
+
+java_test(
     name = "StrategyEngineImplTest",
     srcs = ["StrategyEngineImplTest.java"],
     deps = [

--- a/src/test/java/com/verlumen/tradestream/strategies/KafkaConsumerProviderTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/KafkaConsumerProviderTest.java
@@ -1,0 +1,56 @@
+package com.verlumen.tradestream.strategies;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
+
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.testing.fieldbinder.Bind;
+import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import com.verlumen.tradestream.kafka.KafkaProperties;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.Properties;
+
+@RunWith(JUnit4.class)
+public class KafkaConsumerProviderTest {
+    @Rule public MockitoRule mockito = MockitoJUnit.rule();
+
+    @Mock @Bind private KafkaProperties mockKafkaProperties;
+    @Inject private KafkaConsumerProvider provider;
+
+    @Before
+    public void setUp() {
+        when(mockKafkaProperties.get()).thenReturn(new Properties());
+        when(mockKafkaProperties.bootstrapServers()).thenReturn("localhost:9092");
+        when(mockKafkaProperties.securityProtocol()).thenReturn("");
+        when(mockKafkaProperties.saslMechanism()).thenReturn("");
+        when(mockKafkaProperties.saslJaasConfig()).thenReturn("");
+
+        Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+    }
+
+    @Test
+    public void get_createsConsumerWithValidConfig() {
+        KafkaConsumer<byte[], byte[]> consumer = provider.get();
+        assertNotNull(consumer);
+    }
+
+    @Test
+    public void get_includesSecurityConfig_whenProvided() {
+        when(mockKafkaProperties.securityProtocol()).thenReturn("SASL_SSL");
+        when(mockKafkaProperties.saslMechanism()).thenReturn("PLAIN");
+        when(mockKafkaProperties.saslJaasConfig()).thenReturn("org.apache.kafka.common.security.plain.PlainLoginModule required username=\"user\" password=\"pass\";");
+
+        KafkaConsumer<byte[], byte[]> consumer = provider.get();
+        assertNotNull(consumer);
+    }
+}

--- a/src/test/java/com/verlumen/tradestream/strategies/KafkaConsumerProviderTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/KafkaConsumerProviderTest.java
@@ -1,7 +1,6 @@
 package com.verlumen.tradestream.strategies;
 
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.when;
 
 import com.google.inject.Guice;
 import com.google.inject.Inject;
@@ -10,30 +9,32 @@ import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import com.verlumen.tradestream.kafka.KafkaProperties;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
 
 import java.util.Properties;
 
 @RunWith(JUnit4.class)
 public class KafkaConsumerProviderTest {
-    @Rule public MockitoRule mockito = MockitoJUnit.rule();
-
-    @Mock @Bind private KafkaProperties mockKafkaProperties;
+    @Bind private KafkaProperties kafkaProperties; // No longer a mock
     @Inject private KafkaConsumerProvider provider;
 
     @Before
     public void setUp() {
-        when(mockKafkaProperties.get()).thenReturn(new Properties());
-        when(mockKafkaProperties.bootstrapServers()).thenReturn("localhost:9092");
-        when(mockKafkaProperties.securityProtocol()).thenReturn("");
-        when(mockKafkaProperties.saslMechanism()).thenReturn("");
-        when(mockKafkaProperties.saslJaasConfig()).thenReturn("");
+        kafkaProperties = new KafkaProperties(
+            "all",                // acks
+            16384,               // batchSize
+            "localhost:9092",    // bootstrapServers
+            0,                   // retries 
+            1,                   // lingerMs
+            33554432,            // bufferMemory
+            "org.apache.kafka.common.serialization.StringSerializer", // keySerializer
+            "org.apache.kafka.common.serialization.StringSerializer", // valueSerializer
+            "",                  // securityProtocol
+            "",                  // saslMechanism
+            ""                   // saslJaasConfig
+        );
 
         Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
     }
@@ -46,10 +47,22 @@ public class KafkaConsumerProviderTest {
 
     @Test
     public void get_includesSecurityConfig_whenProvided() {
-        when(mockKafkaProperties.securityProtocol()).thenReturn("SASL_SSL");
-        when(mockKafkaProperties.saslMechanism()).thenReturn("PLAIN");
-        when(mockKafkaProperties.saslJaasConfig()).thenReturn("org.apache.kafka.common.security.plain.PlainLoginModule required username=\"user\" password=\"pass\";");
+        // Create new KafkaProperties with security config
+        kafkaProperties = new KafkaProperties(
+            "all",                // acks
+            16384,               // batchSize
+            "localhost:9092",    // bootstrapServers
+            0,                   // retries 
+            1,                   // lingerMs
+            33554432,            // bufferMemory
+            "org.apache.kafka.common.serialization.StringSerializer", // keySerializer
+            "org.apache.kafka.common.serialization.StringSerializer", // valueSerializer
+            "SASL_SSL",          // securityProtocol
+            "PLAIN",             // saslMechanism
+            "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"user\" password=\"pass\";" // saslJaasConfig
+        );
 
+        Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
         KafkaConsumer<byte[], byte[]> consumer = provider.get();
         assertNotNull(consumer);
     }

--- a/src/test/java/com/verlumen/tradestream/strategies/KafkaConsumerProviderTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/KafkaConsumerProviderTest.java
@@ -17,7 +17,7 @@ import java.util.Properties;
 
 @RunWith(JUnit4.class)
 public class KafkaConsumerProviderTest {
-    @Bind private KafkaProperties kafkaProperties; // No longer a mock
+    @Bind private KafkaProperties kafkaProperties;
     @Inject private KafkaConsumerProvider provider;
 
     @Before
@@ -31,7 +31,7 @@ public class KafkaConsumerProviderTest {
             33554432,            // bufferMemory
             "org.apache.kafka.common.serialization.StringSerializer", // keySerializer
             "org.apache.kafka.common.serialization.StringSerializer", // valueSerializer
-            "",                  // securityProtocol
+            "PLAINTEXT",         // securityProtocol - changed from empty string
             "",                  // saslMechanism
             ""                   // saslJaasConfig
         );
@@ -47,7 +47,6 @@ public class KafkaConsumerProviderTest {
 
     @Test
     public void get_includesSecurityConfig_whenProvided() {
-        // Create new KafkaProperties with security config
         kafkaProperties = new KafkaProperties(
             "all",                // acks
             16384,               // batchSize


### PR DESCRIPTION
This PR introduces a `KafkaConsumerProvider` class for creating and configuring Kafka consumers, along with a corresponding test. This provider centralizes the configuration of Kafka consumers and makes them available for dependency injection.

#### Key Changes
- Added `KafkaConsumerProvider.java` to provide configured `KafkaConsumer` instances.
- Added `KafkaConsumerProviderTest.java` to verify the correct configuration of the provider.
- Updated the `BUILD` files to include `kafka_consumer_provider` and update existing dependencies.
  - Added `kafka_consumer_provider` target.
  - Added `//third_party:kafka_clients` to `strategy_engine_impl` dependencies.

- The Kafka consumer is configured with `ByteArrayDeserializer` and with settings to disable auto-commit, max poll records and interval and the group id is set to a default value.
- The provider supports `SASL` configuration by reading from the `KafkaProperties`

#### Testing
- Added a unit test (`KafkaConsumerProviderTest`) to ensure the provider correctly creates and configures `KafkaConsumer` instances with and without `SASL`.
- Verified the Kafka consumer properties by manually inspecting the properties map after initialization

#### Dependencies/Impact
- The change introduces a new dependency on the `kafka_consumer_provider` target and adds `//third_party:kafka_clients` to `strategy_engine_impl` dependencies.
- No breaking changes to existing components, it is a new provider for `KafkaConsumer` that can be injected.
