### PR TITLE
Remove `CandlePublisher` from Real-Time Data Ingestion

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -274,7 +274,6 @@ java_library(
     srcs = ["RealTimeDataIngestionImpl.java"],
     deps = [
         ":candle_manager",
-        ":candle_publisher",
         ":currency_pair_supply",
         ":exchange_streaming_client",
         ":real_time_data_ingestion",

--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
@@ -18,7 +18,6 @@ final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
     private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
     private final CandleManager candleManager;
-    private final CandlePublisher candlePublisher;
     private final Provider<CurrencyPairSupply> currencyPairSupply;
     private final ExchangeStreamingClient exchangeClient;
     private final Provider<ThinMarketTimer> thinMarketTimer;
@@ -28,7 +27,6 @@ final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
     @Inject
     RealTimeDataIngestionImpl(
         CandleManager candleManager,
-        CandlePublisher candlePublisher,
         Provider<CurrencyPairSupply> currencyPairSupply,
         ExchangeStreamingClient exchangeClient,
         Provider<ThinMarketTimer> thinMarketTimer,
@@ -36,7 +34,6 @@ final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
         TradePublisher tradePublisher
     ) {
         this.candleManager = candleManager;
-        this.candlePublisher = candlePublisher;
         this.currencyPairSupply = currencyPairSupply;
         this.exchangeClient = exchangeClient;
         this.thinMarketTimer = thinMarketTimer;
@@ -68,7 +65,6 @@ final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
         logger.atInfo().log("Closing trade publisher...");
         try {
             tradePublisher.close();
-            candlePublisher.close();
             logger.atInfo().log("Successfully closed trade publisher");
         } catch (Exception e) {
             logger.atWarning().withCause(e).log("Error closing trade publisher");

--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -109,7 +109,6 @@ java_test(
     deps = [
         "//protos:marketdata_java_proto",
         "//src/main/java/com/verlumen/tradestream/ingestion:candle_manager",
-        "//src/main/java/com/verlumen/tradestream/ingestion:candle_publisher",
         "//src/main/java/com/verlumen/tradestream/ingestion:currency_pair_supply",
         "//src/main/java/com/verlumen/tradestream/ingestion:exchange_streaming_client",
         "//src/main/java/com/verlumen/tradestream/ingestion:thin_market_timer",

--- a/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
@@ -45,12 +45,11 @@ public class RealTimeDataIngestionImplTest {
     private static final String TEST_EXCHANGE = "test-exchange";
 
     @Mock @Bind private CandleManager mockCandleManager;
-    @Mock @Bind private CandlePublisher mockCandlePublisher;
     @Mock @Bind private CurrencyPairSupply mockCurrencyPairSupply;
     @Mock @Bind private ExchangeStreamingClient mockExchangeClient;
     @Mock @Bind private ThinMarketTimer mockThinMarketTimer;
     @Mock @Bind private TradeProcessor mockTradeProcessor;
-    @Mock @Bind private TradePublisher tradePublisher;
+    @Mock @Bind private TradePublisher mockTradePublisher;
 
     @Inject private RealTimeDataIngestionImpl realTimeDataIngestion;
 
@@ -92,14 +91,14 @@ public class RealTimeDataIngestionImplTest {
         // Assert
         verify(mockExchangeClient).stopStreaming();
         verify(mockThinMarketTimer).stop();
-        verify(mockCandlePublisher).close();
+        verify(mockTradePublisher).close();
     }
 
     @Test
-    public void shutdown_handlesCandlePublisherException() {
+    public void shutdown_handlesTradePublisherException() {
         // Arrange
         doThrow(new RuntimeException("Test exception"))
-            .when(mockCandlePublisher)
+            .when(mockTradePublisher)
             .close();
 
         // Act - Should not throw
@@ -175,7 +174,7 @@ public class RealTimeDataIngestionImplTest {
         // Assert - Shutdown correctly
         verify(mockExchangeClient).stopStreaming();
         verify(mockThinMarketTimer).stop();
-        verify(mockCandlePublisher).close();
+        verify(mockTradePublisher).close();
     }
 
     @Test


### PR DESCRIPTION
This PR **removes `CandlePublisher` from `RealTimeDataIngestionImpl`**, further streamlining **trade ingestion responsibilities** and shifting candle aggregation fully to the data pipeline.

---

### **Key Changes:**

1. **Removed `CandlePublisher` from `RealTimeDataIngestionImpl`**
   - **No longer publishing candles** from the ingestion layer.
   - Trades are **only published** to Kafka, **candle aggregation now occurs in the pipeline**.

2. **Updated `RealTimeDataIngestionImplTest`**
   - Removed `CandlePublisher` from mock dependencies.
   - **Assertions now verify `TradePublisher` behavior** instead.

3. **Updated `BUILD` Files**
   - **Removed `CandlePublisher` dependencies** in:
     - `src/main/java/com/verlumen/tradestream/ingestion/BUILD`
     - `src/test/java/com/verlumen/tradestream/ingestion/BUILD`
   - **Prevents compilation of unused code**.

---

### **Why This Change?**  
✅ **Completes migration of candle aggregation to the data pipeline.**  
✅ **Simplifies real-time ingestion** by keeping it focused solely on publishing trades.  
✅ **Ensures a more flexible and scalable architecture**.

---

### **Next Steps:**  
- **Monitor performance of the pipeline's candle aggregation.**  
- **Validate that the pipeline correctly generates candles from published trades.**  

🚀 **This finalizes the removal of `CandlePublisher` from real-time ingestion!**