### PR TITLE
Reorder Dependencies in `IngestionModule` for Consistency  

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -245,12 +245,6 @@ java_library(
     name = "ingestion_module",
     srcs = ["IngestionModule.java"],
     deps = [
-        "//src/main/java/com/verlumen/tradestream/kafka:kafka_module",
-        "//src/main/java/com/verlumen/tradestream/execution:run_mode",
-        "//third_party:auto_value",
-        "//third_party:guava",
-        "//third_party:guice_assistedinject",
-        "//third_party:guice",
         ":candle_manager",
         ":candle_manager_impl",
         ":candle_publisher",
@@ -272,6 +266,12 @@ java_library(
         ":thin_market_timer_task",
         ":thin_market_timer_task_impl",
         ":trade_processor",
+        "//src/main/java/com/verlumen/tradestream/execution:run_mode",
+        "//src/main/java/com/verlumen/tradestream/kafka:kafka_module",
+        "//third_party:auto_value",
+        "//third_party:guava",
+        "//third_party:guice_assistedinject",
+        "//third_party:guice",
     ],
 )
 


### PR DESCRIPTION
This PR reorders the dependencies in `IngestionModule` within Bazel's `BUILD` file for improved **readability** and **consistency**.

---

### **Key Changes:**
1. **Reorganized Dependencies**  
   - Moved `guice`, `auto_value`, `guava`, and `guice_assistedinject` **after** ingestion-specific modules.
   - Ensured `kafka_module` and `run_mode` appear **after ingestion components**, aligning with project structure.

2. **No Functional Changes**  
   - This is a **non-breaking change** with **zero functional impact** on execution.
   - Strictly improves **maintainability** and **logical grouping** in the build file.

---

### **Why This Matters**
✅ **Improves Code Readability** — Groups dependencies logically.  
✅ **Enhances Maintainability** — Keeps the dependency structure **predictable**.  
✅ **Aligns with Best Practices** — Ensures **framework dependencies** appear **after** domain-specific dependencies.  

This is a minor but **important cleanup** to maintain **Bazel build hygiene** in the `TradeStream` project. 🚀