### PR TITLE
Add verbose failures to bazel test action

### DIFF
--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -19,4 +19,4 @@ jobs:
         disk-cache: ${{ github.workflow }}
         # Share repository cache between workflows.
         repository-cache: true
-    - run: bazel test //... --test_output=all
+    - run: bazel test //... --test_output=all  --verbose_failures


### PR DESCRIPTION
This PR adds the `--verbose_failures` flag to the `bazel test` command in the CI workflow. This will provide more detailed output for failed tests, making it easier to debug issues.

#### Key Changes
- Added `--verbose_failures` flag to the `bazel test` command in `.github/workflows/bazel-test.yaml`.

#### Testing
- N/A - This change does not require specific testing, as it affects test output only.

#### Dependencies/Impact
- No new dependencies are introduced.
- This change only affects the test output in the CI workflow.