### PR TITLE
Migrate Pipeline from Candle Topic to Trade Topic  

### DIFF
--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -26,11 +26,6 @@ public final class App {
         String getBootstrapServers();
         void setBootstrapServers(String value);
 
-        @Description("Kafka topic to read candle data from.")
-        @Default.String("candles")
-        String getCandleTopic();
-        void setCandleTopic(String value);
-
         @Description("Kafka topic to read trade data from.")
         @Default.String("trades")
         String getTradeTopic();
@@ -87,7 +82,7 @@ public final class App {
 
         var module = PipelineModule.create(
             options.getBootstrapServers(),
-            options.getCandleTopic(),
+            options.getTradeTopic(),
             options.getRunMode());
         var app = Guice.createInjector(module).getInstance(App.class);
         var pipeline = Pipeline.create(options);

--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -31,6 +31,11 @@ public final class App {
         String getCandleTopic();
         void setCandleTopic(String value);
 
+        @Description("Kafka topic to read trade data from.")
+        @Default.String("trades")
+        String getTradeTopic();
+        void setTradeTopic(String value);
+
         @Description("Run mode: wet or dry.")
         @Default.String("wet")
         String getRunMode();

--- a/src/main/java/com/verlumen/tradestream/pipeline/PipelineModule.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/PipelineModule.java
@@ -27,13 +27,13 @@ abstract class PipelineModule extends AbstractModule {
       .build();
 
   static PipelineModule create(
-    String bootstrapServers, String candleTopic, String runMode) {
-    return new AutoValue_PipelineModule(bootstrapServers, candleTopic, runMode);
+    String bootstrapServers, String tradeTopic, String runMode) {
+    return new AutoValue_PipelineModule(bootstrapServers, runMode, tradeTopic);
   }
 
   abstract String bootstrapServers();
-  abstract String candleTopic();
   abstract String runMode();
+  abstract String tradeTopic();
 
   @Override
   protected void configure() {
@@ -47,7 +47,7 @@ abstract class PipelineModule extends AbstractModule {
         return DryRunKafkaReadTransform
             .<String, byte[]>builder()
             .setBootstrapServers(bootstrapServers())
-            .setTopic(candleTopic())
+            .setTopic(tradeTopic())
             .setKeyDeserializerClass(StringDeserializer.class)
             .setValueDeserializerClass(ByteArrayDeserializer.class)
             .setDefaultValue(DRY_RUN_TRADE.toByteArray())
@@ -55,7 +55,7 @@ abstract class PipelineModule extends AbstractModule {
       }
 
       return factory.create(
-          candleTopic(), 
+          tradeTopic(), 
           StringDeserializer.class,
           ByteArrayDeserializer.class);
   }


### PR DESCRIPTION
This PR updates the **TradeStream pipeline** to consume trade data directly from the **`trades`** Kafka topic instead of the previous **`candles`** topic. This change aligns with the recent separation of **trade and candle processing**, ensuring a dedicated trade pipeline.

---

### **Key Changes:**
1. **Renamed `candleTopic` → `tradeTopic`**  
   - Updated `Options` and `PipelineModule` to reflect the new trade topic.  
   - Default Kafka topic is now `"trades"` instead of `"candles"`.  

2. **Updated Pipeline Module and Injection**  
   - Now **reads raw trade data** from Kafka instead of candle data.  
   - Ensures the **correct Kafka topic is injected** during pipeline creation.  

3. **Preserved Dry Run Mode Compatibility**  
   - `DryRunKafkaReadTransform` now simulates trades instead of candles.  
   - Uses the **predefined `DRY_RUN_TRADE` proto** for mock trade data.  

---

### **Why This Change?**  
✅ **Ensures Trade Data is Processed Separately** – No longer coupled with candles.  
✅ **Improves Scalability** – Supports **real-time trade ingestion** for analytics.  
✅ **Aligns with New Trade Publisher** – Consistent with **recent ingestion updates**.  

---

### **Next Steps:**  
- Validate pipeline performance with **real trade data ingestion**.  
- Ensure **downstream consumers** adapt to trade-based processing.  
- Continue **optimizing trade transformations** before aggregation.  

🚀 **This migration ensures a dedicated and scalable pipeline for processing trade data!**