### PR TITLE
Remove Redundant Debug Logging and Adjust Test Expectations  

### DIFF
--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -50,7 +50,6 @@ public final class App {
         PCollection<byte[]> input = pipeline.apply("Read from Kafka", kafkaReadTransform);
 
         input
-            .apply("Print Contents", ParDo.of(new PrintBytesAsString()))
             .apply("Parse Trades", parseTrades);
 
         return pipeline;
@@ -59,14 +58,6 @@ public final class App {
     private void runPipeline(Pipeline pipeline) {
         buildPipeline(pipeline);
         pipeline.run();
-    }
-
-    private static class PrintBytesAsString extends DoFn<byte[], byte[]> {
-        @ProcessElement
-        public void processElement(@Element byte[] element, OutputReceiver<byte[]> receiver) {
-            System.out.println(new String(element));
-            receiver.output(element);
-        }
     }
 
     public static void main(String[] args) {

--- a/src/main/java/com/verlumen/tradestream/pipeline/container-structure-test.yaml
+++ b/src/main/java/com/verlumen/tradestream/pipeline/container-structure-test.yaml
@@ -6,5 +6,6 @@ commandTests:
     args:
       - '-jar'
       - '/src/main/java/com/verlumen/tradestream/pipeline/app_deploy.jar'
-      - "--runMode=dry"
-    expectedOutput: ["DRY/RUN"]
+      - '--runMode=dry'
+    expectedError:
+      - 'DRY/RUN'


### PR DESCRIPTION
This PR cleans up redundant debug logging within the **TradeStream pipeline** and updates test expectations to align with **expected error output behavior**.

---

### **Key Changes:**

1. **Removed `PrintBytesAsString` Transform**  
   - Previously used for logging raw Kafka messages before parsing.  
   - No longer needed as trade parsing is now the primary operation.  

2. **Updated Container Structure Test Expectations**  
   - **Changed `expectedOutput` → `expectedError`** to correctly match the new Flink error stream behavior.  
   - Ensures `"DRY/RUN"` appears in the expected error logs instead of standard output.  

---

### **Why This Change?**  
✅ **Eliminates unnecessary logging** – Avoids cluttering output logs.  
✅ **Improves pipeline efficiency** – Trade parsing now executes without intermediate logging.  
✅ **Fixes test validation** – Ensures container tests match expected Flink behavior.  

---

### **Next Steps:**  
- Verify **container test runs successfully** with updated error expectations.  
- Monitor trade parsing in **real-time deployment** to confirm expected behavior.  
- Continue **streamlining logs** for production readiness.  

🚀 **This cleanup improves the robustness and maintainability of the TradeStream pipeline!**