### PR TITLE
Remove `candleIntervalMillis` from Ingestion Configuration

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/App.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/App.java
@@ -55,7 +55,6 @@ final class App {
       String coinMarketCapApiKey = namespace.getString("coinmarketcap.apiKey");
       int topNCryptocurrencies = namespace.getInt("coinmarketcap.topN");
       String exchangeName = namespace.getString("exchangeName");
-      long candleIntervalMillis = namespace.getInt("candleIntervalSeconds") * 1000L;
       String runModeName = namespace.getString("runMode").toUpperCase();
       RunMode runMode = RunMode.valueOf(runModeName);
       IngestionConfig ingestionConfig =
@@ -63,7 +62,6 @@ final class App {
               coinMarketCapApiKey,
               topNCryptocurrencies,
               exchangeName,
-              candleIntervalMillis,
               runMode,
               namespace.getString("kafka.bootstrap.servers"),
               namespace.getString("tradeTopic"));
@@ -82,12 +80,6 @@ final class App {
       .build()
       .defaultHelp(true)
       .description("Configuration for Kafka producer and exchange settings");
-
-    // Existing arguments
-    parser.addArgument("--candleIntervalSeconds")
-      .type(Integer.class)
-      .setDefault(60)
-      .help("Candle interval in seconds");
 
     // Exchange configuration
     parser.addArgument("--exchangeName")

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionConfig.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionConfig.java
@@ -6,7 +6,6 @@ record IngestionConfig(
     String coinMarketCapApiKey,
     int topCryptocurrencyCount,
     String exchangeName,
-    long candleIntervalMillis,
     RunMode runMode,
     String kafkaBootstrapServers,
     String tradeTopic) {}


### PR DESCRIPTION
- **Removed `candleIntervalMillis` from `IngestionConfig`** as it is no longer needed.  
- **Deleted `--candleIntervalSeconds` argument** from CLI options in `App.java`.  
- **Updated `IngestionConfig` constructor** to exclude the redundant field.  
- This simplifies the ingestion configuration by eliminating an unused parameter.