### PR TITLE
Remove `TradeProcessor` from `RealTimeDataIngestionImpl`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -279,7 +279,6 @@ java_library(
         ":exchange_streaming_client",
         ":real_time_data_ingestion",
         ":thin_market_timer",
-        ":trade_processor",
         "//protos:marketdata_java_proto",
         "//src/main/java/com/verlumen/tradestream/instruments:currency_pair",
         "//src/main/java/com/verlumen/tradestream/marketdata:trade_publisher",

--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
@@ -22,7 +22,6 @@ final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
     private final Provider<CurrencyPairSupply> currencyPairSupply;
     private final ExchangeStreamingClient exchangeClient;
     private final Provider<ThinMarketTimer> thinMarketTimer;
-    private final TradeProcessor tradeProcessor;
     private final TradePublisher tradePublisher;
     
     @Inject
@@ -32,7 +31,6 @@ final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
         Provider<CurrencyPairSupply> currencyPairSupply,
         ExchangeStreamingClient exchangeClient,
         Provider<ThinMarketTimer> thinMarketTimer,
-        TradeProcessor tradeProcessor,
         TradePublisher tradePublisher
     ) {
         this.candleManager = candleManager;
@@ -40,7 +38,6 @@ final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
         this.currencyPairSupply = currencyPairSupply;
         this.exchangeClient = exchangeClient;
         this.thinMarketTimer = thinMarketTimer;
-        this.tradeProcessor = tradeProcessor;
         this.tradePublisher = tradePublisher;
     }
 
@@ -79,12 +76,6 @@ final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
 
     private void processTrade(Trade trade) {
         try {
-            if (tradeProcessor.isProcessed(trade)) {
-                logger.atInfo().log("Skipping duplicate trade for %s: ID=%s",
-                    trade.getCurrencyPair(),
-                    trade.getTradeId());
-                return;
-            }
             logger.atInfo().log("Processing new trade for %s: ID=%s, price=%f, volume=%f", 
                 trade.getCurrencyPair(), 
                 trade.getTradeId(),

--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -113,7 +113,6 @@ java_test(
         "//src/main/java/com/verlumen/tradestream/ingestion:currency_pair_supply",
         "//src/main/java/com/verlumen/tradestream/ingestion:exchange_streaming_client",
         "//src/main/java/com/verlumen/tradestream/ingestion:thin_market_timer",
-        "//src/main/java/com/verlumen/tradestream/ingestion:trade_processor",
         "//src/main/java/com/verlumen/tradestream/ingestion:real_time_data_ingestion_impl",
         "//src/main/java/com/verlumen/tradestream/instruments:currency_pair",
         "//src/main/java/com/verlumen/tradestream/marketdata:trade_publisher",


### PR DESCRIPTION
This PR **removes the `TradeProcessor` dependency** from `RealTimeDataIngestionImpl`, simplifying the trade ingestion process by eliminating the duplicate trade check.

---

### **Key Changes:**
✅ **Removed `TradeProcessor`** from:
  - **`RealTimeDataIngestionImpl`** (constructor, `processTrade` method).
  - **Tests (`RealTimeDataIngestionImplTest`)** related to trade deduplication.
  - **`BUILD` files** to clean up unused dependencies.

---

### **Why This Change?**
📉 **Reduces latency**—Previously, each trade was checked for duplication before publishing, adding unnecessary overhead.  
🚀 **Improves scalability**—Trade ingestion now handles trades directly without coordination delays.  
✅ **Simplifies the architecture**—We now assume the Kafka consumer or downstream services handle deduplication.  

---

### **Next Steps:**
1. **Verify trade deduplication logic in downstream consumers.**  
2. **Monitor performance improvements after deployment.**  

🎯 **Moving towards a more efficient, real-time trade ingestion pipeline!**