### PR TITLE
Use dependency injection in Apache Beam app

### DIFF
--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -1,10 +1,8 @@
 package com.verlumen.tradestream.pipeline;
 
+import com.google.inject.Guice;
 import java.util.Arrays;
-import java.util.List;
-
 import org.apache.beam.sdk.Pipeline;
-import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
@@ -15,28 +13,36 @@ import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TypeDescriptors;
 
 public class App {
-	public interface Options extends StreamingOptions {
-		@Description("Input text to print.")
-		@Default.String("My input text")
-		String getInputText();
+  public interface Options extends StreamingOptions {
+    @Description("Input text to print.")
+    @Default.String("My input text")
+    String getInputText();
 
-		void setInputText(String value);
-	}
+    void setInputText(String value);
+  }
 
-	public static PCollection<String> buildPipeline(Pipeline pipeline, String inputText) {
-		return pipeline
-				.apply("Create elements", Create.of(Arrays.asList("Hello", "World!", inputText)))
-				.apply("Print elements",
-						MapElements.into(TypeDescriptors.strings()).via(x -> {
-							System.out.println(x);
-							return x;
-						}));
-	}
+  public static PCollection<String> buildPipeline(Pipeline pipeline, String inputText) {
+    return pipeline
+        .apply("Create elements", Create.of(Arrays.asList("Hello", "World!", inputText)))
+        .apply(
+            "Print elements",
+            MapElements.into(TypeDescriptors.strings())
+                .via(
+                    x -> {
+                      System.out.println(x);
+                      return x;
+                    }));
+  }
 
-	public static void main(String[] args) {
-		var options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
-		var pipeline = Pipeline.create(options);
-		App.buildPipeline(pipeline, options.getInputText());
-		pipeline.run().waitUntilFinish();
-	}
+  void runPipeline(String[] args) {
+    var options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
+    var pipeline = Pipeline.create(options);
+    App.buildPipeline(pipeline, options.getInputText());
+    pipeline.run().waitUntilFinish();
+  }
+
+  public static void main(String[] args) {
+    App app = Guice.createInjector().getInstance(App.class);
+    app.runPipeline(args);
+  }
 }

--- a/src/main/java/com/verlumen/tradestream/pipeline/BUILD
+++ b/src/main/java/com/verlumen/tradestream/pipeline/BUILD
@@ -12,6 +12,7 @@ java_binary(
   srcs = ["App.java"],
   deps = [
     "//third_party:beam_sdks_java_core",
+    "//third_party:guice",
   ],
   runtime_deps = [
     "//third_party:beam_runners_direct_java",


### PR DESCRIPTION
This PR modifies the Apache Beam application to use dependency injection with Guice. It allows dependency injection of the App class to facilitate modular design and testability.

#### Key Changes
- Updated `src/main/java/com/verlumen/tradestream/pipeline/App.java` to use dependency injection by using Guice in the main method, and the injection of the App class.
- Updated `src/main/java/com/verlumen/tradestream/pipeline/BUILD` to include a dependency on `guice`
- The `runPipeline` method has been added for testability purposes, the `main` method will now be used as a simple entry point for the app, but without being directly invoked for testing.

#### Testing
- The main method was manually invoked to confirm that the pipeline starts correctly.

#### Dependencies/Impact
- Introduces a dependency on Guice in the pipeline module.
- The change allows for dependency injection in the pipeline, improving the modularity and testability of the pipeline code.