### PR TITLE
Add default parameter getter to `StrategyFactory`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
@@ -47,9 +47,7 @@ public interface StrategyFactory<T extends Message> {
   *
   * @return The default parameters for this strategy.
   */
-  default T getDefaultParameters() {
-    throw new UnsupportedOperationException();
-  }
+  T getDefaultParameters();
 
   /**
    * Gets the {@link StrategyType} that this factory handles.

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
@@ -41,7 +41,16 @@ public interface StrategyFactory<T extends Message> {
   default Strategy createStrategy(BarSeries series, Any parameters) throws InvalidProtocolBufferException {
     return createStrategy(series, parameters.unpack(getParameterClass()));
   }
- 
+
+  /**
+  * Gets the default parameters for this strategy.
+  *
+  * @return The default parameters for this strategy.
+  */
+  default T getDefaultParameters() {
+    throw new UnsupportedOperationException();
+  }
+
   /**
    * Gets the {@link StrategyType} that this factory handles.
    *

--- a/src/main/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/movingaverages/DoubleEmaCrossoverStrategyFactory.java
@@ -50,6 +50,14 @@ final class DoubleEmaCrossoverStrategyFactory implements StrategyFactory<DoubleE
     }
 
     @Override
+    public DoubleEmaCrossoverParameters getDefaultParameters() {
+        return DoubleEmaCrossoverParameters.newBuilder()
+            .setShortEmaPeriod(12)
+            .setLongEmaPeriod(26)
+            .build();
+    }
+
+    @Override
     public StrategyType getStrategyType() {
         return StrategyType.DOUBLE_EMA_CROSSOVER;
     }

--- a/src/main/java/com/verlumen/tradestream/strategies/movingaverages/MomentumSmaCrossoverStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/movingaverages/MomentumSmaCrossoverStrategyFactory.java
@@ -59,7 +59,7 @@ final class MomentumSmaCrossoverStrategyFactory
         return MomentumSmaCrossoverParameters.newBuilder()
             .setMomentumPeriod(10)
             .setSmaPeriod(20)
-            .build())
+            .build();
     }
 
     @Override

--- a/src/main/java/com/verlumen/tradestream/strategies/movingaverages/MomentumSmaCrossoverStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/movingaverages/MomentumSmaCrossoverStrategyFactory.java
@@ -53,7 +53,15 @@ final class MomentumSmaCrossoverStrategyFactory
             exitRule,
             Math.max(params.getMomentumPeriod(), params.getSmaPeriod()));
         }
-    
+
+    @Override
+    public MomentumSmaCrossoverParameters getDefaultParameters() {
+        return MomentumSmaCrossoverParameters.newBuilder()
+            .setMomentumPeriod(10)
+            .setSmaPeriod(20)
+            .build())
+    }
+
     @Override
     public StrategyType getStrategyType() {
         return StrategyType.MOMENTUM_SMA_CROSSOVER;

--- a/src/main/java/com/verlumen/tradestream/strategies/movingaverages/SmaEmaCrossoverStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/movingaverages/SmaEmaCrossoverStrategyFactory.java
@@ -44,6 +44,14 @@ final class SmaEmaCrossoverStrategyFactory implements StrategyFactory<SmaEmaCros
   }
 
   @Override
+  public SmaEmaCrossoverParameters getDefaultParameters() {
+      return SmaEmaCrossoverParameters.newBuilder()
+          .setSmaPeriod(20) // Default SMA period, typically used as a short-term trend
+          .setEmaPeriod(50) // Default EMA period, commonly used for medium-term trend
+          .build();
+  }
+
+  @Override
   public StrategyType getStrategyType() {
     return StrategyType.SMA_EMA_CROSSOVER;
   }

--- a/src/main/java/com/verlumen/tradestream/strategies/movingaverages/TripleEmaCrossoverStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/movingaverages/TripleEmaCrossoverStrategyFactory.java
@@ -58,6 +58,15 @@ public class TripleEmaCrossoverStrategyFactory
   }
 
   @Override
+  public TripleEmaCrossoverParameters getDefaultParameters() {
+      return TripleEmaCrossoverParameters.newBuilder()
+          .setShortEmaPeriod(10)   // Default short EMA period for quick responsiveness
+          .setMediumEmaPeriod(20)  // Default medium EMA period for smoother trends
+          .setLongEmaPeriod(50)    // Default long EMA period for overall trend
+          .build();
+  }
+
+  @Override
   public StrategyType getStrategyType() {
     return StrategyType.TRIPLE_EMA_CROSSOVER;
   }

--- a/src/main/java/com/verlumen/tradestream/strategies/oscillators/AdxStochasticStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/oscillators/AdxStochasticStrategyFactory.java
@@ -58,6 +58,16 @@ final class AdxStochasticStrategyFactory
   }
 
   @Override
+  public AdxStochasticParameters getDefaultParameters() {
+      return AdxStochasticParameters.newBuilder()
+          .setAdxPeriod(14)               // Commonly used ADX period
+          .setStochasticKPeriod(14)       // Typical Stochastic K period
+          .setOverboughtThreshold(80)     // Default overbought threshold
+          .setOversoldThreshold(20)       // Default oversold threshold
+          .build();
+  }
+
+  @Override
   public StrategyType getStrategyType() {
     return StrategyType.ADX_STOCHASTIC;
   }

--- a/src/main/java/com/verlumen/tradestream/strategies/oscillators/SmaRsiStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/oscillators/SmaRsiStrategyFactory.java
@@ -51,6 +51,16 @@ final class SmaRsiStrategyFactory implements StrategyFactory<SmaRsiParameters> {
     return new BaseStrategy(strategyName, entryRule, exitRule, params.getRsiPeriod());
   }
 
+  @Override
+  public SmaRsiParameters getDefaultParameters() {
+      return SmaRsiParameters.newBuilder()
+          .setMovingAveragePeriod(14)      // Typical moving average period for smoothing RSI
+          .setRsiPeriod(14)                // Common RSI calculation period
+          .setOverboughtThreshold(70)      // Overbought threshold, often set at 70
+          .setOversoldThreshold(30)        // Oversold threshold, often set at 30
+          .build();
+  }
+
   private SmaRsiStrategyFactory() {}
 
   @Override


### PR DESCRIPTION
This PR adds a `getDefaultParameters()` method to the `StrategyFactory` interface and implements it in all existing strategy factories. This allows strategies to have default parameters that can be used when no parameters are provided, or to simplify the creation of strategies with common settings.

#### Key Changes
- Added a `getDefaultParameters()` method to the `StrategyFactory` interface.
- Implemented the `getDefaultParameters()` method in all strategy factories to return a default instance of their parameter type.
- Added default values to each of the parameter messages.
- Updated all the strategy factories to use the builder pattern to construct the default parameter messages.