### PR TITLE
Add `ParseTrades` Transform and Unit Tests for Trade Deserialization

### DIFF
--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -15,7 +15,7 @@ java_library(
 )
 
 java_library(
-  name = "parse_trade",
+  name = "parse_trades",
   srcs = ["ParseTrades.java"],
   deps = [
     "//protos:marketdata_java_proto",

--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -15,6 +15,17 @@ java_library(
 )
 
 java_library(
+  name = "parse_trade",
+  srcs = ["ParseTrades.java"],
+  deps = [
+    "//protos:marketdata_java_proto",
+    "//third_party:beam_sdks_java_core",
+    "//third_party:beam_sdks_java_extensions_protobuf",
+    "//third_party:flogger",
+  ],
+)
+
+java_library(
     name = "trade_publisher",
     srcs = ["TradePublisher.java"],
     deps = [

--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -22,6 +22,7 @@ java_library(
     "//third_party:beam_sdks_java_core",
     "//third_party:beam_sdks_java_extensions_protobuf",
     "//third_party:flogger",
+    "//third_party:protobuf_java",
   ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/marketdata/ParseTrades.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/ParseTrades.java
@@ -21,7 +21,7 @@ public class ParseTrades extends PTransform<PCollection<byte[]>, PCollection<Tra
                     out.output(trade);
                 } catch (InvalidProtocolBufferException e) {
                     // Log the error. You might also choose to send these bytes to a dead-letter PCollection.
-                    logger.atError().log("Failed to parse Trade message from bytes", e);
+                    logger.atSevere().log("Failed to parse Trade message from bytes", e);
                 }
             }
         }));

--- a/src/main/java/com/verlumen/tradestream/marketdata/ParseTrades.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/ParseTrades.java
@@ -1,0 +1,32 @@
+package com.verlumen.tradestream.transforms;
+
+import com.verlumen.tradestream.marketdata.Trade;
+import com.google.protobuf.InvalidProtocolBufferException;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.PCollection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ParseTrades extends PTransform<PCollection<byte[]>, PCollection<Trade>> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ParseTrades.class);
+
+    @Override
+    public PCollection<Trade> expand(PCollection<byte[]> input) {
+        return input.apply("ParseTradeBytes", ParDo.of(new DoFn<byte[], Trade>() {
+            @ProcessElement
+            public void processElement(@Element byte[] element, OutputReceiver<Trade> out) {
+                try {
+                    // Parse the byte array into a Trade instance.
+                    Trade trade = Trade.parseFrom(element);
+                    out.output(trade);
+                } catch (InvalidProtocolBufferException e) {
+                    // Log the error. You might also choose to send these bytes to a dead-letter PCollection.
+                    LOG.error("Failed to parse Trade message from bytes", e);
+                }
+            }
+        }));
+    }
+}

--- a/src/main/java/com/verlumen/tradestream/marketdata/ParseTrades.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/ParseTrades.java
@@ -21,7 +21,7 @@ public class ParseTrades extends PTransform<PCollection<byte[]>, PCollection<Tra
                     out.output(trade);
                 } catch (InvalidProtocolBufferException e) {
                     // Log the error. You might also choose to send these bytes to a dead-letter PCollection.
-                    logger.atSevere().log("Failed to parse Trade message from bytes", e);
+                    logger.atSevere().withCause(e).log("Failed to parse Trade message from bytes");
                 }
             }
         }));

--- a/src/main/java/com/verlumen/tradestream/marketdata/ParseTrades.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/ParseTrades.java
@@ -1,12 +1,11 @@
 package com.verlumen.tradestream.marketdata;
 
+import com.google.common.flogger.FluentLogger;
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.PCollection;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ParseTrades extends PTransform<PCollection<byte[]>, PCollection<Trade>> {
     private static final FluentLogger logger = FluentLogger.forEnclosingClass();

--- a/src/main/java/com/verlumen/tradestream/marketdata/ParseTrades.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/ParseTrades.java
@@ -1,6 +1,5 @@
-package com.verlumen.tradestream.transforms;
+package com.verlumen.tradestream.marketdata;
 
-import com.verlumen.tradestream.marketdata.Trade;
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -10,8 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ParseTrades extends PTransform<PCollection<byte[]>, PCollection<Trade>> {
-
-    private static final Logger LOG = LoggerFactory.getLogger(ParseTrades.class);
+    private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
     @Override
     public PCollection<Trade> expand(PCollection<byte[]> input) {
@@ -24,7 +22,7 @@ public class ParseTrades extends PTransform<PCollection<byte[]>, PCollection<Tra
                     out.output(trade);
                 } catch (InvalidProtocolBufferException e) {
                     // Log the error. You might also choose to send these bytes to a dead-letter PCollection.
-                    LOG.error("Failed to parse Trade message from bytes", e);
+                    logger.atError().log("Failed to parse Trade message from bytes", e);
                 }
             }
         }));

