### PR TITLE
Feat: Configure Kafka Bootstrap Servers via Command-Line Argument

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/App.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/App.java
@@ -110,7 +110,7 @@ final class App {
       .help("Number of top cryptocurrencies to track (default: 100)");
 
     // Kafka configuration
-    parser.addArgument("--")
+    parser.addArgument("--kafka.bootstrap.servers")
       .setDefault("localhost:9092")
       .help("Kafka bootstrap servers");
 

--- a/src/main/java/com/verlumen/tradestream/ingestion/App.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/App.java
@@ -66,7 +66,8 @@ final class App {
               topNCryptocurrencies,
               exchangeName,
               candleIntervalMillis,
-              runMode);
+              runMode,
+              namespace.getString("kafka.bootstrap.servers"));
       IngestionModule module = IngestionModule.create(ingestionConfig);
       App app = Guice.createInjector(module).getInstance(App.class);
       logger.atInfo().log("Guice initialization complete, running application");
@@ -107,6 +108,11 @@ final class App {
       .type(Integer.class)
       .setDefault(10)
       .help("Number of top cryptocurrencies to track (default: 100)");
+
+    // Kafka configuration
+    parser.addArgument("--")
+      .setDefault("localhost:9092")
+      .help("Kafka bootstrap servers");
 
     // Run mode configuration
     parser.addArgument("--runMode")

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionConfig.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionConfig.java
@@ -8,4 +8,5 @@ record IngestionConfig(
     int topCryptocurrencyCount,
     String exchangeName,
     long candleIntervalMillis,
-    RunMode runMode) {}
+    RunMode runMode,
+    String kafkaBootstrapServers) {}

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -38,7 +38,7 @@ abstract class IngestionModule extends AbstractModule {
             .implement(CandlePublisher.class, CandlePublisherImpl.class)
             .build(CandlePublisher.Factory.class));
 
-    install(KafkaModule.create(ingestionConfig.kafkaBootstrapServers()));
+    install(KafkaModule.create(ingestionConfig().kafkaBootstrapServers()));
   }
 
   @Provides

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -38,7 +38,7 @@ abstract class IngestionModule extends AbstractModule {
             .implement(CandlePublisher.class, CandlePublisherImpl.class)
             .build(CandlePublisher.Factory.class));
 
-    install(KafkaModule.create());
+    install(KafkaModule.create(ingestionConfig.kafkaBootstrapServers()));
   }
 
   @Provides

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaModule.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaModule.java
@@ -3,14 +3,13 @@ package com.verlumen.tradestream.kafka;
 import com.google.auto.value.AutoValue;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.AbstractModule;
