### PR TITLE
Remove SASL config and add defaults to Kafka properties

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/App.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/App.java
@@ -68,8 +68,7 @@ final class App {
         namespace.getInt("kafka.linger.ms"),
         namespace.getInt("kafka.buffer.memory"),
         namespace.getString("kafka.key.serializer"),
-        namespace.getString("kafka.value.serializer"),
-        namespace.getString("kafka.security.protocol"));
+        namespace.getString("kafka.value.serializer"));
       IngestionConfig ingestionConfig =
           new IngestionConfig(
               candlePublisherTopic,

--- a/src/main/java/com/verlumen/tradestream/ingestion/App.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/App.java
@@ -142,11 +142,6 @@ final class App {
       .setDefault("org.apache.kafka.common.serialization.ByteArraySerializer")
       .help("Value serializer class");
 
-    // SASL configuration
-    parser.addArgument("--kafka.security.protocol")
-      .setDefault("PLAINTEXT")
-      .help("Protocol used to communicate with brokers (e.g., PLAINTEXT, SASL_SSL)");
-
     // Exchange configuration
     parser.addArgument("--exchangeName")
       .setDefault("coinbase")

--- a/src/main/java/com/verlumen/tradestream/ingestion/App.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/App.java
@@ -69,9 +69,7 @@ final class App {
         namespace.getInt("kafka.buffer.memory"),
         namespace.getString("kafka.key.serializer"),
         namespace.getString("kafka.value.serializer"),
-        namespace.getString("kafka.security.protocol"),
-        namespace.getString("kafka.sasl.mechanism"),
-        namespace.getString("kafka.sasl.jaas.config"));
+        namespace.getString("kafka.security.protocol"));
       IngestionConfig ingestionConfig =
           new IngestionConfig(
               candlePublisherTopic,
@@ -148,14 +146,6 @@ final class App {
     parser.addArgument("--kafka.security.protocol")
       .setDefault("PLAINTEXT")
       .help("Protocol used to communicate with brokers (e.g., PLAINTEXT, SASL_SSL)");
-
-    parser.addArgument("--kafka.sasl.mechanism")
-      .setDefault("")
-      .help("SASL mechanism used for authentication (e.g., PLAIN, SCRAM-SHA-256)");
-
-    parser.addArgument("--kafka.sasl.jaas.config")
-      .setDefault("")
-      .help("SASL JAAS configuration");
 
     // Exchange configuration
     parser.addArgument("--exchangeName")

--- a/src/main/java/com/verlumen/tradestream/ingestion/App.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/App.java
@@ -60,7 +60,7 @@ final class App {
       long candleIntervalMillis = namespace.getInt("candleIntervalSeconds") * 1000L;
       String runModeName = namespace.getString("runMode").toUpperCase();
       RunMode runMode = RunMode.valueOf(runModeName);
-      KafkaProperties kafkaProperties = new KafkaProperties(
+      KafkaProperties kafkaProperties = KafkaProperties.create(
         namespace.get("kafka.acks"),
         namespace.getInt("kafka.batch.size"),
         namespace.getString("kafka.bootstrap.servers"),

--- a/src/main/java/com/verlumen/tradestream/kafka/BUILD
+++ b/src/main/java/com/verlumen/tradestream/kafka/BUILD
@@ -33,6 +33,9 @@ java_library(
 java_library(
     name = "kafka_properties",
     srcs = ["KafkaProperties.java"],
+    deps = [
+        ":kafka_defaults",
+    ],
 )
 
 java_library(

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaProperties.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaProperties.java
@@ -24,10 +24,9 @@ public record KafkaProperties(
     int lingerMs,
     int bufferMemory,
     String keySerializer,
-    String valueSerializer,
-    String securityProtocol) {
+    String valueSerializer) {
     return new KafkaProperties(
-      acks, batchSize, bootstrapServers, retries, lingerMs, bufferMemory, keySerializer, valueSerializer, securityProtocol, "", "");
+      acks, batchSize, bootstrapServers, retries, lingerMs, bufferMemory, keySerializer, valueSerializer, KafkaDefaults.SECURITY_PROTOCOL, "", "");
   }
 
   @Override

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaProperties.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaProperties.java
@@ -16,17 +16,18 @@ public record KafkaProperties(
   String saslMechanism,
   String saslJaasConfig) implements Supplier<Properties> {
 
-  static KafkaProperties create(String acks,
-      int batchSize,
-      String bootstrapServers,
-      int retries,
-      int lingerMs,
-      int bufferMemory,
-      String keySerializer,
-      String valueSerializer,
-      String securityProtocol) {
-      return new KafkaProperties(
-          acks, batchSize, bootstrapServers, retries, lingerMs, bufferMemory, keySerializer, valueSerializer, securityProtocol, "", "");
+  public static KafkaProperties create(
+    String acks,
+    int batchSize,
+    String bootstrapServers,
+    int retries,
+    int lingerMs,
+    int bufferMemory,
+    String keySerializer,
+    String valueSerializer,
+    String securityProtocol) {
+    return new KafkaProperties(
+      acks, batchSize, bootstrapServers, retries, lingerMs, bufferMemory, keySerializer, valueSerializer, securityProtocol, "", "");
   }
 
   @Override

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaProperties.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaProperties.java
@@ -4,15 +4,30 @@ import java.util.Properties;
 import java.util.function.Supplier;
 
 public record KafkaProperties(
-    String acks,
-    int batchSize,
-    String bootstrapServers,
-    int retries,
-    int lingerMs,
-    int bufferMemory,
-    String keySerializer,
-    String valueSerializer,
-    String securityProtocol) implements Supplier<Properties> {
+  String acks,
+  int batchSize,
+  String bootstrapServers,
+  int retries,
+  int lingerMs,
+  int bufferMemory,
+  String keySerializer,
+  String valueSerializer,
+  String securityProtocol,
+  String saslMechanism,
+  String saslJaasConfig) implements Supplier<Properties> {
+
+  static KafkaProperties create(String acks,
+      int batchSize,
+      String bootstrapServers,
+      int retries,
+      int lingerMs,
+      int bufferMemory,
+      String keySerializer,
+      String valueSerializer,
+      String securityProtocol) {
+      return new KafkaProperties(
+          acks, batchSize, bootstrapServers, retries, lingerMs, bufferMemory, keySerializer, valueSerializer, securityProtocol, "", "");
+  }
 
   @Override
   public Properties get() {
@@ -26,8 +41,8 @@ public record KafkaProperties(
     kafkaProperties.setProperty("key.serializer", keySerializer);
     kafkaProperties.setProperty("value.serializer", valueSerializer);
     kafkaProperties.setProperty("security.protocol", securityProtocol);
-    kafkaProperties.setProperty("sasl.mechanism", "");
-    kafkaProperties.setProperty("sasl.jaas.config", "");
+    kafkaProperties.setProperty("sasl.mechanism", saslMechanism);
+    kafkaProperties.setProperty("sasl.jaas.config", saslJaasConfig);
     return kafkaProperties;
   }
 }

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaProperties.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaProperties.java
@@ -26,6 +26,8 @@ public record KafkaProperties(
     kafkaProperties.setProperty("key.serializer", keySerializer);
     kafkaProperties.setProperty("value.serializer", valueSerializer);
     kafkaProperties.setProperty("security.protocol", securityProtocol);
+    kafkaProperties.setProperty("sasl.mechanism", "");
+    kafkaProperties.setProperty("sasl.jaas.config", "");
     return kafkaProperties;
   }
 }

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaProperties.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaProperties.java
@@ -12,9 +12,7 @@ public record KafkaProperties(
     int bufferMemory,
     String keySerializer,
     String valueSerializer,
-    String securityProtocol,
-    String saslMechanism,
-    String saslJaasConfig) implements Supplier<Properties> {
+    String securityProtocol) implements Supplier<Properties> {
 
   @Override
   public Properties get() {
@@ -28,8 +26,6 @@ public record KafkaProperties(
     kafkaProperties.setProperty("key.serializer", keySerializer);
     kafkaProperties.setProperty("value.serializer", valueSerializer);
     kafkaProperties.setProperty("security.protocol", securityProtocol);
-    kafkaProperties.setProperty("sasl.mechanism", saslMechanism);
-    kafkaProperties.setProperty("sasl.jaas.config", saslJaasConfig);
     return kafkaProperties;
   }
 }

--- a/src/test/java/com/verlumen/tradestream/kafka/KafkaPropertiesTest.java
+++ b/src/test/java/com/verlumen/tradestream/kafka/KafkaPropertiesTest.java
@@ -23,7 +23,9 @@ public class KafkaPropertiesTest {
             33554432,
             "org.apache.kafka.common.serialization.StringSerializer",
             "org.apache.kafka.common.serialization.StringSerializer",
-            "PLAINTEXT");
+            "PLAINTEXT",
+            "PLAIN",
+            "some.config");
 
     // Act
     Properties kafkaProperties = supplier.get();
@@ -45,7 +47,9 @@ public class KafkaPropertiesTest {
             33554432,
             "org.apache.kafka.common.serialization.StringSerializer",
             "org.apache.kafka.common.serialization.StringSerializer",
-            "PLAINTEXT");
+            "PLAINTEXT",
+            "PLAIN",
+            "some.config");
 
     // Act
     Properties kafkaProperties = supplier.get();
@@ -67,7 +71,9 @@ public class KafkaPropertiesTest {
             33554432,
             "org.apache.kafka.common.serialization.StringSerializer",
             "org.apache.kafka.common.serialization.StringSerializer",
-            "PLAINTEXT");
+            "PLAINTEXT",
+            "PLAIN",
+            "some.config");
 
     // Act
     Properties kafkaProps = supplier.get();

--- a/src/test/java/com/verlumen/tradestream/kafka/KafkaPropertiesTest.java
+++ b/src/test/java/com/verlumen/tradestream/kafka/KafkaPropertiesTest.java
@@ -23,9 +23,7 @@ public class KafkaPropertiesTest {
             33554432,
             "org.apache.kafka.common.serialization.StringSerializer",
             "org.apache.kafka.common.serialization.StringSerializer",
-            "PLAINTEXT",
-            "PLAIN",
-            "some.config");
+            "PLAINTEXT");
 
     // Act
     Properties kafkaProperties = supplier.get();
@@ -47,9 +45,7 @@ public class KafkaPropertiesTest {
             33554432,
             "org.apache.kafka.common.serialization.StringSerializer",
             "org.apache.kafka.common.serialization.StringSerializer",
-            "PLAINTEXT",
-            "PLAIN",
-            "some.config");
+            "PLAINTEXT");
 
     // Act
     Properties kafkaProperties = supplier.get();
@@ -71,9 +67,7 @@ public class KafkaPropertiesTest {
             33554432,
             "org.apache.kafka.common.serialization.StringSerializer",
             "org.apache.kafka.common.serialization.StringSerializer",
-            "PLAINTEXT",
-            "PLAIN",
-            "some.config");
+            "PLAINTEXT");
 
     // Act
     Properties kafkaProps = supplier.get();


### PR DESCRIPTION
This PR removes the SASL-related configurations from `KafkaProperties` and introduces a `KafkaDefaults` class that defines default values for properties that are needed by the services. The goal is to simplify the configuration and remove SASL config that is not currently used.

#### Key Changes
- Removed `securityProtocol`, `saslMechanism`, and `saslJaasConfig` from the `KafkaProperties` record.
- Modified the `create` method to no longer take in these parameters, and to set default values from `KafkaDefaults` for those parameters.
- Added a `KafkaDefaults` class that defines the default values for the security protocol.
- Updated the `KafkaProperties` constructor to include the default SASL properties and use the defaults from `KafkaDefaults`
- Updated the Ingestion App to use the new Kafka properties create method.
- Updated the `KafkaProperties` record to implement `Supplier<Properties>`
- Updated the `kafka_properties` target to include a dependency on the `kafka_defaults` target.
- Removed SASL related arguments from the ingestion app.

#### Testing
- N/A - these are configuration changes, and will be tested with integration tests.

#### Dependencies/Impact
- Removed the ability to configure SASL related properties.
- Introduces a `KafkaDefaults` class and `kafka_defaults` target.
- Simplifies the configuration of `KafkaProperties`.