--- a/src/test/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/test/java/com/verlumen/tradestream/marketdata/BUILD
@@ -28,7 +28,9 @@ java_test(
     deps = [
         "//protos:marketdata_java_proto",
         "//src/main/java/com/verlumen/tradestream/marketdata:parse_trades",
+        "//third_party:beam_sdks_java_core",
         "//third_party:beam_sdks_java_test_utils",
+        "//third_party:protobuf_java_util",
         "//third_party:junit",
     ],
 )

--- a/src/test/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/test/java/com/verlumen/tradestream/marketdata/BUILD
@@ -23,6 +23,16 @@ java_test(
 )
 
 java_test(
+    name = "ParseTradesTest",
+    srcs = ["ParseTradesTest.java"],
+    deps = [
+        "//protos:marketdata_java_proto",
+        "//src/main/java/com/verlumen/tradestream/marketdata:parse_trades",
+        "//third_party:beam_sdks_java_test_utils",
+    ],
+)
+
+java_test(
     name = "TradePublisherImplTest",
     srcs = ["TradePublisherImplTest.java"],
     deps = [

--- a/src/test/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/test/java/com/verlumen/tradestream/marketdata/BUILD
@@ -30,6 +30,7 @@ java_test(
         "//src/main/java/com/verlumen/tradestream/marketdata:parse_trades",
         "//third_party:beam_sdks_java_core",
         "//third_party:beam_sdks_java_test_utils",
+        "//third_party:protobuf_java",
         "//third_party:protobuf_java_util",
         "//third_party:junit",
     ],

--- a/src/test/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/test/java/com/verlumen/tradestream/marketdata/BUILD
@@ -34,6 +34,9 @@ java_test(
         "//third_party:protobuf_java_util",
         "//third_party:junit",
     ],
+    runtime_deps = [
+        "//third_party:beam_runners_direct_java",
+    ],
 )
 
 java_test(

--- a/src/test/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/test/java/com/verlumen/tradestream/marketdata/BUILD
@@ -36,6 +36,7 @@ java_test(
     ],
     runtime_deps = [
         "//third_party:beam_runners_direct_java",
+        "//third_party:hamcrest",
     ],
 )
 

--- a/src/test/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/test/java/com/verlumen/tradestream/marketdata/BUILD
@@ -29,6 +29,7 @@ java_test(
         "//protos:marketdata_java_proto",
         "//src/main/java/com/verlumen/tradestream/marketdata:parse_trades",
         "//third_party:beam_sdks_java_test_utils",
+        "//third_party:junit",
     ],
 )
 

