### PR TITLE
Remove dynamic read interval from Kafka read transform

### DIFF
--- a/src/main/java/com/verlumen/tradestream/kafka/BUILD
+++ b/src/main/java/com/verlumen/tradestream/kafka/BUILD
@@ -37,7 +37,6 @@ java_library(
         "//third_party:auto_value",
         "//third_party:beam_sdks_java_core",
         "//third_party:beam_sdks_java_io_kafka",
-        "//third_party:joda_time",
         "//third_party:kafka_clients",
     ],
 )

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaReadTransform.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaReadTransform.java
@@ -10,7 +10,6 @@ import org.apache.beam.sdk.values.TypeDescriptors;
 import org.apache.kafka.common.serialization.LongDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.beam.sdk.io.kafka.KafkaRecord;
-import org.joda.time.Duration;
 
 import java.util.Collections;
 import java.util.Map;
@@ -20,7 +19,6 @@ public abstract class KafkaReadTransform extends PTransform<PBegin, PCollection<
 
   abstract String bootstrapServers();
   abstract String topic();
-  abstract int dynamicReadIntervalHours();
   abstract Map<String, Object> consumerConfig();
 
   public static Builder builder() {
@@ -32,7 +30,6 @@ public abstract class KafkaReadTransform extends PTransform<PBegin, PCollection<
   public abstract static class Builder {
     public abstract Builder setBootstrapServers(String bootstrapServers);
     public abstract Builder setTopic(String topic);
-    public abstract Builder setDynamicReadIntervalHours(int hours);
     public abstract Builder setConsumerConfig(Map<String, Object> consumerConfig);
     public abstract KafkaReadTransform build();
   }
@@ -48,8 +45,7 @@ public abstract class KafkaReadTransform extends PTransform<PBegin, PCollection<
             .withTopic(topic())
             .withKeyDeserializer(LongDeserializer.class)
             .withValueDeserializer(StringDeserializer.class)
-            .withConsumerConfigUpdates(consumerConfig())
-            .withDynamicRead(interval);
+            .withConsumerConfigUpdates(consumerConfig());
 
     // Apply the read, then map each KafkaRecord<Long,String> to just the String value
     return input

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaReadTransform.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaReadTransform.java
@@ -36,8 +36,6 @@ public abstract class KafkaReadTransform extends PTransform<PBegin, PCollection<
 
   @Override
   public PCollection<String> expand(PBegin input) {
-    Duration interval = Duration.standardHours(dynamicReadIntervalHours());
-
     // Create the KafkaIO read transform
     KafkaIO.Read<Long, String> kafkaRead =
         KafkaIO.<Long, String>read()

--- a/src/main/java/com/verlumen/tradestream/pipeline/PipelineModule.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/PipelineModule.java
@@ -24,7 +24,6 @@ abstract class PipelineModule extends AbstractModule {
     return KafkaReadTransform.builder()
       .setBootstrapServers(bootstrapServers())
       .setTopic(candleTopic())
-      .setDynamicReadIntervalHours(dynamicReadIntervalHours())
       .build();
   }
 }

--- a/src/test/java/com/verlumen/tradestream/kafka/KafkaReadTransformTest.java
+++ b/src/test/java/com/verlumen/tradestream/kafka/KafkaReadTransformTest.java
@@ -17,20 +17,17 @@ public class KafkaReadTransformTest {
     // Arrange
     String bootstrapServers = "localhost:9092";
     String topic = "test-topic";
-    int intervalHours = 1;
 
     // Act
     KafkaReadTransform transform =
         KafkaReadTransform.builder()
             .setBootstrapServers(bootstrapServers)
             .setTopic(topic)
-            .setDynamicReadIntervalHours(intervalHours)
             .build();
 
     // Assert
     assertThat(transform.bootstrapServers()).isEqualTo(bootstrapServers);
     assertThat(transform.topic()).isEqualTo(topic);
-    assertThat(transform.dynamicReadIntervalHours()).isEqualTo(intervalHours);
     assertThat(transform.consumerConfig()).isEqualTo(Collections.emptyMap()); // Default config
   }
 
@@ -39,7 +36,6 @@ public class KafkaReadTransformTest {
     // Arrange
     String bootstrapServers = "broker1:9092,broker2:9092";
     String topic = "another-topic";
-    int intervalHours = 24;
     Map<String, Object> consumerConfig = Map.of("group.id", "test-group", "auto.offset.reset", "earliest");
 
     // Act
@@ -47,14 +43,12 @@ public class KafkaReadTransformTest {
         KafkaReadTransform.builder()
             .setBootstrapServers(bootstrapServers)
             .setTopic(topic)
-            .setDynamicReadIntervalHours(intervalHours)
             .setConsumerConfig(consumerConfig)
             .build();
 
     // Assert
     assertThat(transform.bootstrapServers()).isEqualTo(bootstrapServers);
     assertThat(transform.topic()).isEqualTo(topic);
-    assertThat(transform.dynamicReadIntervalHours()).isEqualTo(intervalHours);
     assertThat(transform.consumerConfig()).isEqualTo(consumerConfig);
   }
 
@@ -64,7 +58,6 @@ public class KafkaReadTransformTest {
     KafkaReadTransform transform = KafkaReadTransform.builder()
         .setBootstrapServers("some-servers")
         .setTopic("a-topic")
-        .setDynamicReadIntervalHours(1)
         .build();
 
     // Assert


### PR DESCRIPTION
This PR removes the dynamic read interval configuration from the `KafkaReadTransform`. This simplifies the transform and removes the need for dynamic reads for now.

#### Key Changes
- Removed `dynamicReadIntervalHours` from `KafkaReadTransform` and its builder.
- Removed `joda_time` dependency in the kafka build file
- Removed the call to `.withDynamicRead()` in `KafkaReadTransform`
- Updated the builder tests accordingly.
- Removed unused `dynamicReadIntervalHours` field from the options and pipeline module

#### Testing
- Verified that the tests for `KafkaReadTransform` are passing.

#### Dependencies/Impact
- Removes `joda_time` dependency.
- This change simplifies the configuration of the `KafkaReadTransform`.
- Dynamic read intervals are removed, which makes the transform easier to configure.