### PR TITLE
Refactor Flink Job Arguments in Helm Chart for Better Maintainability

### DIFF
--- a/charts/tradestream/templates/pipeline.yaml
+++ b/charts/tradestream/templates/pipeline.yaml
@@ -26,6 +26,7 @@ spec:
     entryClass: {{ .Values.pipeline.job.entryClass }}
     jarURI: {{ .Values.pipeline.job.jarURI }}
     args: 
-      {{- toYaml .Values.pipeline.job.args | nindent 6 }}
+      - "--bootstrapServers={{ include 'tradestream.fullname' . }}-kafka.{{ .Release.Namespace }}.svc.cluster.local:9092"
+      - "--runner=FlinkRunner"
     parallelism: {{ .Values.pipeline.job.parallelism }}
     upgradeMode: {{ .Values.pipeline.job.upgradeMode }}

--- a/charts/tradestream/templates/pipeline.yaml
+++ b/charts/tradestream/templates/pipeline.yaml
@@ -26,7 +26,7 @@ spec:
     entryClass: {{ .Values.pipeline.job.entryClass }}
     jarURI: {{ .Values.pipeline.job.jarURI }}
     args: 
-      - "--bootstrapServers={{ include 'tradestream.fullname' . }}-kafka.{{ .Release.Namespace }}.svc.cluster.local:9092"
+      - "--bootstrapServers={{ include "tradestream.fullname" . }}-kafka.{{ .Release.Namespace }}.svc.cluster.local:9092"
       - "--runner=FlinkRunner"
     parallelism: {{ .Values.pipeline.job.parallelism }}
     upgradeMode: {{ .Values.pipeline.job.upgradeMode }}

--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -47,8 +47,5 @@ pipeline:
   job:
     entryClass: com.verlumen.tradestream.pipeline.App
     jarURI: local:///src/main/java/com/verlumen/tradestream/pipeline/app_deploy.jar
-    args:
-      - "--bootstrapServers={{ include 'tradestream.fullname' . }}-kafka.{{ .Release.Namespace }}.svc.cluster.local:9092"
-      - "--runner=FlinkRunner"
     parallelism: 1
     upgradeMode: stateless


### PR DESCRIPTION
This PR moves **Flink job arguments** from `values.yaml` directly into the Helm template, ensuring cleaner configuration and reducing redundancy.

### **Changes:**
1. **Moves Flink job arguments** from `values.yaml` → `pipeline.yaml`:
   - `--bootstrapServers` and `--runner=FlinkRunner` are now **hardcoded** in the Helm template.
   - Reduces complexity in `values.yaml` while keeping arguments **explicitly defined** in the deployment template.

2. **Removes unused `args` block** from `values.yaml`:
   - Prevents duplication and unnecessary overrides.

### **Why?**
- **Better maintainability** – Avoids unnecessary overrides in `values.yaml` while keeping the Helm template self-contained.
- **Consistent deployment behavior** – Ensures required arguments are always included in deployments without risk of accidental omission.
- **Reduces complexity** – Simplifies `values.yaml` by keeping essential job settings and parameters only.

This refactor improves **clarity and robustness** in how Flink jobs are deployed! 🚀