### PR TITLE
Use default Kafka properties in Ingestion app

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/App.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/App.java
@@ -60,12 +60,7 @@ final class App {
       long candleIntervalMillis = namespace.getInt("candleIntervalSeconds") * 1000L;
       String runModeName = namespace.getString("runMode").toUpperCase();
       RunMode runMode = RunMode.valueOf(runModeName);
-      KafkaProperties kafkaProperties = KafkaProperties.create(
-        namespace.getInt("kafka.batch.size"),
-        namespace.getString("kafka.bootstrap.servers"),
-        namespace.getInt("kafka.buffer.memory"),
-        namespace.getString("kafka.key.serializer"),
-        namespace.getString("kafka.value.serializer"));
+      KafkaProperties kafkaProperties = KafkaProperties.create();
       IngestionConfig ingestionConfig =
           new IngestionConfig(
               candlePublisherTopic,
@@ -100,29 +95,6 @@ final class App {
     parser.addArgument("--candlePublisherTopic")
       .setDefault("candles")
       .help("Kafka topic to publish candle data");
-
-    // Kafka configuration
-    parser.addArgument("--kafka.bootstrap.servers")
-      .setDefault("localhost:9092")
-      .help("Kafka bootstrap servers");
-
-    parser.addArgument("--kafka.batch.size")
-      .type(Integer.class)
-      .setDefault(16384)
-      .help("Batch size in bytes");
-
-    parser.addArgument("--kafka.buffer.memory")
-      .type(Integer.class)
-      .setDefault(33554432)
-      .help("Buffer memory in bytes");
-
-    parser.addArgument("--kafka.key.serializer")
-      .setDefault("org.apache.kafka.common.serialization.StringSerializer")
-      .help("Key serializer class");
-
-    parser.addArgument("--kafka.value.serializer")
-      .setDefault("org.apache.kafka.common.serialization.ByteArraySerializer")
-      .help("Value serializer class");
 
     // Exchange configuration
     parser.addArgument("--exchangeName")

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaProperties.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaProperties.java
@@ -16,18 +16,13 @@ public record KafkaProperties(
   int lingerMs,
   int retries) implements Supplier<Properties> {
 
-  public static KafkaProperties create(
-    int batchSize,
-    String bootstrapServers,
-    int bufferMemory,
-    String keySerializer,
-    String valueSerializer) {
+  public static KafkaProperties create() {
     return new KafkaProperties(
-      batchSize,
-      bootstrapServers,
-      bufferMemory,
-      keySerializer,
-      valueSerializer,
+      KafkaDefaults.BATCH_SIZE,
+      KafkaDefaults.BOOTSTRAP_SERVERS,
+      KafkaDefaults.BUFFER_MEMORY,
+      KafkaDefaults.KEY_SERIALIZER,
+      KafkaDefaults.VALUE_SERIALIZER,
       KafkaDefaults.SECURITY_PROTOCOL,
       "",
       "",


### PR DESCRIPTION
This PR modifies the Ingestion app to use the default Kafka properties as defined in the `KafkaDefaults` class. It removes the need for manual specification of Kafka properties via command-line arguments. It updates the `KafkaProperties` create method to take no parameters, and removes command line args for these parameters from the ingestion app.

#### Key Changes
- Updated the `KafkaProperties.create()` method in `src/main/java/com/verlumen/tradestream/kafka/KafkaProperties.java` to no longer take any arguments and to use the defaults defined in `KafkaDefaults`
- Updated the `App` class in `src/main/java/com/verlumen/tradestream/ingestion/App.java` to call the `KafkaProperties.create()` method without any arguments.
- Removed command line argument parsing for the kafka properties that are being defaulted in code.

#### Testing
- Manually ran the Ingestion app without any Kafka specific arguments to confirm that defaults are applied
- N/A - these are configuration changes, and will be tested with integration tests.

#### Dependencies/Impact
- This change uses default values for Kafka properties in the ingestion app and removes command line configuration for these.