### PR TITLE
Inject `StrategyEngine` directly into `App`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/App.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/App.java
@@ -23,13 +23,13 @@ final class App {
   private volatile boolean isRunning = false;
   private final MarketDataConsumer marketDataConsumer;
   private final RunMode runMode;
-  private final Provider<StrategyEngine> strategyEngine;
+  private final StrategyEngine strategyEngine;
 
   @Inject
   App(
       MarketDataConsumer marketDataConsumer,
       RunMode runMode,
-      Provider<StrategyEngine> strategyEngine) {
+      StrategyEngine strategyEngine) {
     this.marketDataConsumer = marketDataConsumer;
     this.runMode = runMode;
     this.strategyEngine = strategyEngine;
@@ -51,7 +51,7 @@ final class App {
 
     try {
       isRunning = true;
-      marketDataConsumer.startConsuming(strategyEngine.get()::handleCandle);
+      marketDataConsumer.startConsuming(strategyEngine::handleCandle);
       logger.atInfo().log("Strategy Engine service started successfully");
     } catch (Exception e) {
       logger.atSevere().withCause(e).log("Failed to start Strategy Engine service");


### PR DESCRIPTION
This PR changes the injection of the `StrategyEngine` in the `App` class from a `Provider<StrategyEngine>` to a direct `StrategyEngine` dependency. This simplifies the code by removing unnecessary indirection and allows direct access to the `StrategyEngine` instance.

#### Key Changes
- Changed the `StrategyEngine` injection in `App.java` from `Provider<StrategyEngine>` to `StrategyEngine`.
- Updated the `start()` method to directly use the injected `strategyEngine` instance without calling `get()`.

#### Testing
- N/A - This is a code change and will be covered by existing integration tests.

#### Dependencies/Impact
- This change removes the dependency on `Provider<StrategyEngine>` in the `App` class.
- No breaking changes are expected, the code is more clear and direct.