### PR TITLE
Use default Kafka properties in Kafka module

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/App.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/App.java
@@ -4,7 +4,6 @@ import com.google.common.flogger.FluentLogger;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.verlumen.tradestream.execution.RunMode;
-import com.verlumen.tradestream.kafka.KafkaProperties;
 import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.Namespace;
@@ -60,7 +59,6 @@ final class App {
       long candleIntervalMillis = namespace.getInt("candleIntervalSeconds") * 1000L;
       String runModeName = namespace.getString("runMode").toUpperCase();
       RunMode runMode = RunMode.valueOf(runModeName);
-      KafkaProperties kafkaProperties = KafkaProperties.create();
       IngestionConfig ingestionConfig =
           new IngestionConfig(
               candlePublisherTopic,
@@ -68,8 +66,7 @@ final class App {
               topNCryptocurrencies,
               exchangeName,
               candleIntervalMillis,
-              runMode,
-              kafkaProperties);
+              runMode);
       IngestionModule module = IngestionModule.create(ingestionConfig);
       App app = Guice.createInjector(module).getInstance(App.class);
       logger.atInfo().log("Guice initialization complete, running application");

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -12,7 +12,6 @@ java_binary(
     main_class = "com.verlumen.tradestream.ingestion.App",
     deps = [
         "//src/main/java/com/verlumen/tradestream/execution:run_mode",
-        "//src/main/java/com/verlumen/tradestream/kafka:kafka_properties",
         "//third_party:argparse4j",
         "//third_party:flogger",
         "//third_party:guice",
@@ -239,7 +238,6 @@ java_library(
     srcs = ["IngestionConfig.java"],
     deps = [
         "//src/main/java/com/verlumen/tradestream/execution:run_mode",
-        "//src/main/java/com/verlumen/tradestream/kafka:kafka_properties",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionConfig.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionConfig.java
@@ -1,7 +1,6 @@
 package com.verlumen.tradestream.ingestion;
 
 import com.verlumen.tradestream.execution.RunMode;
-import com.verlumen.tradestream.kafka.KafkaProperties;
 
 record IngestionConfig(
     String candlePublisherTopic,
@@ -9,5 +8,4 @@ record IngestionConfig(
     int topCryptocurrencyCount,
     String exchangeName,
     long candleIntervalMillis,
-    RunMode runMode,
-    KafkaProperties kafkaProperties) {}
+    RunMode runMode) {}

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -38,7 +38,7 @@ abstract class IngestionModule extends AbstractModule {
             .implement(CandlePublisher.class, CandlePublisherImpl.class)
             .build(CandlePublisher.Factory.class));
 
-    install(KafkaModule.create(ingestionConfig().kafkaProperties()));
+    install(KafkaModule.create());
   }
 
   @Provides

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaModule.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaModule.java
@@ -8,15 +8,13 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 
 @AutoValue
 public abstract class KafkaModule extends AbstractModule {
-  public static KafkaModule create(KafkaProperties kafkaProperties) {
-    return new AutoValue_KafkaModule(kafkaProperties);
+  public static KafkaModule create() {
+    return new AutoValue_KafkaModule();
   }
-
-  abstract KafkaProperties kafkaProperties();
   
   @Override
   protected void configure() {
-    bind(KafkaProperties.class).toProvider(this::kafkaProperties);
+    bind(KafkaProperties.class).toProvider(KafkaProperties::create);
     bind(new TypeLiteral<KafkaProducer<String, byte[]>>() {})
         .toProvider(KafkaProducerProvider.class);
   }


### PR DESCRIPTION
This PR modifies the `KafkaModule` to use default Kafka properties, removing the need for passing properties during module initialization. It updates the module to create the properties by itself and remove the explicit binding.

#### Key Changes
- Removed the `KafkaProperties` field from the `KafkaModule`
- Updated the `KafkaModule` to use `KafkaProperties::create` as the provider for the binding.
- Removed the `KafkaProperties` parameter from the `KafkaModule.create()` method in `src/main/java/com/verlumen/tradestream/kafka/KafkaModule.java`
- Updated `src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java` to create the KafkaModule without parameters.
- Updated the `IngestionConfig` to remove `KafkaProperties`.
- Updated the `App` class in `src/main/java/com/verlumen/tradestream/ingestion/App.java` to no longer pass kafka properties to the module.
- Updated `src/main/java/com/verlumen/tradestream/ingestion/BUILD` to no longer depend on `kafka_properties`
- Updated `src/main/java/com/verlumen/tradestream/ingestion/IngestionConfig` to no longer depend on `kafka_properties`

#### Testing
- Manually ran the Ingestion app to confirm that the defaults are applied.
- N/A - These are configuration changes and will be tested in integration.

#### Dependencies/Impact
- This change simplifies the configuration of the `KafkaModule` and removes the need for explicit configuration, the module now configures the default kafka properties from `KafkaDefaults`
- Removes the dependency on `KafkaProperties` in `IngestionConfig`