### PR TITLE
Remove `candlePublisherTopic` from Helm Chart Values  

### DIFF
--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -20,7 +20,6 @@ kafkaUi:
     type: ClusterIP
     port: 8080
 dataIngestion:
-  candlePublisherTopic: candles
   runMode: wet
   replicaCount: 1
   image:
@@ -28,6 +27,7 @@ dataIngestion:
     tag: v0.0.659-develop
   service:
     port: 8080
+  tradeTopic: trades
 pipeline:
   runMode: wet
   image:


### PR DESCRIPTION
 - **Removed `candlePublisherTopic`** from `values.yaml` as it is no longer needed.  
- **Added `tradeTopic`** under `dataIngestion` to ensure the correct topic is referenced.  
- This change **aligns the Helm chart configuration** with the recent refactoring in the ingestion module.