### PR TITLE
Remove `CandleManager` from Real-Time Data Ingestion  

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -273,7 +273,6 @@ java_library(
     name = "real_time_data_ingestion_impl",
     srcs = ["RealTimeDataIngestionImpl.java"],
     deps = [
-        ":candle_manager",
         ":candle_publisher",
         ":currency_pair_supply",
         ":exchange_streaming_client",

--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
@@ -17,7 +17,6 @@ import com.verlumen.tradestream.marketdata.TradePublisher;
 final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
     private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
-    private final CandleManager candleManager;
     private final CandlePublisher candlePublisher;
     private final Provider<CurrencyPairSupply> currencyPairSupply;
     private final ExchangeStreamingClient exchangeClient;
@@ -27,7 +26,6 @@ final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
     
     @Inject
     RealTimeDataIngestionImpl(
-        CandleManager candleManager,
         CandlePublisher candlePublisher,
         Provider<CurrencyPairSupply> currencyPairSupply,
         ExchangeStreamingClient exchangeClient,
@@ -35,7 +33,6 @@ final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
         TradeProcessor tradeProcessor,
         TradePublisher tradePublisher
     ) {
-        this.candleManager = candleManager;
         this.candlePublisher = candlePublisher;
         this.currencyPairSupply = currencyPairSupply;
         this.exchangeClient = exchangeClient;
@@ -91,7 +88,6 @@ final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
                 trade.getPrice(),
                 trade.getVolume());
             tradePublisher.publishTrade(trade);
-            candleManager.processTrade(trade);
         } catch (RuntimeException e) {
             logger.atSevere().withCause(e).log(
                 "Error processing trade: %s", trade.getTradeId());

--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -108,7 +108,6 @@ java_test(
     srcs = ["RealTimeDataIngestionImplTest.java"],
     deps = [
         "//protos:marketdata_java_proto",
-        "//src/main/java/com/verlumen/tradestream/ingestion:candle_manager",
         "//src/main/java/com/verlumen/tradestream/ingestion:candle_publisher",
         "//src/main/java/com/verlumen/tradestream/ingestion:currency_pair_supply",
         "//src/main/java/com/verlumen/tradestream/ingestion:exchange_streaming_client",

--- a/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
@@ -44,13 +44,12 @@ public class RealTimeDataIngestionImplTest {
             .build();
     private static final String TEST_EXCHANGE = "test-exchange";
 
-    @Mock @Bind private CandleManager mockCandleManager;
     @Mock @Bind private CandlePublisher mockCandlePublisher;
     @Mock @Bind private CurrencyPairSupply mockCurrencyPairSupply;
     @Mock @Bind private ExchangeStreamingClient mockExchangeClient;
     @Mock @Bind private ThinMarketTimer mockThinMarketTimer;
     @Mock @Bind private TradeProcessor mockTradeProcessor;
-    @Mock @Bind private TradePublisher tradePublisher;
+    @Mock @Bind private TradePublisher mockTradePublisher;
 
     @Inject private RealTimeDataIngestionImpl realTimeDataIngestion;
 
@@ -132,7 +131,7 @@ public class RealTimeDataIngestionImplTest {
         handlerCaptor.getValue().accept(trade);
 
         // Assert
-        verify(mockCandleManager).processTrade(trade);
+        verify(mockTradePublisher).publishTrade(trade);
     }
 
     @Test
@@ -157,7 +156,7 @@ public class RealTimeDataIngestionImplTest {
         handlerCaptor.getValue().accept(trade);
 
         // Assert
-        verify(mockCandleManager, never()).processTrade(trade);
+        verify(mockTradePublisher, never()).publishTrade(trade);
     }
 
     @Test
@@ -199,6 +198,6 @@ public class RealTimeDataIngestionImplTest {
         handlerCaptor.getValue().accept(trade);
 
         // Assert
-        verify(mockCandleManager, never()).processTrade(any());
+        verify(mockTradePublisher, never()).publishTrade(any());
     }
 }


### PR DESCRIPTION
This PR **removes `CandleManager` from `RealTimeDataIngestionImpl`**, transitioning **candle aggregation responsibilities** to the pipeline.  

---

### **Key Changes:**

1. **Removed `CandleManager` from `RealTimeDataIngestionImpl`**
   - Eliminates direct candle processing from ingestion logic.  
   - **Trades are now only published**, allowing downstream services to handle aggregation.

2. **Updated `RealTimeDataIngestionImplTest`**
   - **Replaced `CandleManager` assertions** with `TradePublisher`.  
   - Ensures **trade publication is still validated**.

3. **Updated `BUILD` Files**
   - **Removed `CandleManager` dependencies** in:
     - `src/main/java/com/verlumen/tradestream/ingestion/BUILD`
     - `src/test/java/com/verlumen/tradestream/ingestion/BUILD`
   - Prevents unnecessary compilation of unused code.

---

### **Why This Change?**  
✅ **Decouples trade ingestion from candle generation**  
✅ **Streamlines real-time ingestion logic** by focusing on trade processing  
✅ **Improves pipeline flexibility** by centralizing candle aggregation  

---

### **Next Steps:**  
- Ensure the **pipeline correctly aggregates trades into candles**.  
- **Monitor system performance** for any latency introduced by the new design.  

🚀 **This completes the removal of `CandleManager` from trade ingestion!**