### PR TITLE
Remove Unused Timer Binding from `IngestionModule`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -9,7 +9,6 @@ import com.verlumen.tradestream.http.HttpModule;
 import com.verlumen.tradestream.kafka.KafkaModule;
 import com.verlumen.tradestream.marketdata.MarketDataConfig;
 import com.verlumen.tradestream.marketdata.MarketDataModule;
-import java.util.Timer;
 
 @AutoValue
 abstract class IngestionModule extends AbstractModule {
@@ -24,7 +23,6 @@ abstract class IngestionModule extends AbstractModule {
     bind(CurrencyPairSupply.class).toProvider(CurrencyPairSupplyProvider.class);
     bind(ExchangeStreamingClient.Factory.class).to(ExchangeStreamingClientFactory.class);
     bind(RealTimeDataIngestion.class).to(RealTimeDataIngestionImpl.class);
-    bind(Timer.class).toProvider(Timer::new);
 
     install(
         new FactoryModuleBuilder()


### PR DESCRIPTION
This PR **removes an unused `Timer` binding** from `IngestionModule` to clean up unnecessary dependencies.

---

### **Changes:**
✅ **Deleted `import java.util.Timer;`** – The `Timer` class was imported but never used.  
✅ **Removed `bind(Timer.class).toProvider(Timer::new);`** – The module no longer binds `Timer` as it was **unused**.

---

### **Why This Change?**
🔹 **Reduces unnecessary dependencies**—Avoids binding objects that are not actually used.  
🔹 **Improves maintainability**—Keeps `IngestionModule` clean and focused on essential dependencies.  
🔹 **Prevents potential confusion**—Future developers won’t assume that `Timer` is required.

---

### **Next Steps:**
1. **Verify module functionality remains unchanged.**  
2. **Confirm no other parts of the codebase rely on this `Timer` binding.**  

🚀 **Leaner, cleaner dependency management!**