### PR TITLE
Remove unused Kafka config from Helm chart and ingestion app

### DIFF
--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -21,9 +21,6 @@ kafkaUi:
 dataIngestion:
   args:
     - --candlePublisherTopic=candles
-    - --kafka.acks=all
-    - --kafka.retries=5
-    - --kafka.linger.ms=50
     - --runMode=wet
   replicaCount: 1
   image:

--- a/src/main/java/com/verlumen/tradestream/ingestion/App.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/App.java
@@ -61,11 +61,8 @@ final class App {
       String runModeName = namespace.getString("runMode").toUpperCase();
       RunMode runMode = RunMode.valueOf(runModeName);
       KafkaProperties kafkaProperties = KafkaProperties.create(
-        namespace.get("kafka.acks"),
         namespace.getInt("kafka.batch.size"),
         namespace.getString("kafka.bootstrap.servers"),
-        namespace.getInt("kafka.retries"),
-        namespace.getInt("kafka.linger.ms"),
         namespace.getInt("kafka.buffer.memory"),
         namespace.getString("kafka.key.serializer"),
         namespace.getString("kafka.value.serializer"));

--- a/src/main/java/com/verlumen/tradestream/ingestion/App.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/App.java
@@ -109,24 +109,10 @@ final class App {
       .setDefault("localhost:9092")
       .help("Kafka bootstrap servers");
 
-    parser.addArgument("--kafka.acks")
-      .setDefault("all")
-      .help("Kafka acknowledgment configuration");
-
-    parser.addArgument("--kafka.retries")
-      .type(Integer.class)
-      .setDefault(0)
-      .help("Number of retries");
-
     parser.addArgument("--kafka.batch.size")
       .type(Integer.class)
       .setDefault(16384)
       .help("Batch size in bytes");
-
-    parser.addArgument("--kafka.linger.ms")
-      .type(Integer.class)
-      .setDefault(1)
-      .help("Linger time in milliseconds");
 
     parser.addArgument("--kafka.buffer.memory")
       .type(Integer.class)

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaDefaults.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaDefaults.java
@@ -14,13 +14,13 @@ public final class KafkaDefaults {
     public static final String ACKS = "all";
 
     /** Number of retries */
-    public static final int RETRIES = 0;
+    public static final int RETRIES = 5;
 
     /** Batch size in bytes */
     public static final int BATCH_SIZE = 16384;
 
     /** Linger time in milliseconds */
-    public static final int LINGER_MS = 1;
+    public static final int LINGER_MS = 50;
 
     /** Buffer memory in bytes */
     public static final int BUFFER_MEMORY = 33554432;

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaProperties.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaProperties.java
@@ -17,7 +17,6 @@ public record KafkaProperties(
   int retries) implements Supplier<Properties> {
 
   public static KafkaProperties create(
-    String acks,
     int batchSize,
     String bootstrapServers,
     int bufferMemory,

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaProperties.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaProperties.java
@@ -7,7 +7,6 @@ public record KafkaProperties(
   String acks,
   int batchSize,
   String bootstrapServers,
-  int retries,
   int lingerMs,
   int bufferMemory,
   String keySerializer,

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaProperties.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaProperties.java
@@ -4,28 +4,38 @@ import java.util.Properties;
 import java.util.function.Supplier;
 
 public record KafkaProperties(
-  String acks,
   int batchSize,
   String bootstrapServers,
-  int lingerMs,
   int bufferMemory,
   String keySerializer,
   String valueSerializer,
   String securityProtocol,
   String saslMechanism,
-  String saslJaasConfig) implements Supplier<Properties> {
+  String saslJaasConfig,
+  String acks,
+  int lingerMs,
+  int retries) implements Supplier<Properties> {
 
   public static KafkaProperties create(
     String acks,
     int batchSize,
     String bootstrapServers,
-    int retries,
-    int lingerMs,
     int bufferMemory,
     String keySerializer,
     String valueSerializer) {
     return new KafkaProperties(
-      acks, batchSize, bootstrapServers, retries, lingerMs, bufferMemory, keySerializer, valueSerializer, KafkaDefaults.SECURITY_PROTOCOL, "", "");
+      batchSize,
+      bootstrapServers,
+      bufferMemory,
+      keySerializer,
+      valueSerializer,
+      KafkaDefaults.SECURITY_PROTOCOL,
+      "",
+      "",
+      KafkaDefaults.ACKS,
+      KafkaDefaults.LINGER_MS,
+      KafkaDefaults.RETRIES,
+      );
   }
 
   @Override

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaProperties.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaProperties.java
@@ -34,8 +34,7 @@ public record KafkaProperties(
       "",
       KafkaDefaults.ACKS,
       KafkaDefaults.LINGER_MS,
-      KafkaDefaults.RETRIES,
-      );
+      KafkaDefaults.RETRIES);
   }
 
   @Override

--- a/src/test/java/com/verlumen/tradestream/kafka/KafkaPropertiesTest.java
+++ b/src/test/java/com/verlumen/tradestream/kafka/KafkaPropertiesTest.java
@@ -15,17 +15,17 @@ public class KafkaPropertiesTest {
     // Arrange
     KafkaProperties supplier =
         new KafkaProperties(
-            "all",
             16384,
             "localhost:9092",
-            0,
-            1,
             33554432,
             "org.apache.kafka.common.serialization.StringSerializer",
             "org.apache.kafka.common.serialization.StringSerializer",
             "PLAINTEXT",
             "PLAIN",
-            "some.config");
+            "some.config",
+            "all",
+            0,
+            1);
 
     // Act
     Properties kafkaProperties = supplier.get();
@@ -39,17 +39,17 @@ public class KafkaPropertiesTest {
     // Arrange
     KafkaProperties supplier =
         new KafkaProperties(
-            "all",
             16384,
             "localhost:9092",
-            0,
-            1,
             33554432,
             "org.apache.kafka.common.serialization.StringSerializer",
             "org.apache.kafka.common.serialization.StringSerializer",
             "PLAINTEXT",
             "PLAIN",
-            "some.config");
+            "some.config",
+            "all",
+            0,
+            1);
 
     // Act
     Properties kafkaProperties = supplier.get();
@@ -63,18 +63,17 @@ public class KafkaPropertiesTest {
     // Arrange
     KafkaProperties supplier =
         new KafkaProperties(
-            "all",
             16384,
             "localhost:9092",
-            5,
-            50,
             33554432,
             "org.apache.kafka.common.serialization.StringSerializer",
             "org.apache.kafka.common.serialization.StringSerializer",
             "PLAINTEXT",
             "PLAIN",
-            "some.config");
-
+            "some.config",
+            "all",
+            5,
+            50);
     // Act
     Properties kafkaProps = supplier.get();
 

--- a/src/test/java/com/verlumen/tradestream/kafka/KafkaPropertiesTest.java
+++ b/src/test/java/com/verlumen/tradestream/kafka/KafkaPropertiesTest.java
@@ -72,8 +72,8 @@ public class KafkaPropertiesTest {
             "PLAIN",
             "some.config",
             "all",
-            5,
-            50);
+            50,
+            5);
     // Act
     Properties kafkaProps = supplier.get();
 

--- a/src/test/java/com/verlumen/tradestream/strategies/KafkaConsumerProviderTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/KafkaConsumerProviderTest.java
@@ -23,17 +23,17 @@ public class KafkaConsumerProviderTest {
     @Before
     public void setUp() {
         kafkaProperties = new KafkaProperties(
-            "all",                // acks
             16384,               // batchSize
             "localhost:9092",    // bootstrapServers
-            0,                   // retries 
-            1,                   // lingerMs
             33554432,            // bufferMemory
             "org.apache.kafka.common.serialization.StringSerializer", // keySerializer
             "org.apache.kafka.common.serialization.StringSerializer", // valueSerializer
             "PLAINTEXT",         // securityProtocol - changed from empty string
             "",                  // saslMechanism
-            ""                   // saslJaasConfig
+            "",                  // saslJaasConfig
+            "all",               // acks
+            1,                   // lingerMs
+            0                    // retries 
         );
 
         Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);

--- a/src/test/java/com/verlumen/tradestream/strategies/KafkaConsumerProviderTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/KafkaConsumerProviderTest.java
@@ -48,17 +48,17 @@ public class KafkaConsumerProviderTest {
     @Test
     public void get_includesSecurityConfig_whenProvided() {
         kafkaProperties = new KafkaProperties(
-            "all",                // acks
             16384,               // batchSize
             "localhost:9092",    // bootstrapServers
-            0,                   // retries 
-            1,                   // lingerMs
             33554432,            // bufferMemory
             "org.apache.kafka.common.serialization.StringSerializer", // keySerializer
             "org.apache.kafka.common.serialization.StringSerializer", // valueSerializer
             "SASL_SSL",          // securityProtocol
             "PLAIN",             // saslMechanism
-            "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"user\" password=\"pass\";" // saslJaasConfig
+            "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"user\" password=\"pass\";", // saslJaasConfig
+            "all",               // acks
+            1,                   // lingerMs
+            0                    // retries 
         );
 
         Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);


### PR DESCRIPTION
This PR removes unused configurations for Kafka from the Helm chart and the ingestion application. It removes the configurations that are now defaulted in the code, and are not intended to be customized by the user.

#### Key Changes
- Removed `kafka.acks`, `kafka.retries`, and `kafka.linger.ms` from `charts/tradestream/values.yaml`
- Removed `kafka.acks`, `kafka.retries`, and `kafka.linger.ms` argument parsing in `src/main/java/com/verlumen/tradestream/ingestion/App.java`.

#### Testing
- N/A - This change is just removing configurations.

#### Dependencies/Impact
- This change removes unused configurations from the project, and simplifies both the helm chart and ingestion app.