### PR TITLE
Enable Writable Flink Configuration in Pipeline Deployment  

### DIFF
--- a/charts/tradestream/templates/pipeline.yaml
+++ b/charts/tradestream/templates/pipeline.yaml
@@ -25,8 +25,26 @@ spec:
   job:
     entryClass: {{ .Values.pipeline.job.entryClass }}
     jarURI: {{ .Values.pipeline.job.jarURI }}
-    args: 
+    args:
       - "--bootstrapServers={{ include "tradestream.fullname" . }}-kafka.{{ .Release.Namespace }}.svc.cluster.local:9092"
       - "--runner=FlinkRunner"
     parallelism: {{ .Values.pipeline.job.parallelism }}
     upgradeMode: {{ .Values.pipeline.job.upgradeMode }}
+
+  #############################################
+  # Example podTemplate to mount /opt/flink/conf as RW
+  #############################################
+  podTemplate:
+    metadata:
+      labels:
+        custom-pod-template: "true"
+    spec:
+      volumes:
+        - name: flink-conf-volume
+          emptyDir: {}
+      containers:
+        - name: flink-main-container
+          volumeMounts:
+            - name: flink-conf-volume
+              mountPath: /opt/flink/conf
+              readOnly: false

--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -3,18 +3,18 @@ package com.verlumen.tradestream.pipeline;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.verlumen.tradestream.kafka.KafkaReadTransform;
-import org.apache.beam.runners.flink.FlinkPipelineOptions;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.options.StreamingOptions;
+import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TypeDescriptors;
 
 public final class App {
-  public interface Options extends StreamingOptions, FlinkPipelineOptions {
+  public interface Options extends StreamingOptions {
     @Description("Comma-separated list of Kafka bootstrap servers.")
     @Default.String("localhost:9092") 
     String getBootstrapServers();
@@ -58,10 +58,6 @@ public final class App {
 
   public static void main(String[] args) {
     var options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
-    
-    // Ensure the Flink job is not submitted in detached mode
-    options.setDetached(false);
-
     var module = PipelineModule.create(
       options.getBootstrapServers(),
       options.getCandleTopic(),

--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -3,19 +3,18 @@ package com.verlumen.tradestream.pipeline;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.verlumen.tradestream.kafka.KafkaReadTransform;
-import java.util.Arrays;
+import org.apache.beam.runners.flink.FlinkPipelineOptions;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.options.StreamingOptions;
-import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TypeDescriptors;
 
 public final class App {
-  public interface Options extends StreamingOptions {
+  public interface Options extends StreamingOptions, FlinkPipelineOptions {
     @Description("Comma-separated list of Kafka bootstrap servers.")
     @Default.String("localhost:9092") 
     String getBootstrapServers();
@@ -59,6 +58,10 @@ public final class App {
 
   public static void main(String[] args) {
     var options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
+    
+    // Ensure the Flink job is not submitted in detached mode
+    options.setDetached(false);
+
     var module = PipelineModule.create(
       options.getBootstrapServers(),
       options.getCandleTopic(),


### PR DESCRIPTION
This PR enhances the **Flink-based Tradestream pipeline** by adding **writable Flink configuration support** and improving **pipeline execution**.

### **Key Changes:**  

1. **Introduce a writable `/opt/flink/conf` directory**
   - Adds a `podTemplate` in the **Helm chart** for the pipeline.
   - **Mounts an empty volume** at `/opt/flink/conf`, allowing runtime modifications.
   - Ensures Flink can update configuration files dynamically.

2. **Remove unnecessary import (`java.util.Arrays`)**  
   - Cleans up the `App.java` file for better maintainability.  

### **Why?**  
- **Enables dynamic Flink configuration updates** without rebuilding the container.  
- **Prepares for future custom Flink settings** (e.g., tuning parallelism, task slots, etc.).  
- **Enhances flexibility** for scaling and fine-tuning Flink job execution.  

This update **lays the groundwork for more robust pipeline configuration management** while keeping the existing structure intact. 🚀