### PR TITLE
Ensure Flink Pipeline Runs in Detached Streaming Mode

### DIFF
--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -3,6 +3,7 @@ package com.verlumen.tradestream.pipeline;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.verlumen.tradestream.kafka.KafkaReadTransform;
+import org.apache.beam.runners.flink.FlinkPipelineOptions;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.Description;
@@ -57,7 +58,15 @@ public final class App {
   }
 
   public static void main(String[] args) {
+    // Parse your custom options
     var options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
+
+    // Convert to FlinkPipelineOptions so we can set attachedMode(false)
+    FlinkPipelineOptions flinkOptions = options.as(FlinkPipelineOptions.class);
+    flinkOptions.setAttachedMode(false);   // <--- CRUCIAL
+    // If this is a streaming job, ensure it's flagged as streaming:
+    flinkOptions.setStreaming(true);
+
     var module = PipelineModule.create(
       options.getBootstrapServers(),
       options.getCandleTopic(),

--- a/src/main/java/com/verlumen/tradestream/pipeline/BUILD
+++ b/src/main/java/com/verlumen/tradestream/pipeline/BUILD
@@ -15,10 +15,10 @@ java_binary(
     "//src/main/java/com/verlumen/tradestream/kafka:kafka_read_transform",
     "//third_party:beam_sdks_java_core",
     "//third_party:guice",
+    "//third_party:beam_runners_flink_java",
   ],
   runtime_deps = [
     "//third_party:beam_runners_direct_java",
-    "//third_party:beam_runners_flink_java",
   ],
 )
 


### PR DESCRIPTION
This PR modifies the Flink pipeline execution settings to ensure proper behavior in a streaming environment.

#### **Key Changes:**
- **Set `attachedMode(false)`**:  
  - Flink pipelines were previously running in attached mode by default.  
  - Detached mode prevents blocking and allows the job to run independently.
  
- **Explicitly set `setStreaming(true)`**:  
  - Ensures that the Flink runner treats the pipeline as a streaming job.  
  - Prevents potential issues with execution mode inference.

- **Updated `BUILD` dependencies**:  
  - Ensures `beam_runners_flink_java` is included in `deps`, not `runtime_deps`, to guarantee proper linkage at build time.

#### **Why This Matters:**
- Prevents jobs from being interrupted when the process exits.
- Aligns with best practices for Flink-based streaming applications.
- Ensures the pipeline can be properly managed within Kubernetes and Helm.

This should improve the robustness of our streaming deployment. 🚀