### PR TITLE
Remove Redundant Trade Processing Log Statement in `RealTimeDataIngestionImpl`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
@@ -85,11 +85,6 @@ final class RealTimeDataIngestionImpl implements RealTimeDataIngestion {
                     trade.getTradeId());
                 return;
             }
-            logger.atInfo().log("Processing new trade for %s: ID=%s, price=%f, volume=%f", 
-                trade.getCurrencyPair(), 
-                trade.getTradeId(),
-                trade.getPrice(),
-                trade.getVolume());
             tradePublisher.publishTrade(trade);
             candleManager.processTrade(trade);
         } catch (RuntimeException e) {


### PR DESCRIPTION
This PR **removes a redundant logging statement** in `RealTimeDataIngestionImpl` that logs every trade before publishing. Since trade processing is already well-monitored by **downstream logging and metrics**, this log statement is **unnecessary and adds noise**.

---

### **Key Change:**
- **Removed the `Processing new trade` log statement**
  - Trades are **already logged** when they are **published** and **processed by the pipeline**.
  - Reduces **log clutter** in high-frequency trading environments.

---

### **Why This Change?**  
✅ **Reduces redundant logs**, improving **log signal-to-noise ratio**.  
✅ **Enhances system performance** by avoiding unnecessary logging overhead.  
✅ **Ensures cleaner logs** that focus on actionable errors and insights.

---

### **Next Steps:**  
- Monitor logs to confirm that **critical trade processing logs remain intact**.  
- Ensure **no loss of necessary trade visibility** in debugging scenarios.  

🚀 **A small but effective cleanup for better log clarity and performance!**