### PR TITLE
Cleanup `App.java` in TradeStream Pipeline

### DIFF
--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -63,7 +63,8 @@ public final class App {
 
   public static void main(String[] args) {
     // Parse custom options
-    var options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
+    var options =
+        PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
 
     // Convert to FlinkPipelineOptions and set required properties
     FlinkPipelineOptions flinkOptions = options.as(FlinkPipelineOptions.class);

--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -2,9 +2,7 @@ package com.verlumen.tradestream.pipeline;
 
 import com.google.inject.Guice;
 import com.google.inject.Inject;
-import com.google.protobuf.InvalidProtocolBufferException;
 import com.verlumen.tradestream.kafka.KafkaReadTransform;
-import com.verlumen.tradestream.marketdata.Candle;
 import com.verlumen.tradestream.marketdata.CreateCandles;
 import com.verlumen.tradestream.marketdata.ParseTrades;
 import org.apache.beam.runners.flink.FlinkPipelineOptions;
@@ -13,28 +11,26 @@ import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.options.StreamingOptions;
-import org.apache.beam.sdk.transforms.MapElements;
-import org.apache.beam.sdk.transforms.ParDo;
-import org.apache.beam.sdk.transforms.DoFn;
-import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.TypeDescriptors;
 
 public final class App {
     public interface Options extends StreamingOptions {
         @Description("Comma-separated list of Kafka bootstrap servers.")
-        @Default.String("localhost:9092") 
+        @Default.String("localhost:9092")
         String getBootstrapServers();
+
         void setBootstrapServers(String value);
 
         @Description("Kafka topic to read trade data from.")
         @Default.String("trades")
         String getTradeTopic();
+
         void setTradeTopic(String value);
 
         @Description("Run mode: wet or dry.")
         @Default.String("wet")
         String getRunMode();
+
         void setRunMode(String value);
     }
 
@@ -54,8 +50,7 @@ public final class App {
     private Pipeline buildPipeline(Pipeline pipeline) {
         PCollection<byte[]> input = pipeline.apply("Read from Kafka", kafkaReadTransform);
 
-        input
-            .apply("Parse Trades", parseTrades);
+        input.apply("Parse Trades", parseTrades);
 
         return pipeline;
     }


### PR DESCRIPTION
- **Removed unused imports** (e.g., `InvalidProtocolBufferException`, `Candle`).  
- **Refactored formatting** for better readability and consistency.  
- **Simplified pipeline transformation** by directly applying `ParseTrades`.  
- **No functional changes**, just cleanup and minor code style improvements.