-import com.google.inject.Provides;
 import com.google.inject.TypeLiteral;
 import org.apache.kafka.clients.producer.KafkaProducer;
 
 @AutoValue
 public abstract class KafkaModule extends AbstractModule {
   public static KafkaModule create(String bootstrapServers) {
-    return new AutoValue_KafkaModule();
+    return new AutoValue_KafkaModule(bootstrapServers);
   }
 
   abstract String bootstrapServers();
@@ -19,11 +18,7 @@ public abstract class KafkaModule extends AbstractModule {
   protected void configure() {
     bind(new TypeLiteral<KafkaProducer<String, byte[]>>() {})
         .toProvider(KafkaProducerProvider.class);
+    bind(KafkaProperties.class).toInstance(KafkaProperties.create(bootstrapServers()));
     bind(KafkaReadTransform.Factory.class).to(KafkaReadTransformFactory.class);
-  }
-
-  @Provides
-  KafkaProperties provideKafkaProperties() {
-    return KafkaProperties.create(bootstrapServers());
   }
 }

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaModule.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaModule.java
@@ -3,14 +3,17 @@ package com.verlumen.tradestream.kafka;
 import com.google.auto.value.AutoValue;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
 import com.google.inject.TypeLiteral;
 import org.apache.kafka.clients.producer.KafkaProducer;
 
 @AutoValue
 public abstract class KafkaModule extends AbstractModule {
-  public static KafkaModule create() {
+  public static KafkaModule create(String bootstrapServers) {
     return new AutoValue_KafkaModule();
   }
+
+  abstract String bootstrapServers();
   
   @Override
   protected void configure() {
@@ -18,5 +21,10 @@ public abstract class KafkaModule extends AbstractModule {
         .toProvider(KafkaProducerProvider.class);
     bind(KafkaProperties.class).toProvider(KafkaProperties::create);
     bind(KafkaReadTransform.Factory.class).to(KafkaReadTransformFactory.class);
+  }
+
+  @Provides
+  KafkaProperties provideKafkaProperties() {
+    return KafkaProperties.create(bootstrapServers());
   }
 }

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaModule.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaModule.java
@@ -19,7 +19,6 @@ public abstract class KafkaModule extends AbstractModule {
   protected void configure() {
     bind(new TypeLiteral<KafkaProducer<String, byte[]>>() {})
         .toProvider(KafkaProducerProvider.class);
-    bind(KafkaProperties.class).toProvider(KafkaProperties::create);
     bind(KafkaReadTransform.Factory.class).to(KafkaReadTransformFactory.class);
   }
 

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaProperties.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaProperties.java
@@ -16,10 +16,10 @@ public record KafkaProperties(
   int lingerMs,
   int retries) implements Supplier<Properties> {
 
-  public static KafkaProperties create() {
+  public static KafkaProperties create(String bootstrapServers) {
     return new KafkaProperties(
       KafkaDefaults.BATCH_SIZE,
-      KafkaDefaults.BOOTSTRAP_SERVERS,
+      bootstrapServers,
       KafkaDefaults.BUFFER_MEMORY,
       KafkaDefaults.KEY_SERIALIZER,
       KafkaDefaults.VALUE_SERIALIZER,

--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -26,11 +26,6 @@ final class App {
     String getCandleTopic();
     void setCandleTopic(String value);
 
-    @Description("Interval in hours for dynamic read.")
-    @Default.Integer(1) // Default to 1 hour
-    int getDynamicReadIntervalHours();
-    void setDynamicReadIntervalHours(int value);
-
     @Description("Run mode: wet or dry.")
     @Default.String("wet") // Default to "wet" mode
     String getRunMode();
@@ -67,7 +62,6 @@ final class App {
     var module = PipelineModule.create(
       options.getBootstrapServers(),
       options.getCandleTopic(),
-      options.getDynamicReadIntervalHours(),
       options.getRunMode());
     var app = Guice.createInjector(module).getInstance(App.class);
     var pipeline = Pipeline.create(options);

--- a/src/main/java/com/verlumen/tradestream/pipeline/PipelineModule.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/PipelineModule.java
@@ -21,7 +21,7 @@ abstract class PipelineModule extends AbstractModule {
   @Override
   protected void configure() {
     install(ExecutionModule.create(runMode()));
-    install(KafkaModule.create(bootstrapServers());
+    install(KafkaModule.create(bootstrapServers()));
   }
 
   @Provides

--- a/src/main/java/com/verlumen/tradestream/pipeline/PipelineModule.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/PipelineModule.java
@@ -10,19 +10,18 @@ import com.verlumen.tradestream.kafka.KafkaReadTransform;
 @AutoValue
 abstract class PipelineModule extends AbstractModule {
   static PipelineModule create(
-    String bootstrapServers, String candleTopic, int intervalHours, String runMode) {
-    return new AutoValue_PipelineModule(bootstrapServers, candleTopic, intervalHours, runMode);
+    String bootstrapServers, String candleTopic, String runMode) {
+    return new AutoValue_PipelineModule(bootstrapServers, candleTopic, runMode);
   }
 
   abstract String bootstrapServers();
   abstract String candleTopic();
-  abstract int dynamicReadIntervalHours();
   abstract String runMode();
 
   @Override
   protected void configure() {
     install(ExecutionModule.create(runMode()));
-    install(KafkaModule.create());
+    install(KafkaModule.create(bootstrapServers());
   }
 
   @Provides


### PR DESCRIPTION
This pull request introduces the ability to configure Kafka bootstrap servers via a command-line argument for the ingestion application. This enhancement allows users to easily specify different Kafka clusters without modifying the application code directly. Additionally, it removes the unused `dynamicReadIntervalHours` option from the pipeline application.

### Key Changes
- **`src/main/java/com/verlumen/tradestream/ingestion/App.java`**:
    - Added a new command-line argument `--kafka.bootstrap.servers` to allow users to specify Kafka bootstrap servers.
    - Modified the application to pass this argument to the `IngestionConfig`.
- **`src/main/java/com/verlumen/tradestream/ingestion/IngestionConfig.java`**:
    - Added a `kafkaBootstrapServers` field to store the Kafka bootstrap server configuration.
- **`src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java`**:
    - Updated the module to pass the `kafkaBootstrapServers` from the `IngestionConfig` to the `KafkaModule`.
- **`src/main/java/com/verlumen/tradestream/kafka/KafkaModule.java`**:
    - Modified the `create` method to accept `bootstrapServers` as a parameter.
    - Updated the module to use the provided `bootstrapServers` when creating `KafkaProperties`.
- **`src/main/java/com/verlumen/tradestream/kafka/KafkaProperties.java`**:
    - Modified the `create` method to accept `bootstrapServers` as a parameter and use it to configure Kafka properties.
- **`src/main/java/com/verlumen/tradestream/pipeline/App.java` & `src/main/java/com/verlumen/tradestream/pipeline/PipelineModule.java`**:
    - Removed the `--dynamicReadIntervalHours` option as it was not being used.
    - Updated `PipelineModule` to pass the bootstrap servers argument to `KafkaModule`.

### Testing
- Verified that the ingestion application can be started with the `--kafka.bootstrap.servers` argument and successfully connect to the specified Kafka cluster.
- Tested the pipeline application to ensure it functions correctly after the removal of the unused option and Kafka configuration changes.
- Locally tested both applications with a Kafka instance running on a non-default address.

### Dependencies/Impact
- No new dependencies are introduced.
- This change is backward compatible as it provides a default value for `--kafka.bootstrap.servers`.
- Users who need to connect to a Kafka cluster other than `localhost:9092` will now be able to configure it via the command line.