### PR TITLE
Add cert-manager and flink operator to CI and Helm Chart

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,6 +83,7 @@ jobs:
 
       - name: Install TradeStream Helm Chart
         run: |
+          kubectl create -f https://github.com/jetstack/cert-manager/releases/download/v1.8.2/cert-manager.yaml && \
           helm dependency update charts/tradestream && \
           helm install my-tradestream charts/tradestream \
             --namespace tradestream-namespace \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,7 +81,6 @@ jobs:
           minikube image load tradestream-data-ingestion:latest
           minikube image load tradestream-strategy-engine:latest
 
-      # Install cert-manager in its own step
       - name: Install Cert Manager
         run: |
           # Create the cert-manager namespace if it doesn't exist
@@ -94,7 +93,7 @@ jobs:
         run: |
           kubectl wait \
             --for=condition=Available \
-            --timeout=300s \
+            --timeout=90s \
             deployment \
             -l app.kubernetes.io/instance=cert-manager \
             -n cert-manager

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,9 +81,26 @@ jobs:
           minikube image load tradestream-data-ingestion:latest
           minikube image load tradestream-strategy-engine:latest
 
+      # Install cert-manager in its own step
+      - name: Install Cert Manager
+        run: |
+          # Create the cert-manager namespace if it doesn't exist
+          kubectl create namespace cert-manager || true
+ 
+          # Apply the cert-manager manifests
+          kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.8.2/cert-manager.yaml
+ 
+      - name: Wait for Cert Manager
+        run: |
+          kubectl wait \
+            --for=condition=Available \
+            --timeout=300s \
+            deployment \
+            -l app.kubernetes.io/instance=cert-manager \
+            -n cert-manager
+
       - name: Install TradeStream Helm Chart
         run: |
-          kubectl create -f https://github.com/jetstack/cert-manager/releases/download/v1.8.2/cert-manager.yaml && \
           helm dependency update charts/tradestream && \
           helm install my-tradestream charts/tradestream \
             --namespace tradestream-namespace \

--- a/charts/tradestream/Chart.yaml
+++ b/charts/tradestream/Chart.yaml
@@ -4,6 +4,11 @@ description: Chart for deploying TradeStream.
 version: 0.1.0
 appVersion: "3.0.0"
 dependencies:
+  - name: cert-manager
+    version: v1.9.1
+    repository: https://charts.jetstack.io
+    alias: cert-manager
+    condition: cert-manager.enabled
   - name: flink-kubernetes-operator
     version: "1.10.0"
     repository: "https://downloads.apache.org/flink/flink-kubernetes-operator-1.10.0/"

--- a/charts/tradestream/Chart.yaml
+++ b/charts/tradestream/Chart.yaml
@@ -4,11 +4,6 @@ description: Chart for deploying TradeStream.
 version: 0.1.0
 appVersion: "3.0.0"
 dependencies:
-  - name: cert-manager
-    version: v1.9.1
-    repository: https://charts.jetstack.io
-    alias: cert-manager
-    condition: cert-manager.enabled
   - name: flink-kubernetes-operator
     version: "1.10.0"
     repository: "https://downloads.apache.org/flink/flink-kubernetes-operator-1.10.0/"

--- a/charts/tradestream/Chart.yaml
+++ b/charts/tradestream/Chart.yaml
@@ -7,6 +7,7 @@ dependencies:
   - name: kafka
     version: 30.1.8
     repository: https://charts.bitnami.com/bitnami
-  - name: flink
-    version: 1.20.0
-    repository: https://charts.bitnami.com/flink
+  - name: flink-kubernetes-operator
+    version: "1.10.0"
+    repository: "https://downloads.apache.org/flink/flink-kubernetes-operator-1.10.0/"
+

--- a/charts/tradestream/Chart.yaml
+++ b/charts/tradestream/Chart.yaml
@@ -7,3 +7,6 @@ dependencies:
   - name: kafka
     version: 30.1.8
     repository: https://charts.bitnami.com/bitnami
+  - name: flink
+    version: 1.20.0
+    repository: https://charts.bitnami.com/flink

--- a/charts/tradestream/Chart.yaml
+++ b/charts/tradestream/Chart.yaml
@@ -4,9 +4,14 @@ description: Chart for deploying TradeStream.
 version: 0.1.0
 appVersion: "3.0.0"
 dependencies:
-  - name: kafka
-    version: 30.1.8
-    repository: https://charts.bitnami.com/bitnami
+  - name: cert-manager
+    version: v1.9.1
+    repository: https://charts.jetstack.io
+    alias: cert-manager
+    condition: cert-manager.enabled
   - name: flink-kubernetes-operator
     version: "1.10.0"
     repository: "https://downloads.apache.org/flink/flink-kubernetes-operator-1.10.0/"
+  - name: kafka
+    version: 30.1.8
+    repository: https://charts.bitnami.com/bitnami

--- a/charts/tradestream/Chart.yaml
+++ b/charts/tradestream/Chart.yaml
@@ -10,4 +10,3 @@ dependencies:
   - name: flink-kubernetes-operator
     version: "1.10.0"
     repository: "https://downloads.apache.org/flink/flink-kubernetes-operator-1.10.0/"
-


### PR DESCRIPTION
This PR adds cert-manager to the CI workflow and adds the flink-kubernetes-operator to the Helm chart dependencies. This is necessary for the upcoming integration of Flink. It sets up cert-manager in the cluster and ensures the flink operator is installed when the Helm chart is deployed.

#### Key Changes
- Added a step to the CI workflow to install cert-manager.
- Added a step to wait for cert-manager to be ready.
- Added `flink-kubernetes-operator` as a dependency to the `charts/tradestream/Chart.yaml` file.

#### Testing
- The CI workflow was manually triggered to verify the cert-manager installation.
- The helm chart was updated locally to verify that the flink operator dependency is correctly added.

#### Dependencies/Impact
- This change introduces a dependency on cert-manager.
- This change introduces a dependency on the flink-kubernetes-operator
- No breaking changes to existing components.
- This addition prepares the environment for the planned Flink integration.