--- a/src/test/java/com/verlumen/tradestream/marketdata/ParseTradesTest.java
+++ b/src/test/java/com/verlumen/tradestream/marketdata/ParseTradesTest.java
@@ -1,0 +1,180 @@
+package com.verlumen.tradestream.marketdata;
+
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.util.Timestamps;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.values.PCollection;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for {@link ParseTrades}. Each test follows the Arrange-Act-Assert (AAA)
+ * pattern with one assertion per test case.
+ */
+@RunWith(JUnit4.class)
+public class ParseTradesTest {
+
+    // The TestPipeline rule creates a Beam pipeline for testing.
+    @Rule
+    public final TestPipeline pipeline = TestPipeline.create();
+
+    /**
+     * Test that a valid Trade message (encoded as a byte array) is correctly parsed.
+     *
+     * <p>Arrange: Build a valid Trade with all expected fields set.
+     * <br>Act: Create a PCollection containing this byte array and apply ParseTrades.
+     * <br>Assert: The output contains exactly the expected Trade message.
+     */
+    @Test
+    public void testValidTradeParsing() throws Exception {
+        // Arrange
+        Trade expectedTrade = Trade.newBuilder()
+            // Build a Timestamp (using an epoch value, for example)
+            .setTimestamp(Timestamp.newBuilder().setSeconds(1620000000).setNanos(0).build())
+            .setExchange("TestExchange")
+            .setCurrencyPair("BTC/USD")
+            .setPrice(10000.0)
+            .setVolume(0.5)
+            .setTradeId("trade123")
+            .build();
+        byte[] validTradeBytes = expectedTrade.toByteArray();
+
+        // Act
+        PCollection<byte[]> input = pipeline.apply("CreateValidTrade", Create.of(validTradeBytes));
+        PCollection<Trade> output = input.apply(new ParseTrades());
+
+        // Assert: Verify that the output PCollection contains exactly the expected Trade.
+        PAssert.that(output).containsInAnyOrder(expectedTrade);
+
+        // Run the pipeline.
+        pipeline.run().waitUntilFinish();
+    }
+
+    /**
+     * Test that an invalid byte array (which does not represent a valid Trade) produces no output.
+     *
+     * <p>Arrange: Create an invalid byte array.
+     * <br>Act: Apply ParseTrades to a PCollection with the invalid byte array.
+     * <br>Assert: The output PCollection is empty.
+     */
+    @Test
+    public void testInvalidTradeParsing() throws Exception {
+        // Arrange: An arbitrary byte array that does not represent a valid Trade.
+        byte[] invalidBytes = new byte[]{0, 1, 2, 3};
+
+        // Act
+        PCollection<byte[]> input = pipeline.apply("CreateInvalidTrade", Create.of(invalidBytes));
+        PCollection<Trade> output = input.apply(new ParseTrades());
+
+        // Assert: The output should be empty because parsing fails.
+        PAssert.that(output).empty();
+
+        // Run the pipeline.
+        pipeline.run().waitUntilFinish();
+    }
+
+    /**
+     * Test that a mix of valid and invalid Trade byte arrays results in output containing only the
+     * valid Trade message.
+     *
+     * <p>Arrange: Create one valid Trade byte array and one invalid byte array.
+     * <br>Act: Apply ParseTrades.
+     * <br>Assert: The output contains only the valid Trade.
+     */
+    @Test
+    public void testMixedValidAndInvalidTradeParsing() throws Exception {
+        // Arrange: Build a valid Trade message.
+        Trade expectedTrade = Trade.newBuilder()
+            .setTimestamp(Timestamp.newBuilder().setSeconds(1620001000).setNanos(0).build())
+            .setExchange("TestExchange")
+            .setCurrencyPair("BTC/USD")
+            .setPrice(5000.0)
+            .setVolume(1.0)
+            .setTradeId("trade456")
+            .build();
+        byte[] validTradeBytes = expectedTrade.toByteArray();
+        byte[] invalidBytes = new byte[]{9, 8, 7}; // An invalid byte array.
+
+        // Act
+        List<byte[]> inputs = Arrays.asList(validTradeBytes, invalidBytes);
+        PCollection<byte[]> input = pipeline.apply("CreateMixedTrades", Create.of(inputs));
+        PCollection<Trade> output = input.apply(new ParseTrades());
+
+        // Assert: Only the valid Trade should be present in the output.
+        PAssert.that(output).containsInAnyOrder(expectedTrade);
+
+        // Run the pipeline.
+        pipeline.run().waitUntilFinish();
+    }
+
+    /**
+     * Test that an empty input PCollection produces an empty output.
+     *
+     * <p>Arrange: Create an empty PCollection.
+     * <br>Act: Apply ParseTrades.
+     * <br>Assert: The output is empty.
+     */
+    @Test
+    public void testEmptyInput() throws Exception {
+        // Arrange: Create an empty PCollection of byte[].
+        PCollection<byte[]> input = pipeline.apply("CreateEmptyInput", Create.empty(byte[].class));
+
+        // Act
+        PCollection<Trade> output = input.apply(new ParseTrades());
+
+        // Assert: The output should be empty.
+        PAssert.that(output).empty();
+
+        // Run the pipeline.
+        pipeline.run().waitUntilFinish();
+    }
+
+    /**
+     * Test that multiple valid Trade messages are all parsed correctly.
+     *
+     * <p>Arrange: Create multiple valid Trade messages and convert them to byte arrays.
+     * <br>Act: Apply ParseTrades to a PCollection of these byte arrays.
+     * <br>Assert: The output contains all the Trade messages.
+     */
+    @Test
+    public void testMultipleValidTrades() throws Exception {
+        // Arrange: Build two valid Trade messages.
+        Trade trade1 = Trade.newBuilder()
+            .setTimestamp(Timestamp.newBuilder().setSeconds(1620002000).setNanos(0).build())
+            .setExchange("Exchange1")
+            .setCurrencyPair("BTC/USD")
+            .setPrice(9000.0)
+            .setVolume(0.3)
+            .setTradeId("trade001")
+            .build();
+
+        Trade trade2 = Trade.newBuilder()
+            .setTimestamp(Timestamp.newBuilder().setSeconds(1620003000).setNanos(0).build())
+            .setExchange("Exchange2")
+            .setCurrencyPair("ETH/USD")
+            .setPrice(200.0)
+            .setVolume(5.0)
+            .setTradeId("trade002")
+            .build();
+
+        byte[] trade1Bytes = trade1.toByteArray();
+        byte[] trade2Bytes = trade2.toByteArray();
+
+        // Act
+        List<byte[]> tradesBytes = Arrays.asList(trade1Bytes, trade2Bytes);
+        PCollection<byte[]> input = pipeline.apply("CreateMultipleValidTrades", Create.of(tradesBytes));
+        PCollection<Trade> output = input.apply(new ParseTrades());
+
+        // Assert: The output should contain both Trade messages.
+        PAssert.that(output).containsInAnyOrder(trade1, trade2);
+
+        // Run the pipeline.
+        pipeline.run().waitUntilFinish();
+    }
+}

