### PR TITLE
Fix pipeline image name and update CI/Release workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,7 +81,7 @@ jobs:
             --verbose_failures \
             --sandbox_debug \
             -- \
-            --repository localhost:5000/tradestream-pipeline \
+            --repository localhost:5000/tradestream-data-pipeline \
             --tag "latest" 2>&1 | _logger
           
           docker images 2>&1 | _logger
@@ -95,9 +95,9 @@ jobs:
             minikube image load tradestream-data-ingestion:latest
             
             # Load pipeline image
-            docker pull localhost:5000/tradestream-pipeline:latest
-            docker tag localhost:5000/tradestream-pipeline:latest tradestream-pipeline:latest
-            minikube image load tradestream-pipeline:latest
+            docker pull localhost:5000/tradestream-data-pipeline:latest
+            docker tag localhost:5000/tradestream-data-pipeline:latest tradestream-data-pipeline:latest
+            minikube image load tradestream-data-pipeline:latest
             
             # List all images
             minikube image ls

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
     env:
       DATA_INGESTION_REPO: tradestreamhq/tradestream-data-ingestion
       DATA_INGESTION_SECTION_KEY: dataIngestion
-      PIPELINE_REPO: tradestreamhq/tradestream-pipeline
+      PIPELINE_REPO: tradestreamhq/tradestream-data-pipeline
       PIPELINE_SECTION_KEY: pipeline
     steps:
       - name: Checkout

--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -31,7 +31,7 @@ dataIngestion:
 pipeline:
   runMode: wet
   image:
-    repository: tradestreamhq/tradestream-pipeline
+    repository: tradestreamhq/tradestream-data-pipeline
     tag: v0.0.609-develop
     pullPolicy: IfNotPresent
   version: v1_18


### PR DESCRIPTION
This PR fixes an issue where the pipeline image name was incorrect in the CI and Release workflows, and updates the workflows to use the correct image name. It also updates the Helm chart values to reflect the correct image repository.

#### Key Changes
- **`.github/workflows/ci.yaml`**:
    - Updated the `bazel run` command to push the correct image name `tradestream-data-pipeline`.
    - Updated the `docker pull` and `docker tag` commands to use the correct image name `tradestream-data-pipeline`.
- **`.github/workflows/release.yaml`**:
    - Updated the `PIPELINE_REPO` env variable to `tradestreamhq/tradestream-data-pipeline`.
- **`charts/tradestream/values.yaml`**:
    - Updated `pipeline.image.repository` to `tradestreamhq/tradestream-data-pipeline`.

#### Testing
- N/A - This is a configuration change. Implicitly tested by CI.

#### Dependencies/Impact
- No new dependencies.
- Fixes the pipeline image name and ensures the CI and Release workflows use the correct image.