### PR TITLE
Add Kafka bootstrap server arg and update strategy engine args in Helm chart

### DIFF
--- a/charts/tradestream/templates/data-ingestion.yaml
+++ b/charts/tradestream/templates/data-ingestion.yaml
@@ -25,6 +25,7 @@ spec:
           {{- range .Values.dataIngestion.args }}
             - {{ . }}
           {{- end }}
+            - "--kafka.bootstrap.servers={{ include "tradestream.fullname" . }}-kafka.{{ .Release.Namespace }}.svc.cluster.local:9092"
           image: "{{ .Values.dataIngestion.image.repository }}:{{ .Values.dataIngestion.image.tag }}"
           imagePullPolicy: {{ default "IfNotPresent" .Values.dataIngestion.image.pullPolicy }}
           ports:

--- a/charts/tradestream/templates/strategy-engine.yaml
+++ b/charts/tradestream/templates/strategy-engine.yaml
@@ -25,6 +25,7 @@ spec:
           {{- range .Values.strategyEngine.args }}
             - {{ . }}
           {{- end }}
+            - "--kafka.bootstrap.servers={{ include "tradestream.fullname" . }}-kafka.{{ .Release.Namespace }}.svc.cluster.local:9092"
           image: "{{ .Values.strategyEngine.image.repository }}:{{ .Values.strategyEngine.image.tag }}"
           imagePullPolicy: {{ default "IfNotPresent" .Values.strategyEngine.image.pullPolicy }}
           ports:

--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -34,6 +34,9 @@ dataIngestion:
 strategyEngine:
   args:
     - --candleTopic=candles
+    - --kafka.acks=all
+    - --kafka.retries=5
+    - --kafka.linger.ms=50
     - --runMode=wet
     - --tradeSignalTopic=tradeSignals
   image:


### PR DESCRIPTION
This PR updates the Helm chart to dynamically inject the Kafka bootstrap server address into the `dataIngestion` and `strategyEngine` deployments. Additionally, it adds default Kafka configuration arguments to the `strategyEngine`.

#### Key Changes
- Renamed `data-ingestion-deployment.yaml` to `data-ingestion.yaml`.
- Added a dynamically generated Kafka bootstrap server argument to the `args` of `dataIngestion` and `strategyEngine` deployments using the Helm template function `include "tradestream.fullname" .`.
- Added default Kafka configuration arguments (`--kafka.acks`, `--kafka.retries`, `--kafka.linger.ms`) to `strategyEngine.args`.
- Update the `strategyEngine` args to include a `kafka.linger.ms` default.

#### Testing
- N/A - These are configuration changes, verification will be during deployment.

#### Dependencies/Impact
- This change impacts the deployment configuration for `dataIngestion` and `strategyEngine` services.
- It ensures the services can locate the Kafka broker via a dynamically generated address.
- This adds default configuration arguments for kafka to the `strategyEngine` to make running the application locally easier.
- No breaking changes to the existing components.