### PR TITLE
Simplify dataIngestion args in Helm chart

### DIFF
--- a/charts/tradestream/templates/data-ingestion.yaml
+++ b/charts/tradestream/templates/data-ingestion.yaml
@@ -22,9 +22,8 @@ spec:
       containers:
         - name: data-ingestion
           args:
-          {{- range .Values.dataIngestion.args }}
-            - {{ . }}
-          {{- end }}
+            - "--candlePublisherTopic={{ .Values.dataIngestion.candlePublisherTopic }}"
+            - "--runMode={{ .Values.dataIngestion.runMode }}"
             - "--kafka.bootstrap.servers={{ include "tradestream.fullname" . }}-kafka.{{ .Release.Namespace }}.svc.cluster.local:9092"
           image: "{{ .Values.dataIngestion.image.repository }}:{{ .Values.dataIngestion.image.tag }}"
           imagePullPolicy: {{ default "IfNotPresent" .Values.dataIngestion.image.pullPolicy }}

--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -19,9 +19,8 @@ kafkaUi:
     type: ClusterIP
     port: 8080
 dataIngestion:
-  args:
-    - --candlePublisherTopic=candles
-    - --runMode=wet
+  candlePublisherTopic: candles
+  runMode: wet
   replicaCount: 1
   image:
     repository: "tradestreamhq/tradestream-data-ingestion"


### PR DESCRIPTION
This PR simplifies the configuration of the `dataIngestion` service within the Helm chart. Instead of using a generic `args` list, it now uses dedicated properties (`candlePublisherTopic` and `runMode`) directly within the `values.yaml` and template for clarity and easier management.

#### Key Changes
- **`charts/tradestream/templates/data-ingestion.yaml`**:
    - Modified the container `args` to directly reference `{{ .Values.dataIngestion.candlePublisherTopic }}` and `{{ .Values.dataIngestion.runMode }}` instead of iterating over a generic `args` list.
- **`charts/tradestream/values.yaml`**:
    - Replaced the `dataIngestion.args` list with specific properties:
        - `dataIngestion.candlePublisherTopic`: Defines the candle publisher topic.
        - `dataIngestion.runMode`: Defines the run mode for data ingestion.

#### Testing
- N/A - This is a configuration change in the Helm chart.
- Verification can be done by deploying the updated Helm chart and confirming that the `data-ingestion` container starts with the correctly configured arguments.

#### Dependencies/Impact
- This change simplifies the Helm chart configuration for `dataIngestion`.
- No breaking changes are expected as it refactors the configuration structure without altering the functionality.