### PR TITLE
Add initial Apache Beam pipeline

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -62,6 +62,7 @@ maven.install(
         "io.reactivex.rxjava3:rxjava:3.1.6",
         "javax.inject:javax.inject:1",
         "net.sourceforge.argparse4j:argparse4j:0.9.0",
+        "org.apache.beam:beam-sdks-java-core:2.62.0",
         "org.apache.kafka:kafka-clients:3.6.1",
         "org.knowm.xchange:xchange-coinbasepro:5.2.0",
         "org.knowm.xchange:xchange-core:5.2.0",

--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -1,0 +1,42 @@
+package com.verlumen.tradestream.pipeline;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.options.StreamingOptions;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.TypeDescriptors;
+
+public class App {
+	public interface Options extends StreamingOptions {
+		@Description("Input text to print.")
+		@Default.String("My input text")
+		String getInputText();
+
+		void setInputText(String value);
+	}
+
+	public static PCollection<String> buildPipeline(Pipeline pipeline, String inputText) {
+		return pipeline
+				.apply("Create elements", Create.of(Arrays.asList("Hello", "World!", inputText)))
+				.apply("Print elements",
+						MapElements.into(TypeDescriptors.strings()).via(x -> {
+							System.out.println(x);
+							return x;
+						}));
+	}
+
+	public static void main(String[] args) {
+		var options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
+		var pipeline = Pipeline.create(options);
+		App.buildPipeline(pipeline, options.getInputText());
+		pipeline.run().waitUntilFinish();
+	}
+}

--- a/src/main/java/com/verlumen/tradestream/pipeline/BUILD
+++ b/src/main/java/com/verlumen/tradestream/pipeline/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 java_binary(
   name = "app",
   main_class = "com.verlumen.tradestream.pipeline.App",

--- a/src/main/java/com/verlumen/tradestream/pipeline/BUILD
+++ b/src/main/java/com/verlumen/tradestream/pipeline/BUILD
@@ -1,0 +1,8 @@
+java_binary(
+  name = "app",
+  main_class = "com.verlumen.tradestream.pipeline.App",
+  srcs = ["App.java"],
+  deps = [
+    "//third_party:beam_sdks_java_core",
+  ],
+)

--- a/src/main/java/com/verlumen/tradestream/pipeline/Pipeline.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/Pipeline.java
@@ -1,3 +1,0 @@
-package com.verlumen.tradestream.pipeline;
-
-final class Pipeline {}

--- a/src/main/java/com/verlumen/tradestream/pipeline/Pipeline.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/Pipeline.java
@@ -1,0 +1,3 @@
+package com.verlumen.tradestream.pipeline;
+
+final class Pipeline {}

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -77,6 +77,13 @@ java_plugin(
     ],
 )
 
+java_plugin(
+    name = "beam_sdks_java_core",
+    deps = [
+        "@tradestream_maven//:org_apache_beam_beam_sdks_java_core",
+    ],
+)
+
 java_library(
     name = "flogger",
     visibility = ["//visibility:public"],

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -77,10 +77,10 @@ java_plugin(
     ],
 )
 
-java_plugin(
+java_library(
     name = "beam_sdks_java_core",
     visibility = ["//visibility:public"],
-    deps = [
+    exports = [
         "@tradestream_maven//:org_apache_beam_beam_sdks_java_core",
     ],
 )

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -79,6 +79,7 @@ java_plugin(
 
 java_plugin(
     name = "beam_sdks_java_core",
+    visibility = ["//visibility:public"],
     deps = [
         "@tradestream_maven//:org_apache_beam_beam_sdks_java_core",
     ],


### PR DESCRIPTION
This PR adds an initial Apache Beam pipeline to the project. It sets up a simple pipeline that prints some input strings to demonstrate the integration with Apache Beam and lays the groundwork for more complex data processing pipelines.

#### Key Changes
- Added a new `src/main/java/com/verlumen/tradestream/pipeline/App.java` file which contains the implementation of the Apache Beam pipeline.
- The pipeline reads a default input string, and also takes in an input string as an arg and prints them to the console.
- Added a `src/main/java/com/verlumen/tradestream/pipeline/BUILD` file to build the pipeline binary.
- Added `org.apache.beam:beam-sdks-java-core` dependency to `MODULE.bazel`
- Added `beam_sdks_java_core` to `third_party/BUILD`
- Added `beam_sdks_java_core` as dependency to the `app` target in `src/main/java/com/verlumen/tradestream/pipeline/BUILD`.
