### PR TITLE
Improve Trade Ingestion with Blocking Queue and Background Processing  

### DIFF
--- a/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
@@ -99,25 +99,25 @@ public class RealTimeDataIngestionImplTest {
 
     @Test
     public void processTrade_handlesNewTrade() {
-        // Arrange
-        ArgumentCaptor<Consumer<Trade>> handlerCaptor = 
+        // Arrange: Capture the consumer provided to startStreaming.
+        ArgumentCaptor<Consumer<Trade>> handlerCaptor =
             ArgumentCaptor.forClass(Consumer.class);
-        
+
         realTimeDataIngestion.start();
         verify(mockExchangeClient).startStreaming(any(), handlerCaptor.capture());
-        
+
         Trade trade = Trade.newBuilder()
             .setTradeId("test-trade")
             .setCurrencyPair("BTC/USD")
             .setPrice(50000.0)
             .setVolume(1.0)
             .build();
-        
-        // Act
+
+        // Act: Enqueue the trade.
         handlerCaptor.getValue().accept(trade);
 
-        // Assert
-        verify(mockTradePublisher).publishTrade(trade);
+        // Assert: Wait up to 1 second for the background thread to publish the trade.
+        verify(mockTradePublisher, timeout(1000)).publishTrade(trade);
     }
 
     @Test

--- a/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
@@ -1,6 +1,5 @@
 package com.verlumen.tradestream.ingestion;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -13,6 +12,9 @@ import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import com.verlumen.tradestream.instruments.CurrencyPair;
 import com.verlumen.tradestream.marketdata.Trade;
 import com.verlumen.tradestream.marketdata.TradePublisher;
+import java.lang.reflect.Field;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import org.junit.Before;
@@ -32,11 +34,11 @@ public class RealTimeDataIngestionImplTest {
     private static final ImmutableList<CurrencyPair> SUPPORTED_CURRENCY_PAIRS = 
         Stream.of("BTC/USD", "ETH/USD")
             .map(CurrencyPair::fromSymbol)
-            .collect(toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     private static final ImmutableList<CurrencyPair> UNSUPPORTED_CURRENCY_PAIRS = 
         Stream.of("ETH/USD", "DOGE/USD")
             .map(CurrencyPair::fromSymbol)
-            .collect(toImmutableList());
+            .collect(ImmutableList.toImmutableList());
     private static final ImmutableList<CurrencyPair> TEST_CURRENCY_PAIRS = 
         ImmutableList.<CurrencyPair>builder()
             .addAll(SUPPORTED_CURRENCY_PAIRS)
@@ -132,5 +134,28 @@ public class RealTimeDataIngestionImplTest {
         // Assert - Shutdown correctly
         verify(mockExchangeClient).stopStreaming();
         verify(mockTradePublisher).close();
+    }
+
+    @Test
+    public void backgroundThread_runsUntilShutdown() throws Exception {
+        // Act - Start the ingestion service.
+        realTimeDataIngestion.start();
+
+        // Use reflection to get the private 'tradePublisherExecutor' field.
+        Field executorField = RealTimeDataIngestionImpl.class.getDeclaredField("tradePublisherExecutor");
+        executorField.setAccessible(true);
+        ExecutorService executorService = (ExecutorService) executorField.get(realTimeDataIngestion);
+
+        // Assert that the executor is not null and is still running.
+        assertThat(executorService).isNotNull();
+        assertThat(executorService.isShutdown()).isFalse();
+
+        // Call shutdown on the ingestion service.
+        realTimeDataIngestion.shutdown();
+
+        // Wait a bit to allow shutdown to complete.
+        boolean terminated = executorService.awaitTermination(5, TimeUnit.SECONDS);
+        assertThat(terminated).isTrue();
+        assertThat(executorService.isShutdown()).isTrue();
     }
 }


### PR DESCRIPTION
This PR enhances the **real-time data ingestion** in `RealTimeDataIngestionImpl` by introducing a **blocking queue** and a **dedicated background thread** for publishing trades. Instead of publishing trades directly from the exchange client callback, trades are now enqueued and processed asynchronously in a separate executor service.  

#### **Key Changes**  
✅ **Introduced a `BlockingQueue<Trade>`** to store incoming trades before publishing.  
✅ **Added a single-threaded executor (`tradePublisherExecutor`)** to process trades from the queue.  
✅ **Updated `start()` method** to queue trades instead of publishing them immediately.  
✅ **Implemented a background task using `Stream.generate()`** to continuously take trades from the queue and publish them.  
✅ **Ensured proper shutdown handling** by stopping the executor and waiting for termination.  

#### **Test Enhancements**  
✅ **Updated `processTrade_handlesNewTrade()`** to wait for trade processing in the background.  
✅ **Added `backgroundThread_runsUntilShutdown()`** to verify that the background executor runs correctly and shuts down as expected.  

This change improves **scalability** and **resilience** by ensuring that trade processing is **decoupled from the streaming client**, preventing slowdowns or missed trades under heavy load. 🚀