### PR TITLE
Enhance Kafka Read Transform with Coder Support for Key and Value Types

### DIFF
--- a/src/main/java/com/verlumen/tradestream/kafka/BUILD
+++ b/src/main/java/com/verlumen/tradestream/kafka/BUILD
@@ -69,6 +69,7 @@ java_library(
         ":kafka_read_transform",
         ":kafka_read_transform_impl",
         "//third_party:beam_sdks_java_core",
+        "//third_party:guava",
         "//third_party:guice",
         "//third_party:kafka_clients",
     ],

--- a/src/main/java/com/verlumen/tradestream/kafka/BUILD
+++ b/src/main/java/com/verlumen/tradestream/kafka/BUILD
@@ -56,7 +56,6 @@ java_library(
     srcs = ["KafkaReadTransform.java"],
     deps = [
         "//third_party:beam_sdks_java_core",
-        "//third_party:guava",
         "//third_party:kafka_clients",
     ],
 )
@@ -83,6 +82,7 @@ java_library(
         "//third_party:auto_value",
         "//third_party:beam_sdks_java_core",
         "//third_party:beam_sdks_java_io_kafka",
+        "//third_party:guava",
         "//third_party:kafka_clients",
     ],
 )

--- a/src/main/java/com/verlumen/tradestream/kafka/BUILD
+++ b/src/main/java/com/verlumen/tradestream/kafka/BUILD
@@ -56,6 +56,7 @@ java_library(
     srcs = ["KafkaReadTransform.java"],
     deps = [
         "//third_party:beam_sdks_java_core",
+        "//third_party:guava",
         "//third_party:kafka_clients",
     ],
 )
@@ -69,7 +70,6 @@ java_library(
         ":kafka_read_transform",
         ":kafka_read_transform_impl",
         "//third_party:beam_sdks_java_core",
-        "//third_party:guava",
         "//third_party:guice",
         "//third_party:kafka_clients",
     ],

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaReadTransformFactory.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaReadTransformFactory.java
@@ -25,6 +25,10 @@ final class KafkaReadTransformFactory implements KafkaReadTransform.Factory {
     this.kafkaProperties = kafkaProperties;
   }
 
