### PR TITLE
fix: Make App class public to allow Flink execution

### DIFF
--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -14,7 +14,7 @@ import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TypeDescriptors;
 
-final class App {
+public final class App {
   public interface Options extends StreamingOptions {
     @Description("Comma-separated list of Kafka bootstrap servers.")
     @Default.String("localhost:9092") 


### PR DESCRIPTION
## Issue
The Flink application fails to start with error:
"The class com.verlumen.tradestream.pipeline.App must be public"

## Changes
- Made the App class public to allow Flink to properly instantiate and execute it
- No functional changes to the application logic

## Testing
- Verified Flink application starts successfully after the change
- No changes to existing behavior, only fixing access modifier

## Related Logs
```
Caused by: org.apache.flink.client.program.ProgramInvocationException: The class com.verlumen.tradestream.pipeline.App must be public.
```
```
