### PR TITLE
Remove `MarketDataConfig` Dependency from Ingestion Module

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -171,7 +171,6 @@ java_library(
         ":exchange_streaming_client",
         ":exchange_streaming_client_factory",
         ":ingestion_config",
-        ":market_data_config",
         ":real_time_data_ingestion",
         ":real_time_data_ingestion_impl",
         ":trade_processor",

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -177,7 +177,6 @@ java_library(
         "//src/main/java/com/verlumen/tradestream/execution:run_mode",
         "//src/main/java/com/verlumen/tradestream/http:http_module",
         "//src/main/java/com/verlumen/tradestream/kafka:kafka_module",
-        "//src/main/java/com/verlumen/tradestream/marketdata:market_data_config",
         "//src/main/java/com/verlumen/tradestream/marketdata:market_data_module",
         "//third_party:auto_value",
         "//third_party:guava",

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -171,6 +171,7 @@ java_library(
         ":exchange_streaming_client",
         ":exchange_streaming_client_factory",
         ":ingestion_config",
+        ":market_data_config",
         ":real_time_data_ingestion",
         ":real_time_data_ingestion_impl",
         ":trade_processor",

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -25,7 +25,7 @@ abstract class IngestionModule extends AbstractModule {
 
     install(HttpModule.create());
     install(KafkaModule.create(ingestionConfig().kafkaBootstrapServers()));
-    install(MarketDataModule.create(MarketDataConfig.create(ingestionConfig().tradeTopic())));
+    install(MarketDataModule.create(ingestionConfig().tradeTopic()));
   }
 
   @Provides

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -6,7 +6,6 @@ import com.google.inject.Provides;
 import com.verlumen.tradestream.execution.RunMode;
 import com.verlumen.tradestream.http.HttpModule;
 import com.verlumen.tradestream.kafka.KafkaModule;
-import com.verlumen.tradestream.marketdata.MarketDataConfig;
 import com.verlumen.tradestream.marketdata.MarketDataModule;
 
 @AutoValue

--- a/src/main/java/com/verlumen/tradestream/marketdata/MarketDataModule.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/MarketDataModule.java
@@ -7,8 +7,8 @@ import com.google.inject.assistedinject.FactoryModuleBuilder;
 
 @AutoValue
 public abstract class MarketDataModule extends AbstractModule {
-  public static MarketDataModule create(MarketDataConfig config) {
-    return new AutoValue_MarketDataModule(config);
+  public static MarketDataModule create(String tradeTopic) {
+    return new AutoValue_MarketDataModule(MarketDataConfig.create(tradeTopic));
   }
 
   abstract MarketDataConfig config();


### PR DESCRIPTION
- **Removed `market_data_config` dependency** from `BUILD` as it's no longer required.  
- **Refactored `MarketDataModule.create()`** to accept `tradeTopic` directly instead of `MarketDataConfig`.  
- **Updated `IngestionModule`** to pass `tradeTopic` directly, simplifying configuration.  
- This change **streamlines initialization** by reducing unnecessary dependencies.