### PR TITLE
Add gRPC netty shaded dependency to backtesting module

### DIFF
--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -97,6 +97,7 @@ java_library(
         "//protos:backtesting_java_proto",
         "//third_party:guice",
         "//third_party:grpc_java_api",
+        "//third_party:grpc_java_netty_shaded",
         "//third_party:grpc_java_stub",
         ":ga_service_client",
     ],


### PR DESCRIPTION
This PR adds the `grpc-netty-shaded` dependency to the backtesting module. This is required to use the gRPC client for communication with the GA service.

#### Key Changes
- Added `//third_party:grpc_java_netty_shaded` to the dependencies of the `backtesting_module` target.

#### Testing
- N/A - This is a dependency change. It will be implicitly tested during the integration tests.

#### Dependencies/Impact
- This change adds a new dependency on `grpc-netty-shaded` to the backtesting module.
- No breaking changes to existing components.
- This dependency will allow the backtesting module to communicate with the gRPC service.