### PR TITLE
Refactor Flink Job Naming for Data Pipeline Consistency

### DIFF
--- a/charts/tradestream/templates/pipeline.yaml
+++ b/charts/tradestream/templates/pipeline.yaml
@@ -1,11 +1,11 @@
 apiVersion: flink.apache.org/v1beta1
 kind: FlinkDeployment
 metadata:
-  name: {{ include "tradestream.fullname" . }}-flink-beam
+  name: {{ include "tradestream.fullname" . }}-data-pipeline
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "tradestream.name" . }}
-    component: flink-beam
+    component: data-pipeline
     release: {{ .Release.Name }}
 spec:
   image: {{ .Values.pipeline.image.repository }}:{{ .Values.pipeline.image.tag }}


### PR DESCRIPTION
This PR updates the **Flink job naming convention** in the Helm chart to enhance clarity and consistency across deployments.

### **Changes:**
1. **Renames Flink deployment**
   - `flink-beam` → `data-pipeline`
   - Ensures naming aligns with **Tradestream's data processing pipeline**.

2. **Updates Helm labels**
   - `component: flink-beam` → `component: data-pipeline`
   - Maintains uniformity with other Tradestream services.

3. **No functional impact**
   - The underlying pipeline behavior remains **unchanged**.
   - This is purely a **naming refactor** for **better readability and maintainability**.

### **Why?**
- Avoids confusion with **Apache Beam**, which is also used in the project.
- More accurately reflects **data processing responsibilities**.

This PR is a **small but meaningful step** toward a more intuitive infrastructure! 🚀