### PR TITLE
Add `TradePublisher` for Publishing Trades to Kafka

### DIFF
--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -16,7 +16,7 @@ java_library(
 
 java_library(
     name = "trade_publisher",
-    srcs = ["CandlePublisher.java"],
+    srcs = ["TradePublisher.java"],
     deps = [
         "//protos:marketdata_java_proto",
     ],
@@ -24,14 +24,14 @@ java_library(
 
 java_library(
     name = "trade_publisher_impl",
-    srcs = ["CandlePublisherImpl.java"],
+    srcs = ["TradePublisherImpl.java"],
     deps = [
+        ":trade_publisher",
         "//protos:marketdata_java_proto",
         "//third_party:flogger",
         "//third_party:guice",
         "//third_party:guice_assistedinject",
         "//third_party:kafka_clients",
         "//third_party:protobuf_java_util",
-        ":trade_publisher",
     ],
 )

--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -13,3 +13,25 @@ java_library(
     "//third_party:protobuf_java_util",
   ],
 )
+
+java_library(
+    name = "trade_publisher",
+    srcs = ["CandlePublisher.java"],
+    deps = [
+        "//protos:marketdata_java_proto",
+    ],
+)
+
+java_library(
+    name = "trade_publisher_impl",
+    srcs = ["CandlePublisherImpl.java"],
+    deps = [
+        "//protos:marketdata_java_proto",
+        "//third_party:flogger",
+        "//third_party:guice",
+        "//third_party:guice_assistedinject",
+        "//third_party:kafka_clients",
+        "//third_party:protobuf_java_util",
+        ":trade_publisher",
+    ],
+)

--- a/src/main/java/com/verlumen/tradestream/marketdata/TradePublisher.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/TradePublisher.java
@@ -1,0 +1,13 @@
+package com.verlumen.tradestream.marketdata;
+
+import java.time.Duration;
+
+public interface TradePublisher {
+    void publishTrade(Trade trade);
+
+    void close();
+
+    interface Factory {
+        TradePublisher create(String topic);
+    }
+}

--- a/src/main/java/com/verlumen/tradestream/marketdata/TradePublisherImpl.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/TradePublisherImpl.java
@@ -1,0 +1,75 @@
+package com.verlumen.tradestream.marketdata;
+
+import com.google.common.flogger.FluentLogger;
+import com.google.inject.assistedinject.Assisted;
+import com.google.inject.Inject;
+import com.google.protobuf.util.Timestamps;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import java.time.Duration;
+
+final class TradePublisherImpl implements TradePublisher {
+    private static final FluentLogger logger = FluentLogger.forEnclosingClass();
+    private final KafkaProducer<String, byte[]> kafkaProducer;
+    private final String topic;
+
+    @Inject
+    TradePublisherImpl(
+        KafkaProducer<String, byte[]> kafkaProducer,
+        @Assisted String topic
+    ) {
+        logger.atInfo().log("Initializing TradePublisher for topic: %s", topic);
+        this.topic = topic;
+        this.kafkaProducer = kafkaProducer;
+        logger.atInfo().log("TradePublisher initialization complete");
+    }
+
+    public void publishTrade(Trade trade) {
+        logger.atInfo().log("Publishing trade for %s to topic %s. Timestamp=%s, Open=%f, High=%f, Low=%f, Close=%f, Volume=%f", 
+            trade.getCurrencyPair(), 
+            topic,
+            Timestamps.toString(trade.getTimestamp()),
+            trade.getOpen(),
+            trade.getHigh(),
+            trade.getLow(),
+            trade.getClose(),
+            trade.getVolume());
+
+        byte[] tradeBytes = trade.toByteArray();
+        logger.atFine().log("Serialized trade data size: %d bytes", tradeBytes.length);
+
+        ProducerRecord<String, byte[]> record = new ProducerRecord<>(
+            topic,
+            trade.getCurrencyPair(),
+            tradeBytes
+        );
+
+        kafkaProducer.send(record, (metadata, exception) -> {
+            if (exception != null) {
+                logger.atSevere().withCause(exception)
+                    .log("Failed to publish trade for %s to topic %s", 
+                        trade.getCurrencyPair(), topic);
+            } else {
+                logger.atInfo().log("Successfully published trade: topic=%s, partition=%d, offset=%d, timestamp=%d",
+                    metadata.topic(), 
+                    metadata.partition(), 
+                    metadata.offset(),
+                    metadata.timestamp());
+            }
+        });
+    }
+
+    public void close() {
+        logger.atInfo().log("Initiating Kafka producer shutdown");
+        try {
+            logger.atInfo().log("Flushing any pending messages...");
+            kafkaProducer.flush();
+            logger.atInfo().log("Starting graceful shutdown with 5 second timeout");
+            kafkaProducer.close(Duration.ofSeconds(5));
+            logger.atInfo().log("Kafka producer closed successfully");
+        } catch (Exception e) {
+            logger.atSevere().withCause(e).log("Error during Kafka producer shutdown");
+            throw e;
+        }
+    }
+}

--- a/src/test/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/test/java/com/verlumen/tradestream/marketdata/BUILD
@@ -21,3 +21,20 @@ java_test(
         "//third_party:hamcrest",
     ],
 )
+
+java_test(
+    name = "TradePublisherImplTest",
+    srcs = ["TradePublisherImplTest.java"],
+    deps = [
+        "//protos:marketdata_java_proto",
+        "//src/main/java/com/verlumen/tradestream/marketdata:trade_publisher",
+        "//src/main/java/com/verlumen/tradestream/marketdata:trade_publisher_impl",
+        "//third_party:guice",
+        "//third_party:guice_assistedinject",
+        "//third_party:guice_testlib",
+        "//third_party:junit",
+        "//third_party:kafka_clients",
+        "//third_party:mockito_core",
+        "//third_party:protobuf_java_util",
+    ],
+)

--- a/src/test/java/com/verlumen/tradestream/marketdata/TradePublisherImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/marketdata/TradePublisherImplTest.java
@@ -1,4 +1,4 @@
-package com.verlumen.tradestream.ingestion;
+package com.verlumen.tradestream.marketdata;
 
 import static com.google.protobuf.util.Timestamps.fromMillis;
 import static org.mockito.ArgumentMatchers.any;

--- a/src/test/java/com/verlumen/tradestream/marketdata/TradePublisherImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/marketdata/TradePublisherImplTest.java
@@ -1,0 +1,69 @@
+package com.verlumen.tradestream.ingestion;
+
+import static com.google.protobuf.util.Timestamps.fromMillis;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import com.google.inject.assistedinject.FactoryModuleBuilder;
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.testing.fieldbinder.Bind;
+import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import java.time.Duration; 
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+@RunWith(JUnit4.class)
+public class TradePublisherImplTest {
+    @Rule public MockitoRule mocks = MockitoJUnit.rule();
+
+    private static final String TOPIC = "test-topic";
+    
+    @Mock @Bind private KafkaProducer<String, byte[]> mockProducer;
+    @Inject private TradePublisher.Factory factory;
+
+    @Before
+    public void setUp() {
+        Guice
+            .createInjector(
+                BoundFieldModule.of(this), 
+                new FactoryModuleBuilder()
+                     .implement(TradePublisher.class, TradePublisherImpl.class)
+                     .build(TradePublisher.Factory.class)
+            )
+            .injectMembers(this);
+    }
+
+    @Test
+    public void publishTrade_sendsToKafka() {
+        // Arrange
+        long epochMillis = System.currentTimeMillis();
+        Trade trade = Trade.newBuilder()
+            .setCurrencyPair("BTC/USD")
+            .setTimestamp(fromMillis(epochMillis))
+            .build();
+
+        // Act
+        factory.create(TOPIC).publishTrade(trade);
+
+        // Assert
+        verify(mockProducer).send(any(ProducerRecord.class), any());
+    }
+
+    @Test
+    public void close_closesProducer() {
+        // Act
+        factory.create(TOPIC).close();
+
+        // Assert
+        verify(mockProducer).close(any(Duration.class));
+    }
+}

--- a/src/test/java/com/verlumen/tradestream/marketdata/TradePublisherImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/marketdata/TradePublisherImplTest.java
@@ -2,7 +2,7 @@ package com.verlumen.tradestream.marketdata;
 
 import static com.google.protobuf.util.Timestamps.fromMillis;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
 
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.Guice;
@@ -26,7 +26,7 @@ public class TradePublisherImplTest {
     @Rule public MockitoRule mocks = MockitoJUnit.rule();
 
     private static final String TOPIC = "test-topic";
-    
+
     @Mock @Bind private KafkaProducer<String, byte[]> mockProducer;
     @Inject private TradePublisher.Factory factory;
 
@@ -47,8 +47,12 @@ public class TradePublisherImplTest {
         // Arrange
         long epochMillis = System.currentTimeMillis();
         Trade trade = Trade.newBuilder()
+            .setExchange("Coinbase")
             .setCurrencyPair("BTC/USD")
+            .setTradeId("trade-123")
             .setTimestamp(fromMillis(epochMillis))
+            .setPrice(50000.0)
+            .setVolume(0.1)
             .build();
 
         // Act


### PR DESCRIPTION
This PR introduces the `TradePublisher` component, which provides a structured and reliable mechanism for publishing `Trade` messages to Kafka. It includes:
- A new `TradePublisher` interface
- An implementation `TradePublisherImpl`
- Corresponding unit tests to validate its functionality

---

### **Key Features:**
#### **1. `TradePublisher` Interface**
- Defines a contract for publishing trades.
- Supports graceful shutdown via `close()` method.

#### **2. `TradePublisherImpl` Implementation**
- Uses **KafkaProducer** to send trade data to Kafka.
- Supports **Google Flogger** for structured logging.
- Implements **assisted injection** to allow dynamic topic assignment.

#### **3. Enhanced Logging**
- Logs trade metadata before sending.
- Provides detailed logging on **success** (topic, partition, offset).
- Handles **failures gracefully**, logging errors.

#### **4. Unit Testing**
- **Mocks KafkaProducer** to validate interactions.
- **Verifies trade messages** are properly sent.
- **Ensures producer closure** is handled correctly.

---

### **Why This Matters**
✅ **Encapsulates trade publishing** into a clean, testable component.  
✅ **Reduces boilerplate** by leveraging dependency injection.  
✅ **Improves maintainability** – making it easier to test and extend.  
✅ **Enhances logging and observability** to track trades efficiently.  

This is a foundational step for ensuring **robust real-time data ingestion** in TradeStream. 🚀