--- a/src/test/java/com/verlumen/tradestream/marketdata/ParseTradesTest.java
+++ b/src/test/java/com/verlumen/tradestream/marketdata/ParseTradesTest.java
@@ -4,6 +4,7 @@ import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
 import java.util.Arrays;
 import java.util.List;
+import org.apache.beam.sdk.coders.ByteArrayCoder;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
@@ -123,7 +124,7 @@ public class ParseTradesTest {
     @Test
     public void testEmptyInput() throws Exception {
         // Arrange: Create an empty PCollection of byte[].
-        PCollection<byte[]> input = pipeline.apply("CreateEmptyInput", Create.empty(byte[].class));
+        PCollection<byte[]> input = pipeline.apply("CreateEmptyInput", Create.empty(ByteArrayCoder.of()));
 
         // Act
         PCollection<Trade> output = input.apply(new ParseTrades());


### PR DESCRIPTION
This PR introduces the `ParseTrades` transform, which parses raw Kafka byte arrays into `Trade` protobuf messages. It also includes a full suite of **unit tests** to validate functionality.

---

### **Key Changes:**
1. **New `ParseTrades` Transform**
   - Converts `byte[]` messages into `Trade` protobuf objects.
   - Uses **Apache Beam's `ParDo`** for efficient parallel processing.
   - Logs errors and prevents pipeline crashes on malformed messages.

2. **Comprehensive Unit Tests**
   - Added **`ParseTradesTest`** with **five test cases**:
     ✅ **Valid Trade Parsing**: Ensures correct deserialization.  
     ✅ **Invalid Trade Handling**: Ensures invalid messages are dropped.  
     ✅ **Mixed Input Handling**: Valid messages pass, invalid messages are skipped.  
     ✅ **Empty Input Handling**: Ensures no output for an empty input.  
     ✅ **Multiple Trades Handling**: Validates multiple messages are processed correctly.

3. **Bazel Build Updates**
   - Added `parse_trades` to `BUILD` files.
   - Updated `test/BUILD` to include `ParseTradesTest`.

---

### **Why This Matters**
✅ **Prepares for Scalable Trade Ingestion** — Standardizes trade message parsing.  
✅ **Enhances Data Reliability** — Drops corrupt messages without pipeline failures.  
✅ **Strengthens Code Quality** — Unit tests ensure long-term maintainability.  

🚀 This is a critical step toward robust, **fault-tolerant trade ingestion** in `TradeStream`.