### PR TITLE
Add GA server implementation

### DIFF
--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -104,9 +104,10 @@ java_library(
 )
 
 java_library(
-    name = "ga_service",
-    srcs = ["GAService.java"],
+    name = "ga_server",
+    srcs = ["GAServer.java"],
     deps = [
+        "//third_party:grpc_java_api",
         "//third_party:guice",
         ":ga_service_impl",
     ],

--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -104,6 +104,15 @@ java_library(
 )
 
 java_library(
+    name = "ga_service",
+    srcs = ["GAService.java"],
+    deps = [
+        "//third_party:guice",
+        ":ga_service_impl",
+    ],
+)
+
+java_library(
     name = "ga_service_impl",
     srcs = ["GAServiceImpl.java"],
     deps = [

--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -1,4 +1,4 @@
-load("@rules_java//java:defs.bzl", "java_library")
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -81,6 +81,17 @@ java_library(
 )
 
 java_library(
+    name = "ga_server",
+    srcs = ["GAServer.java"],
+    deps = [
+        "//third_party:grpc_java_api",
+        "//third_party:guice",
+        ":backtesting_module",
+        ":ga_service_impl",
+    ],
+)
+
+java_library(
     name = "ga_service_client",
     srcs = ["GAServiceClient.java"],
     deps = [
@@ -100,16 +111,6 @@ java_library(
         "//third_party:grpc_java_netty_shaded",
         "//third_party:grpc_java_stub",
         ":ga_service_client",
-    ],
-)
-
-java_library(
-    name = "ga_server",
-    srcs = ["GAServer.java"],
-    deps = [
-        "//third_party:grpc_java_api",
-        "//third_party:guice",
-        ":ga_service_impl",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/backtesting/GAServer.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/GAServer.java
@@ -8,7 +8,7 @@ import com.google.inject.Injector;
 public class GAServer {
     public static void main(String[] args) throws Exception {
         // Create Guice injector
-        Injector injector = Guice.createInjector(new BacktestingModule());
+        Injector injector = Guice.createInjector(BacktestingModule.create());
         
         // Get GAServiceImpl instance from Guice
         GAServiceImpl gaService = injector.getInstance(GAServiceImpl.class);

--- a/src/main/java/com/verlumen/tradestream/backtesting/GAServer.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/GAServer.java
@@ -1,0 +1,27 @@
+package com.verlumen.tradestream.backtesting;
+
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+public class GAServer {
+    public static void main(String[] args) throws Exception {
+        // Create Guice injector
+        Injector injector = Guice.createInjector(new GAModule());
+        
+        // Get GAServiceImpl instance from Guice
+        GAServiceImpl gaService = injector.getInstance(GAServiceImpl.class);
+        
+        // Create and start gRPC server
+        Server server = ServerBuilder.forPort(50051)
+            .addService(gaService)
+            .build();
+        
+        server.start();
+        System.out.println("GA Server started on port 50051");
+        
+        // Keep server running
+        server.awaitTermination();
+    }
+}

--- a/src/main/java/com/verlumen/tradestream/backtesting/GAServer.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/GAServer.java
@@ -8,7 +8,7 @@ import com.google.inject.Injector;
 public class GAServer {
     public static void main(String[] args) throws Exception {
         // Create Guice injector
-        Injector injector = Guice.createInjector(new GAModule());
+        Injector injector = Guice.createInjector(new BacktestingModule());
         
         // Get GAServiceImpl instance from Guice
         GAServiceImpl gaService = injector.getInstance(GAServiceImpl.class);


### PR DESCRIPTION
This PR introduces the `GAServer` class, which sets up and starts a gRPC server for the backtesting module. It uses Guice for dependency injection and starts the server to handle optimization requests. This provides a server implementation for the GA Service.

#### Key Changes
- Added `GAServer.java` which sets up and starts a gRPC server on port 50051.
- The server uses a Guice injector for dependency injection.
- The `GAServiceImpl` is added as a service to the gRPC server.
- The `GAServer` waits for termination to keep the server running.
- Added a `ga_server` target to `src/main/java/com/verlumen/tradestream/backtesting/BUILD`.

#### Testing
- N/A - This is infrastructure change. Integration tests will be added later.

#### Dependencies/Impact
- This change introduces the `GAServer` class to the backtesting module.
- No breaking changes to existing code.
- This is the initial implementation of the backtesting service.