### PR TITLE
Downgrade Java Version from 21 to 17 and Adjust Dependencies

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,10 +1,10 @@
 common --enable_bzlmod
 
 # Add Java toolchain platform configuration
-build --java_runtime_version=remotejdk_21
-build --java_language_version=21
-build --tool_java_runtime_version=remotejdk_21
-build --tool_java_language_version=21
+build --java_runtime_version=remotejdk_17
+build --java_language_version=17
+build --tool_java_runtime_version=remotejdk_17
+build --tool_java_language_version=17
 
 # Enable platform-based toolchain resolution
 build --incompatible_enable_cc_toolchain_resolution

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,12 +14,12 @@ bazel_dep(name = "rules_jvm_external", version = "6.5")
 bazel_dep(name = "rules_oci", version = "2.0.1")
 
 # Add Java toolchain configuration
-JAVA_LANGUAGE_LEVEL = "21"
+JAVA_LANGUAGE_LEVEL = "17"
 
 java = use_extension("@rules_java//java:extensions.bzl", "java")
 java.toolchain(
     name = "java",
-    java_runtime = "@rules_java//toolchains:remotejdk_21",
+    java_runtime = "@rules_java//toolchains:remotejdk_17",
     source_version = JAVA_LANGUAGE_LEVEL,
     target_version = JAVA_LANGUAGE_LEVEL,
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -52,7 +52,7 @@ maven.install(
         "com.ryanharter.auto.value:auto-value-gson:1.3.1",
         "com.ryanharter.auto.value:auto-value-gson-annotations:0.8.0",
         "com.ryanharter.auto.value:auto-value-gson-factory:1.3.1",
-        "io.jenetics:jenetics:8.1.0",
+        "io.jenetics:jenetics:7.2.0",
         "io.reactivex.rxjava3:rxjava:3.1.6",
         "javax.inject:javax.inject:1",
         "net.sourceforge.argparse4j:argparse4j:0.9.0",


### PR DESCRIPTION
This PR downgrades the Java version from **21 to 17** across the project for better compatibility and stability. Key updates include:

1. **Bazel Configuration Updates**:
   - `.bazelrc`: Changes Java runtime and tool versions from `remotejdk_21` to `remotejdk_17`.
   - `MODULE.bazel`: Updates Java toolchain configuration to use Java 17 instead of Java 21.

2. **Dependency Adjustments**:
   - Downgrades `io.jenetics:jenetics` from version **8.1.0** to **7.2.0** to maintain compatibility with Java 17.

### Rationale:
- Some dependencies may not fully support Java 21 yet.
- Java 17 is a **long-term support (LTS) release**, ensuring stability for production workloads.
- Prevents potential issues with toolchain resolution in Bazel.

### Impact:
- Ensures compatibility across all Java dependencies.
- Avoids breaking changes that might arise from Java 21 deprecations.
- No functional impact, but developers should ensure they have Java 17 installed.

### Testing:
- Verified that Bazel builds successfully with Java 17.
- Confirmed all dependencies are resolved correctly after the downgrade.

### Notes:
- Developers should ensure their local environment is configured for Java 17.
- Future upgrades to Java 21 can be considered once all dependencies fully support it.