### PR TITLE
Migrate Trade Publishing to New Publisher in Real-Time Data Ingestion  

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
@@ -65,12 +65,13 @@ final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
         logger.atInfo().log("Stopping thin market timer...");
         thinMarketTimer.get().stop();
 
-        logger.atInfo().log("Closing candle publisher...");
+        logger.atInfo().log("Closing trade publisher...");
         try {
+            tradePublisher.close();
             candlePublisher.close();
-            logger.atInfo().log("Successfully closed candle publisher");
+            logger.atInfo().log("Successfully closed trade publisher");
         } catch (Exception e) {
-            logger.atWarning().withCause(e).log("Error closing candle publisher");
+            logger.atWarning().withCause(e).log("Error closing trade publisher");
         }
 
         logger.atInfo().log("Shutdown sequence complete");
@@ -89,6 +90,7 @@ final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
                 trade.getTradeId(),
                 trade.getPrice(),
                 trade.getVolume());
+            tradePublisher.publishTrade(trade);
             candleManager.processTrade(trade);
         } catch (RuntimeException e) {
             logger.atSevere().withCause(e).log(


### PR DESCRIPTION
This PR updates **`RealTimeDataIngestionImpl`** to transition from publishing trades indirectly via the **candle publisher** to using a dedicated **trade publisher**. This is part of an ongoing migration to improve data separation and maintainability.  

---

### **Key Updates:**
1. **Introduced `tradePublisher.publishTrade(trade);`**  
   - Trades are now **published separately** before candle aggregation.  
   - Enables better **scalability and flexibility** in trade data handling.  

2. **Updated Logging Messages**  
   - Changed references from `"candle publisher"` to `"trade publisher"` to reflect the **new separation**.  
   - Improves **debugging clarity** when tracking published trade events.  

3. **Ensured Proper Shutdown of Trade Publisher**  
   - Calls `tradePublisher.close();` during shutdown to **prevent resource leaks**.  

---

### **Why This Change?**  
✅ **Improves Data Pipeline Modularity** – Trades and candles are **no longer coupled**, allowing **independent scaling**.  
✅ **Enhances Debugging & Maintenance** – Separate logging and publishing for **trades vs. candles**.  
✅ **Lays Foundation for Future Improvements** – Supports future enhancements like **dedicated trade analytics**.  

---

### **Next Steps:**  
- **Monitor trade publishing performance** post-migration.  
- **Update downstream consumers** to leverage the dedicated trade publisher.  

🚀 **This migration ensures cleaner trade processing and sets the stage for improved data handling!**