### PR TITLE
Remove Unused `FORWARD_SLASH` Constant

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
@@ -15,7 +15,6 @@ import com.verlumen.tradestream.marketdata.Trade;
 
 final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
     private static final FluentLogger logger = FluentLogger.forEnclosingClass();
-    private static final String FORWARD_SLASH = "/";
 
     private final CandleManager candleManager;
     private final CandlePublisher candlePublisher;


### PR DESCRIPTION
The `FORWARD_SLASH` constant was unused in `RealTimeDataIngestionImpl.java`, so this removes it to clean up the code. 🚀