### PR TITLE
Optimize Flink Pipeline Execution by Removing `waitUntilFinish()`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -53,7 +53,7 @@ public final class App {
 
   void runPipeline(Pipeline pipeline) {
     buildPipeline(pipeline);
-    pipeline.run().waitUntilFinish();
+    pipeline.run();
   }
 
   public static void main(String[] args) {


### PR DESCRIPTION
This PR optimizes the execution behavior of the Flink-based data pipeline by modifying the pipeline execution method:

#### **Changes:**
- Removed `.waitUntilFinish()` in `runPipeline()`, allowing the pipeline to execute asynchronously.

#### **Why This Change?**
- `waitUntilFinish()` blocks execution until the pipeline completes, which is unnecessary in streaming jobs.
- Flink streaming pipelines are meant to run indefinitely, and blocking execution can lead to undesired behavior in managed deployments.

#### **Impact**
- Ensures proper behavior for long-running streaming pipelines.
- Aligns with Flink’s best practices for executing streaming jobs.
- Avoids unnecessary blocking that could interfere with Kubernetes job lifecycle management.
