### PR TITLE
Rename and Simplify Kafka Byte Processing

### DIFF
--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -43,7 +43,6 @@ public final class App {
         this.kafkaReadTransform = kafkaReadTransform;
     }
 
-    // In App.java
     private Pipeline buildPipeline(Pipeline pipeline) {
         PCollection<byte[]> input = pipeline.apply("Read from Kafka", kafkaReadTransform);
 
@@ -60,7 +59,7 @@ public final class App {
     private static class PrintBytesAsString extends DoFn<byte[], byte[]> {
         @ProcessElement
         public void processElement(@Element byte[] element, OutputReceiver<byte[]> receiver) {
-            System.out.println(new String(value));
+            System.out.println(new String(element));
             receiver.output(element);
         }
     }

--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -43,12 +43,11 @@ public final class App {
         this.kafkaReadTransform = kafkaReadTransform;
     }
 
-
     // In App.java
     private Pipeline buildPipeline(Pipeline pipeline) {
         PCollection<byte[]> input = pipeline.apply("Read from Kafka", kafkaReadTransform);
 
-        input.apply("Convert to String", ParDo.of(new BytesToStringDoFn()));
+        input.apply("Convert to String", ParDo.of(new PrintBytesAsString()));
         
         return pipeline;
     }
@@ -58,23 +57,11 @@ public final class App {
         pipeline.run();
     }
 
-    private static class BytesToStringDoFn extends DoFn<byte[], String> {
+    private static class PrintBytesAsString extends DoFn<byte[], byte[]> {
         @ProcessElement
-        public void processElement(@Element byte[] element, OutputReceiver<String> receiver) {
-            try {
-                String value = new String(element);
-                System.out.println(value);
-                System.out.println(Candle.parseFrom(element));
-                receiver.output(value);
-            } catch (InvalidProtocolBufferException e) {
-                // Handle checked exception for Protocol Buffer parsing
-                System.err.println("Failed to parse Protocol Buffer: " + e.getMessage());
-                e.printStackTrace();
-            } catch (RuntimeException e) {
-                // Handle any unchecked exceptions
-                System.err.println("Unexpected error processing element: " + e.getMessage());
-                e.printStackTrace();
-            }
+        public void processElement(@Element byte[] element, OutputReceiver<byte[]> receiver) {
+            System.out.println(new String(value));
+            receiver.output(element);
         }
     }
 


### PR DESCRIPTION
- Renames `BytesToStringDoFn` to `PrintBytesAsString` for clarity.  
- Simplifies byte processing by removing unnecessary exception handling and protobuf parsing.  
- Ensures Kafka messages are printed as strings while keeping the pipeline output unchanged. 🚀