### PR TITLE
Update gRPC java library dependencies

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -99,7 +99,7 @@ java_library(
     name = "grpc_java_api",
     visibility = ["//visibility:public"],
     exports = [
-        "@tradestream_maven//:io_grpc_grpc_api",
+        "@io_grpc_grpc_java//api",
     ],
 )
 
@@ -124,7 +124,7 @@ java_library(
     name = "grpc_java_stub",
     visibility = ["//visibility:public"],
     exports = [
-        "@tradestream_maven//:io_grpc_grpc_stub",
+        "@io_grpc_grpc_java//stub",
     ],
 )
 


### PR DESCRIPTION
This PR updates the gRPC java library dependencies in the `third_party/BUILD` file. It changes the maven coordinates to use the explicit bazel targets provided by the `io_grpc_grpc_java` module.

#### Key Changes
- Updated the export for `grpc_java_api` from `@tradestream_maven//:io_grpc_grpc_api` to `@io_grpc_grpc_java//api`.
- Updated the export for `grpc_java_stub` from `@tradestream_maven//:io_grpc_grpc_stub` to `@io_grpc_grpc_java//stub`.
