### PR TITLE
Adjust Allowed Timestamp Skew for Late Arriving Trades  

### DIFF
--- a/src/main/java/com/verlumen/tradestream/pipeline/PipelineConfig.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/PipelineConfig.java
@@ -9,11 +9,11 @@ record PipelineConfig(
   Duration allowedLateness,
   Duration windowDuration,
   Duration allowedTimestampSkew) {
+  private static final Duration FIVE_MINUTES = Duration.standardMinutes(5);
   private static final Duration FIVE_SECONDS = Duration.standardSeconds(5);
-  private static final Duration ONE_MINUTE = Duration.standardMinutes(1);
   private static final Duration ONE_SECOND = Duration.standardSeconds(1);
 
   static PipelineConfig create(String bootstrapServers, String tradeTopic, String runMode) {
-    return new PipelineConfig(bootstrapServers, tradeTopic, runMode, FIVE_SECONDS, ONE_MINUTE, ONE_SECOND);
+    return new PipelineConfig(bootstrapServers, tradeTopic, runMode, FIVE_SECONDS, ONE_MINUTE, FIVE_MINUTES);
   }
 }


### PR DESCRIPTION
- **Increased `allowedTimestampSkew`** from **1 second to 5 minutes** to accommodate late-arriving trades.  
- **Refactored duration constants** for better clarity and maintainability.  
- **Ensures more accurate trade aggregation** by reducing data loss due to minor delays in trade ingestion.