### PR TITLE
Remove explicit flogger runtime dependency from BUILD files

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -21,9 +21,6 @@ java_binary(
         ":real_time_data_ingestion",
         ":real_time_data_ingestion_impl",
     ],
-    runtime_deps = [
-        "//third_party:flogger_system_backend",
-    ],
 )
 
 java_library(
@@ -34,9 +31,6 @@ java_library(
         "//third_party:flogger",
         "//third_party:protobuf_java",
         "//third_party:protobuf_java_util",
-    ],
-    runtime_deps = [
-        "//third_party:flogger_system_backend",
     ],
 )
 
@@ -66,9 +60,6 @@ java_library(
         ":candle_publisher",
         ":price_tracker",
     ],
-    runtime_deps = [
-        "//third_party:flogger_system_backend",
-    ],
 )
 
 java_library(
@@ -91,9 +82,6 @@ java_library(
         "//third_party:protobuf_java_util",
         ":candle_publisher",
     ],
-    runtime_deps = [
-        "//third_party:flogger_system_backend",
-    ],
 )
 
 java_library(
@@ -108,9 +96,6 @@ java_library(
         "//third_party:guice",
         "//third_party:protobuf_java_util",
         ":exchange_streaming_client",
-    ],
-    runtime_deps = [
-        "//third_party:flogger_system_backend",
     ],
 )
 
@@ -205,9 +190,6 @@ java_library(
         "//third_party:guice",
         ":http_client",
         ":http_url_connection_factory",
-    ],
-    runtime_deps = [
-        "//third_party:flogger_system_backend",
     ],
 )
 
@@ -337,9 +319,6 @@ java_library(
         ":thin_market_timer",
         ":trade_processor",
     ],
-    runtime_deps = [
-        "//third_party:flogger_system_backend",
-    ],
 )
 
 java_library(
@@ -356,9 +335,6 @@ java_library(
         "//third_party:xchange_core",
         ":thin_market_timer",
         ":thin_market_timer_task",
-    ],
-    runtime_deps = [
-        "//third_party:flogger_system_backend",
     ],
 )
 
@@ -388,8 +364,5 @@ java_library(
         "//third_party:auto_value",
         "//third_party:flogger",
         "//third_party:protobuf_java_util",
-    ],
-    runtime_deps = [
-        "//third_party:flogger_system_backend",
     ],
 )

--- a/src/main/java/com/verlumen/tradestream/signals/BUILD
+++ b/src/main/java/com/verlumen/tradestream/signals/BUILD
@@ -33,7 +33,4 @@ java_library(
         "//third_party:protobuf_java_util",
         ":trade_signal_publisher",
     ],
-    runtime_deps = [
-        "//third_party:flogger_system_backend",
-    ],
 )

--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -22,9 +22,6 @@ java_binary(
         ":strategies_module",
         ":strategy_engine",
     ],
-    runtime_deps = [
-        "//third_party:flogger_system_backend",
-    ],
 )
 
 java_library(
@@ -126,9 +123,6 @@ java_library(
         "//third_party:guice_assistedinject",
         "//third_party:kafka_clients",
         ":market_data_consumer",
-    ],
-    runtime_deps = [
-        "//third_party:flogger_system_backend",
     ],
 )
 

--- a/src/test/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/test/java/com/verlumen/tradestream/backtesting/BUILD
@@ -37,9 +37,6 @@ java_test(
         "//third_party:guice",
         "//third_party:guice_testlib",
     ],
-    runtime_deps = [
-        "//third_party:flogger_system_backend",
-    ],
 )
 
 java_test(

--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -17,7 +17,6 @@ java_test(
     ],
     runtime_deps = [
         "//third_party:argparse4j",
-        "//third_party:flogger_system_backend",
     ],
 )
 

