### PR TITLE
Migrate Data Ingestion to Use `tradeTopic` Instead of `candlePublisherTopic`

### DIFF
--- a/charts/tradestream/templates/data-ingestion.yaml
+++ b/charts/tradestream/templates/data-ingestion.yaml
@@ -22,9 +22,9 @@ spec:
       containers:
         - name: data-ingestion
           args:
-            - "--candlePublisherTopic={{ .Values.dataIngestion.candlePublisherTopic }}"
-            - "--runMode={{ .Values.dataIngestion.runMode }}"
             - "--kafka.bootstrap.servers={{ include "tradestream.fullname" . }}-kafka.{{ .Release.Namespace }}.svc.cluster.local:9092"
+            - "--runMode={{ .Values.dataIngestion.runMode }}"
+            - "--tradeTopic={{ .Values.dataIngestion.tradeTopic }}"
           image: "{{ .Values.dataIngestion.image.repository }}:{{ .Values.dataIngestion.image.tag }}"
           imagePullPolicy: {{ default "IfNotPresent" .Values.dataIngestion.image.pullPolicy }}
           ports:


### PR DESCRIPTION
This PR updates the **Data Ingestion Kubernetes configuration** to reflect the migration from **candle-based ingestion** to **trade-based ingestion**.  

---

### **Key Changes:**

1. **Removed `candlePublisherTopic` from Helm Chart**  
   - Data ingestion now **publishes trade data** instead of candles.  

2. **Introduced `tradeTopic` Configuration**  
   - `tradeTopic` is now passed as a command-line argument to the container.  

3. **Reordered Arguments for Clarity**  
   - Ensured `runMode` appears before `tradeTopic` for **better readability**.  

---

### **Why This Change?**  
✅ **Aligns with pipeline migration** – The system is now ingesting **trades instead of candles**.  
✅ **Ensures consistency** – Matches the `tradeTopic` parameter used in the **Flink-based pipeline**.  
✅ **Improves Helm Chart maintainability** – Keeps configurations **clear and relevant**.  

---

### **Next Steps:**  
- **Verify deployment in Kubernetes** with updated Helm values.  
- **Confirm trade ingestion works** correctly via Kafka topics.  
- **Remove any remaining candle references** in documentation or scripts.  

🚀 **This PR completes the transition to trade-based ingestion for Tradestream!**