### PR TITLE
Remove unused input text parameter from Apache Beam pipeline options

### DIFF
--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -16,11 +16,6 @@ import org.apache.beam.sdk.values.TypeDescriptors;
 
 final class App {
   public interface Options extends StreamingOptions {
-    @Description("Input text to print.")
-    @Default.String("My input text")
-    String getInputText();
-    void setInputText(String value);
-
     @Description("Comma-separated list of Kafka bootstrap servers.")
     @Default.String("localhost:9092") 
     String getBootstrapServers();


### PR DESCRIPTION
This PR removes the `InputText` parameter from the Apache Beam pipeline options as it's not being used in the pipeline. This simplifies the options interface and removes unnecessary configuration.

#### Key Changes
- Removed the `getInputText()` and `setInputText()` methods from the `Options` interface in `src/main/java/com/verlumen/tradestream/pipeline/App.java`.

#### Testing
- N/A - This is a code removal and no tests are required.

#### Dependencies/Impact
- No new dependencies are introduced.
- This change simplifies the options interface of the Apache Beam pipeline.