### PR TITLE
Switch Base Image to Flink 1.18 with Java 17

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -101,8 +101,8 @@ use_repo(oci, "openjdk_java")
 
 oci.pull(
     name = "flink_java17",
-    image = "docker.io/library/flink:java17",
-    digest = "sha256:1a089cc897a4f34ceaa4e15215d9a05cc32a6b5f7cba84dc0583e32eead42113",
+    image = "docker.io/library/flink:1.18-java17",
+    digest = "sha256:e3836db6fbdf5186156cebe9aaa9a8d7a6edfa43450476faa1224fae8d5c4b80",
     platforms = [
         "linux/amd64",
         "linux/arm64/v8",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -99,6 +99,18 @@ oci.pull(
 
 use_repo(oci, "openjdk_java")
 
+oci.pull(
+    name = "flink_java17",
+    image = "docker.io/library/flink:java17",
+    digest = "sha256:1a089cc897a4f34ceaa4e15215d9a05cc32a6b5f7cba84dc0583e32eead42113",
+    platforms = [
+        "linux/amd64",
+        "linux/arm64/v8",
+    ],
+)
+
+use_repo(oci, "flink_java17")
+
 # Configure Bazel libraries
 bazel_lib = use_extension("@aspect_bazel_lib//lib:extensions.bzl", "toolchains")
 bazel_lib.jq()

--- a/src/main/java/com/verlumen/tradestream/pipeline/BUILD
+++ b/src/main/java/com/verlumen/tradestream/pipeline/BUILD
@@ -39,7 +39,7 @@ genrule(
 
 oci_image(
     name = "image",
-    base = "@openjdk_java",
+    base = "@flink_java17",
     entrypoint = [
         "java",
         "-jar",


### PR DESCRIPTION
This PR updates the base image for the **pipeline container** to use **Flink 1.18 with Java 17**, ensuring compatibility with Apache Flink runtime. Key changes include:

1. **OCI Image Update**:
   - Pulls `flink:1.18-java17` from Docker Hub and adds it to `MODULE.bazel`.
   - Specifies **SHA-256 digest** to ensure reproducibility and security.

2. **Pipeline Build Adjustments**:
   - Changes the **base image** for the pipeline's `oci_image` from `@openjdk_java` to `@flink_java17` in `BUILD.bazel`.

### Rationale:
- **Aligns the container runtime with Flink 1.18**, which is optimized for Java 17.
- Ensures that the **Flink runtime dependencies** are pre-installed in the container, reducing setup overhead.
- Provides **cross-platform support** for both `linux/amd64` and `linux/arm64/v8`.

### Impact:
- The pipeline container will now run **Flink natively**, reducing the need for manual dependency management.
- No functional impact on existing Java 17 compatibility.

### Testing:
- Verified that the Flink 1.18 image is **successfully pulled** and used in the pipeline container.
- Ensured the **pipeline still builds and runs** with Java 17.

### Notes:
- Future updates can be made to support newer Flink versions as needed.
- Developers running Flink locally should ensure they match **Flink 1.18 with Java 17** for consistency.