### PR TITLE
Reorder Kafka Module dependencies

### DIFF
--- a/src/main/java/com/verlumen/tradestream/kafka/BUILD
+++ b/src/main/java/com/verlumen/tradestream/kafka/BUILD
@@ -11,12 +11,12 @@ java_library(
     name = "kafka_module",
     srcs = ["KafkaModule.java"],
     deps = [
+        ":kafka_producer_provider",
+        ":kafka_properties",
         "//third_party:auto_value",
         "//third_party:guice",
         "//third_party:guice_assistedinject",
         "//third_party:kafka_clients",
-        ":kafka_producer_provider",
-        ":kafka_properties",
     ],
 )
 
@@ -24,9 +24,9 @@ java_library(
     name = "kafka_producer_provider",
     srcs = ["KafkaProducerProvider.java"],
     deps = [
+        ":kafka_properties",
         "//third_party:guice",
         "//third_party:kafka_clients",
-        ":kafka_properties",
     ],    
 )
 


### PR DESCRIPTION
This PR reorders the dependencies within the `kafka_module` and `kafka_producer_provider` targets in the `src/main/java/com/verlumen/tradestream/kafka/BUILD` file. This change ensures that the dependencies are listed in a consistent and logical order.

#### Key Changes
- Reordered dependencies in `kafka_module` target to list internal dependencies before external dependencies.
- Reordered dependencies in `kafka_producer_provider` target to list internal dependencies before external dependencies.

#### Testing
- N/A - This is a dependency ordering change and no tests are required.

#### Dependencies/Impact
- No new dependencies are introduced or removed.
- This change only affects the order of dependencies within the `BUILD` file for organization and readability.