### PR TITLE
Integrate `MarketDataModule` into `IngestionModule`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -245,8 +245,9 @@ java_library(
     name = "ingestion_module",
     srcs = ["IngestionModule.java"],
     deps = [
-        "//src/main/java/com/verlumen/tradestream/kafka:kafka_module",
         "//src/main/java/com/verlumen/tradestream/execution:run_mode",
+        "//src/main/java/com/verlumen/tradestream/kafka:kafka_module",
+        "//src/main/java/com/verlumen/tradestream/marketdata:market_data_module",
         "//third_party:auto_value",
         "//third_party:guava",
         "//third_party:guice_assistedinject",

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -6,6 +6,7 @@ import com.google.inject.Provides;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.verlumen.tradestream.execution.RunMode;
 import com.verlumen.tradestream.kafka.KafkaModule;
+import com.verlumen.tradestream.marketdata.MarketDataModule;
 import java.util.Timer;
 
 @AutoValue
@@ -39,6 +40,7 @@ abstract class IngestionModule extends AbstractModule {
             .build(CandlePublisher.Factory.class));
 
     install(KafkaModule.create(ingestionConfig().kafkaBootstrapServers()));
+    install(MarketDataModule.create());
   }
 
   @Provides


### PR DESCRIPTION
This PR integrates the `MarketDataModule` into the `IngestionModule`, ensuring that market data dependencies (e.g., trade parsing and publishing) are properly injected for real-time data ingestion.

---

### **Key Changes:**
1. **Updated `IngestionModule.java`**
   - Installed `MarketDataModule` alongside `KafkaModule`.
   - This enables dependency injection for trade processing components.

2. **Modified `BUILD` Files**
   - Added `//src/main/java/com/verlumen/tradestream/marketdata:market_data_module` as a dependency in `ingestion/BUILD`.

---

### **Why This Matters**
✅ **Ensures Proper Dependency Injection** — `MarketDataModule` is now available within the ingestion pipeline.  
✅ **Prepares for Future Expansion** — Facilitates modular trade processing and market data integration.  
✅ **Enhances Code Maintainability** — Keeps dependencies clean and properly structured.  

🚀 This is a crucial step toward **scalable trade ingestion** in `TradeStream`.