### PR TITLE
Refactor `CreateCandles` for Dependency Injection & Remove Static Factory Method

### DIFF
--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -9,7 +9,7 @@ java_library(
     "//protos:marketdata_java_proto",
     "//third_party:beam_sdks_java_core",
     "//third_party:beam_sdks_java_extensions_protobuf",
-    "//third_party:guava",
+    "//third_party:guice",
     "//third_party:joda_time",
     "//third_party:protobuf_java_util",
   ],

--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -9,6 +9,7 @@ java_library(
     "//protos:marketdata_java_proto",
     "//third_party:beam_sdks_java_core",
     "//third_party:beam_sdks_java_extensions_protobuf",
+    "//third_party:guava",
     "//third_party:joda_time",
     "//third_party:protobuf_java_util",
   ],

--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -23,7 +23,6 @@ java_library(
   name = "market_data_module",
   srcs = ["MarketDataModule.java"],
   deps = [
-    ":create_candles",
     ":market_data_config",
     ":trade_publisher",
     ":trade_publisher_impl",

--- a/src/main/java/com/verlumen/tradestream/marketdata/CreateCandles.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/CreateCandles.java
@@ -1,5 +1,6 @@
 package com.verlumen.tradestream.marketdata;
 
+import com.google.inject.Inject;
 import com.google.protobuf.util.Timestamps;
 import java.io.Serializable;
 import org.apache.beam.sdk.coders.SerializableCoder;
@@ -23,9 +24,8 @@ import org.apache.beam.sdk.values.PCollection;
 import org.joda.time.Duration;
 
 public class CreateCandles extends PTransform<PCollection<KV<String, Trade>>, PCollection<Candle>> {
-  public static CreateCandles create() {
-    return new CreateCandles();
-  }
+  @Inject
+  CreateCandles() {}
 
   @Override
   public PCollection<Candle> expand(PCollection<KV<String, Trade>> input) {

--- a/src/main/java/com/verlumen/tradestream/marketdata/MarketDataModule.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/MarketDataModule.java
@@ -15,8 +15,6 @@ public abstract class MarketDataModule extends AbstractModule {
 
   @Override
   protected void configure() {
-    bind(CreateCandles.class).toProvider(CreateCandles::create);
-
     install(
         new FactoryModuleBuilder()
             .implement(TradePublisher.class, TradePublisherImpl.class)

--- a/src/test/java/com/verlumen/tradestream/marketdata/CreateCandlesTest.java
+++ b/src/test/java/com/verlumen/tradestream/marketdata/CreateCandlesTest.java
@@ -61,7 +61,7 @@ public class CreateCandlesTest {
   //–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––
   // Integration Test 1: Single Trade produces a correct candle.
   // Arrange: One KV element for key "EUR/USD" in a fixed window.
-  // Act: Apply windowing and CreateCandles.create().
+  // Act: Apply windowing and new CreateCandles().
   // Assert: The output candle’s open price equals the trade price.
   @Test
   public void testSingleTradeProducesCorrectCandle() {
@@ -88,7 +88,7 @@ public class CreateCandlesTest {
         pipeline
             .apply("Input", stream)
             .apply("Window", Window.<KV<String, Trade>>into(FixedWindows.of(Duration.standardSeconds(10))))
-            .apply("Candle", CreateCandles.create());
+            .apply("Candle", new CreateCandles());
 
     PAssert.that(candles).satisfies((Iterable<Candle> outs) -> {
       int count = 0;
@@ -137,14 +137,14 @@ public class CreateCandlesTest {
     pipeline
         .apply("Input2", stream)
         .apply("Window2", Window.<KV<String, Trade>>into(FixedWindows.of(Duration.standardSeconds(10))))
-        .apply("Candle2", CreateCandles.create());
+        .apply("Candle2", new CreateCandles());
         
     // Assert: Use PAssert to check that the maximum (high) value equals 105.0.
     PAssert.thatSingleton(
             pipeline
                 .apply("InputForPAssert2", stream)
                 .apply("WindowForPAssert2", Window.<KV<String, Trade>>into(FixedWindows.of(Duration.standardSeconds(10))))
-                .apply("CandleForPAssert2", CreateCandles.create())
+                .apply("CandleForPAssert2", new CreateCandles())
                 .apply("ExtractHigh", org.apache.beam.sdk.transforms.MapElements.into(
                     org.apache.beam.sdk.values.TypeDescriptors.doubles())
                     .via((Candle c) -> c.getHigh())))
@@ -170,7 +170,7 @@ public class CreateCandlesTest {
         pipeline
             .apply("EmptyInput", emptyStream)
             .apply("WindowEmpty", Window.<KV<String, Trade>>into(FixedWindows.of(Duration.standardSeconds(10))))
-            .apply("CandleEmpty", CreateCandles.create());
+            .apply("CandleEmpty", new CreateCandles());
 
     // Assert: The output PCollection should be empty.
     PAssert.that(output).empty();


### PR DESCRIPTION
This PR refactors `CreateCandles` to support **dependency injection (DI) via Guice**, removing the static factory method (`CreateCandles.create()`).  

---

### **Key Changes:**

1. **Dependency Injection via Guice**  
   - Replaced `CreateCandles.create()` with direct `@Inject` constructor.  
   - Removed explicit binding in `MarketDataModule`.  
   - Ensures better **testability and configurability**.

2. **Updated Tests for Constructor Invocation**  
   - All test cases now use `new CreateCandles()` instead of `CreateCandles.create()`.  
   - This allows greater flexibility in test setup.  

3. **Removed Unused Binding in `MarketDataModule`**  
   - Eliminated explicit binding for `CreateCandles` as Guice now **automatically injects** it.  

---

### **Why This Change?**  
✅ **Aligns with DI Best Practices** – Removes **unnecessary static factory methods**.  
✅ **Improves Testability** – Allows injecting mocks when needed.  
✅ **Simplifies Code** – No more static method call, just instantiate directly.  

---

### **Next Steps:**  
- Verify that `CreateCandles` integrates smoothly with the pipeline.  
- Ensure **correct aggregation of trade data** into candles.  

🚀 **This completes the migration of `CreateCandles` to dependency injection!**