+  /**
+   * Returns a KafkaReadTransform, either the "dry-run" version or the real version,
+   * depending on the current RunMode. Both are parameterized by K, V.
+   */
   @SuppressWarnings("unchecked")
   private <T> Coder<T> getCoderForDeserializer(Class<? extends Deserializer<? super T>> deserializerClass) {
     Coder<?> coder = DESERIALIZER_TO_CODER_MAP.get(deserializerClass);

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaReadTransformFactory.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaReadTransformFactory.java
@@ -1,20 +1,42 @@
 package com.verlumen.tradestream.kafka;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
+import org.apache.beam.sdk.coders.ByteArrayCoder;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+
+import java.util.Map;
 
 final class KafkaReadTransformFactory implements KafkaReadTransform.Factory {
   private final KafkaProperties kafkaProperties;
+  
+  private static final Map<Class<? extends Deserializer<?>>, Coder<?>> DESERIALIZER_TO_CODER_MAP =
+      ImmutableMap.<Class<? extends Deserializer<?>>, Coder<?>>builder()
+          .put(StringDeserializer.class, StringUtf8Coder.of())
+          .put(ByteArrayDeserializer.class, ByteArrayCoder.of())
+          .build();
 
   @Inject
   KafkaReadTransformFactory(KafkaProperties kafkaProperties) {
     this.kafkaProperties = kafkaProperties;
   }
 
-  /**
-   * Returns a KafkaReadTransform, either the "dry-run" version or the real version,
-   * depending on the current RunMode. Both are parameterized by K, V.
-   */
+  @SuppressWarnings("unchecked")
+  private <T> Coder<T> getCoderForDeserializer(Class<? extends Deserializer<? super T>> deserializerClass) {
+    Coder<?> coder = DESERIALIZER_TO_CODER_MAP.get(deserializerClass);
+    if (coder == null) {
+      throw new IllegalArgumentException(
+          String.format("No coder mapping found for deserializer class: %s. Supported deserializers: %s",
+              deserializerClass.getName(),
+              DESERIALIZER_TO_CODER_MAP.keySet()));
+    }
+    return (Coder<T>) coder;
+  }
+
   @Override
   public <K, V> KafkaReadTransform<K, V> create(
       String topic,
@@ -26,6 +48,8 @@ final class KafkaReadTransformFactory implements KafkaReadTransform.Factory {
         .setTopic(topic)
         .setKeyDeserializerClass((Class) keyDeserializer)
         .setValueDeserializerClass((Class) valueDeserializer)
+        .setKeyCoder(getCoderForDeserializer(keyDeserializer))
+        .setValueCoder(getCoderForDeserializer(valueDeserializer))
         .build();
   }
 }

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaReadTransformFactory.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaReadTransformFactory.java
@@ -1,6 +1,5 @@
 package com.verlumen.tradestream.kafka;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import org.apache.beam.sdk.coders.ByteArrayCoder;
 import org.apache.beam.sdk.coders.Coder;
@@ -9,36 +8,12 @@ import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 
-import java.util.Map;
-
 final class KafkaReadTransformFactory implements KafkaReadTransform.Factory {
   private final KafkaProperties kafkaProperties;
-  
-  private static final Map<Class<? extends Deserializer<?>>, Coder<?>> DESERIALIZER_TO_CODER_MAP =
-      ImmutableMap.<Class<? extends Deserializer<?>>, Coder<?>>builder()
-          .put(StringDeserializer.class, StringUtf8Coder.of())
-          .put(ByteArrayDeserializer.class, ByteArrayCoder.of())
-          .build();
 
   @Inject
   KafkaReadTransformFactory(KafkaProperties kafkaProperties) {
     this.kafkaProperties = kafkaProperties;
-  }
-
-  /**
-   * Returns a KafkaReadTransform, either the "dry-run" version or the real version,
-   * depending on the current RunMode. Both are parameterized by K, V.
-   */
-  @SuppressWarnings("unchecked")
-  private <T> Coder<T> getCoderForDeserializer(Class<? extends Deserializer<? super T>> deserializerClass) {
-    Coder<?> coder = DESERIALIZER_TO_CODER_MAP.get(deserializerClass);
-    if (coder == null) {
-      throw new IllegalArgumentException(
-          String.format("No coder mapping found for deserializer class: %s. Supported deserializers: %s",
-              deserializerClass.getName(),
-              DESERIALIZER_TO_CODER_MAP.keySet()));
-    }
-    return (Coder<T>) coder;
   }
 
   @Override
@@ -52,8 +27,6 @@ final class KafkaReadTransformFactory implements KafkaReadTransform.Factory {
         .setTopic(topic)
         .setKeyDeserializerClass((Class) keyDeserializer)
         .setValueDeserializerClass((Class) valueDeserializer)
-        .setKeyCoder(getCoderForDeserializer(keyDeserializer))
-        .setValueCoder(getCoderForDeserializer(valueDeserializer))
         .build();
   }
 }

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaReadTransformFactory.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaReadTransformFactory.java
@@ -11,6 +11,10 @@ final class KafkaReadTransformFactory implements KafkaReadTransform.Factory {
     this.kafkaProperties = kafkaProperties;
   }
 
+  /**
+   * Returns a KafkaReadTransform, either the "dry-run" version or the real version,
+   * depending on the current RunMode. Both are parameterized by K, V.
+   */
   @Override
   public <K, V> KafkaReadTransform<K, V> create(
       String topic,

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaReadTransformFactory.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaReadTransformFactory.java
@@ -1,12 +1,7 @@
 package com.verlumen.tradestream.kafka;
 
 import com.google.inject.Inject;
-import org.apache.beam.sdk.coders.ByteArrayCoder;
-import org.apache.beam.sdk.coders.Coder;
-import org.apache.beam.sdk.coders.StringUtf8Coder;
-import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.Deserializer;
-import org.apache.kafka.common.serialization.StringDeserializer;
 
 final class KafkaReadTransformFactory implements KafkaReadTransform.Factory {
   private final KafkaProperties kafkaProperties;

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaReadTransformImpl.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaReadTransformImpl.java
@@ -2,7 +2,9 @@ package com.verlumen.tradestream.kafka;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
+import org.apache.beam.sdk.coders.ByteArrayCoder;
 import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.io.kafka.KafkaIO;
 import org.apache.beam.sdk.io.kafka.KafkaRecord;
 import org.apache.beam.sdk.transforms.MapElements;
@@ -10,6 +12,8 @@ import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
 
 import java.util.Collections;
 import java.util.Map;

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaReadTransformImpl.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaReadTransformImpl.java
@@ -18,6 +18,10 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import java.util.Collections;
 import java.util.Map;
 
+/**
+ * Generic implementation of Kafka read transform, allowing the user to specify
+ * K (the key type) and V (the value type) plus their deserializers.
+ */
 @AutoValue
 abstract class KafkaReadTransformImpl<K, V> extends KafkaReadTransform<K, V> {
   private static final ImmutableMap<Class<? extends Deserializer<?>>, Coder<?>> DESERIALIZER_TO_CODER_MAP =

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaReadTransformImpl.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaReadTransformImpl.java
@@ -77,8 +77,7 @@ abstract class KafkaReadTransformImpl<K, V> extends KafkaReadTransform<K, V> {
     }
 
       /**
-     * Returns a KafkaReadTransform, either the "dry-run" version or the real version,
-     * depending on the current RunMode. Both are parameterized by K, V.
+     * Returns a KafkaReadTransform, parameterized by K, V.
      */
     @SuppressWarnings("unchecked")
     private <T> Coder<T> getCoderForDeserializer(Class<? extends Deserializer<? super T>> deserializerClass) {

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaReadTransformImpl.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaReadTransformImpl.java
@@ -53,7 +53,7 @@ abstract class KafkaReadTransformImpl<K, V> extends KafkaReadTransform<K, V> {
                     .withValueDeserializerAndCoder(valueDeserializerClass(), valueCoder())
                     .withConsumerConfigUpdates(consumerConfig()))
             .apply("ExtractValue",
-                MapElements.into(TypeDescriptor.of(valueCoder().getEncodedTypeDescriptor()))
+                MapElements.into(valueCoder().getEncodedTypeDescriptor())
                     .via((KafkaRecord<K, V> record) -> record.getKV().getValue()));
     }
 }

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaReadTransformImpl.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaReadTransformImpl.java
@@ -76,9 +76,6 @@ abstract class KafkaReadTransformImpl<K, V> extends KafkaReadTransform<K, V> {
                     .via((KafkaRecord<K, V> record) -> record.getKV().getValue()));
     }
 
-      /**
-     * Returns a KafkaReadTransform, parameterized by K, V.
-     */
     @SuppressWarnings("unchecked")
     private <T> Coder<T> getCoderForDeserializer(Class<? extends Deserializer<? super T>> deserializerClass) {
         Coder<?> coder = DESERIALIZER_TO_CODER_MAP.get(deserializerClass);


### PR DESCRIPTION
This PR improves **KafkaReadTransformImpl** by adding **Beam coders** for key-value deserialization, enabling **efficient and type-safe message processing** within Apache Beam pipelines.

#### **Key Enhancements:**
1. **Introduced Automatic Coder Selection for Kafka Keys and Values**
   - Added an **immutable mapping of Kafka deserializers to Beam coders**.
   - Currently supports:
     - `StringDeserializer` → `StringUtf8Coder`
     - `ByteArrayDeserializer` → `ByteArrayCoder`
   - Prevents unnecessary type conversions, reducing processing overhead.

2. **Updated `KafkaReadTransformImpl` to Use `withKeyDeserializerAndCoder` and `withValueDeserializerAndCoder`**
   - This ensures that Kafka messages are decoded **correctly and efficiently** in Beam.

3. **Implemented `getCoderForDeserializer()` for Dynamic Coder Selection**
   - Throws an **explicit exception** if an unsupported deserializer is provided.
   - Encourages safer and more predictable Kafka message handling.

4. **Refactored `expand()` in `KafkaReadTransformImpl`**
   - Applies the correct **key-value coders** directly within `KafkaIO.read()`.
   - Uses `MapElements` to **transform messages into their expected types**.

#### **Why This Matters:**
- **Improves performance** by avoiding unnecessary object transformations.
- **Enhances maintainability** with explicit type mappings for Kafka deserialization.
- **Increases flexibility** by allowing different key-value types with proper coders.
- **Prepares for future scalability** by making it easy to extend support for other data formats like Avro or Protobuf.

This refactor strengthens the **TradeStream data pipeline** by ensuring efficient and accurate message deserialization within **Apache Beam on Flink**. 🚀 