--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -9,6 +9,7 @@ java_test(
         "//src/main/java/com/verlumen/tradestream/execution:run_mode",
         "//src/main/java/com/verlumen/tradestream/ingestion:app",
         "//src/main/java/com/verlumen/tradestream/ingestion:real_time_data_ingestion",
+        "//third_party:flogger",
         "//third_party:guice",
         "//third_party:guice_testlib",
         "//third_party:junit",

--- a/src/test/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/test/java/com/verlumen/tradestream/strategies/BUILD
@@ -55,9 +55,6 @@ java_test(
         "//third_party:ta4j_core",
         "//third_party:truth",
     ],
-    runtime_deps = [
-        "//third_party:flogger_system_backend",
-    ],
 )
 
 java_test(
@@ -77,8 +74,5 @@ java_test(
         "//third_party:mockito_core",
         "//third_party:ta4j_core",
         "//third_party:truth",
-    ],
-    runtime_deps = [
-        "//third_party:flogger_system_backend",
     ],
 )

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/BUILD
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/BUILD
@@ -16,9 +16,6 @@ java_test(
         "//third_party:ta4j_core",
         "//third_party:truth",
     ],
-    runtime_deps = [
-        "//third_party:flogger_system_backend",
-    ],
 )
 
 java_test(
@@ -36,9 +33,6 @@ java_test(
         "//third_party:protobuf_java",
         "//third_party:ta4j_core",
         "//third_party:truth",
-    ],
-    runtime_deps = [
-        "//third_party:flogger_system_backend",
     ],
 )
 
@@ -58,9 +52,6 @@ java_test(
         "//third_party:ta4j_core",
         "//third_party:truth",
     ],
-    runtime_deps = [
-        "//third_party:flogger_system_backend",
-    ],
 )
 
 java_test(
@@ -78,8 +69,5 @@ java_test(
         "//third_party:protobuf_java",
         "//third_party:ta4j_core",
         "//third_party:truth",
-    ],
-    runtime_deps = [
-        "//third_party:flogger_system_backend",
     ],
 )

--- a/src/test/java/com/verlumen/tradestream/strategies/oscillators/BUILD
+++ b/src/test/java/com/verlumen/tradestream/strategies/oscillators/BUILD
@@ -15,9 +15,6 @@ java_test(
         "//third_party:truth",
         "//third_party:ta4j_core",
     ],
-     runtime_deps = [
-        "//third_party:flogger_system_backend",
-    ],
 )
 
 java_test(
@@ -34,8 +31,5 @@ java_test(
         "//third_party:mockito_core",
         "//third_party:truth",
         "//third_party:ta4j_core",
-    ],
-     runtime_deps = [
-        "//third_party:flogger_system_backend",
     ],
 )

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -83,7 +83,7 @@ java_library(
     exports = [
         "@tradestream_maven//:com_google_flogger_flogger",
     ],
-    runtime_dpes = [
+    runtime_deps = [
         ":flogger_system_backend",
     ],
 )

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -83,11 +83,13 @@ java_library(
     exports = [
         "@tradestream_maven//:com_google_flogger_flogger",
     ],
+    runtime_dpes = [
+        ":flogger_system_backend",
+    ],
 )
 
 java_library(
     name = "flogger_system_backend",
-    visibility = ["//visibility:public"],
     exports = [
         "@tradestream_maven//:com_google_flogger_flogger_system_backend",
     ],


### PR DESCRIPTION
This PR removes the explicit `flogger_system_backend` runtime dependency from various `BUILD` files across the project. The `flogger_system_backend` is now a runtime dependency of `flogger`, so we can remove the explicit runtime depenencies for targets that use `flogger`. This change simplifies dependency management and ensures consistency across the project.

#### Key Changes
- Removed `//third_party:flogger_system_backend` from `runtime_deps` in the following targets:
  - `src/main/java/com/verlumen/tradestream/ingestion/BUILD`
  - `src/main/java/com/verlumen/tradestream/signals/BUILD`
  - `src/main/java/com/verlumen/tradestream/strategies/BUILD`
  - `src/test/java/com/verlumen/tradestream/backtesting/BUILD`
  - `src/test/java/com/verlumen/tradestream/ingestion/BUILD`
  - `src/test/java/com/verlumen/tradestream/strategies/BUILD`
  - `src/test/java/com/verlumen/tradestream/strategies/movingaverages/BUILD`
  - `src/test/java/com/verlumen/tradestream/strategies/oscillators/BUILD`
- Added `flogger_system_backend` as runtime dependency of `flogger` in `third_party/BUILD`.

#### Testing
- N/A - This is a dependency management change. Implicitly tested by all the tests.

#### Dependencies/Impact
- This change simplifies dependency management across the project.
- No breaking changes are expected as the runtime dependency is still satisfied by the `flogger` dependency.