### PR TITLE
Add PipelineModule for dependency injection

### DIFF
--- a/src/main/java/com/verlumen/tradestream/pipeline/BUILD
+++ b/src/main/java/com/verlumen/tradestream/pipeline/BUILD
@@ -66,6 +66,14 @@ tar(
     srcs = [":app_deploy.jar"],
 )
 
+java_library(
+    name = "pipeline_module",
+    srcs = ["PipelineModule.java"],
+    deps = [
+        "//third_party:guice",
+    ],
+)
+
 oci_push(
     name = "push_image",
     image = ":index",

--- a/src/main/java/com/verlumen/tradestream/pipeline/PipelineModule.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/PipelineModule.java
@@ -1,0 +1,8 @@
+package com.verlumen.tradestream.pipeline;
+
+import com.google.inject.AbstractModule;
+
+class PipelineModule extends AbstractModule {
+  @Override
+  protected void configure() {}
+}


### PR DESCRIPTION
This PR introduces the `PipelineModule` which provides a Guice module for dependency injection in the pipeline package. This facilitates the use of dependency injection in future pipeline code.

#### Key Changes
- Added `PipelineModule.java` which implements a basic Guice AbstractModule.
- Added `pipeline_module` to `src/main/java/com/verlumen/tradestream/pipeline/BUILD`
- Currently does not bind any dependencies.

#### Testing
- N/A - This is a setup change and no specific testing is required for this PR.

#### Dependencies/Impact
- This change introduces a dependency on Guice.
- No breaking changes to existing components.
- This provides dependency injection for the pipeline module.