### PR TITLE
Create DefaultTradeGenerator.java

### DIFF
--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -20,8 +20,9 @@ java_library(
     name = "default_trade_generator",
     srcs = ["DefaultTradeGenerator.java"],
     deps = [
+        "//protos:marketdata_java_proto",
         "//third_party:beam_sdks_java_core",
-        "//third_party:protobuf_java",
+        "//third_party:beam_sdks_java_extensions_protobuf",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -20,9 +20,11 @@ java_library(
     name = "default_trade_generator",
     srcs = ["DefaultTradeGenerator.java"],
     deps = [
-        "//protos:marketdata_java_proto",
-        "//third_party:beam_sdks_java_core",
-        "//third_party:beam_sdks_java_extensions_protobuf",
+      "//protos:marketdata_java_proto",
+      "//third_party:beam_sdks_java_core",
+      "//third_party:beam_sdks_java_extensions_protobuf",
+      "//third_party:joda_time",
+      "//third_party:protobuf_java",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -25,6 +25,7 @@ java_library(
       "//third_party:beam_sdks_java_extensions_protobuf",
       "//third_party:joda_time",
       "//third_party:protobuf_java",
+      "//third_party:protobuf_java_util",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -17,6 +17,15 @@ java_library(
 )
 
 java_library(
+    name = "default_trade_generator",
+    srcs = ["DefaultTradeGenerator.java"],
+    deps = [
+        "//third_party:beam_sdks_java_core",
+        "//third_party:protobuf_java",
+    ],
+)
+
+java_library(
   name = "last_candles_fn",
   srcs = ["LastCandlesFn.java"],
   deps = [

--- a/src/main/java/com/verlumen/tradestream/marketdata/DefaultTradeGenerator.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/DefaultTradeGenerator.java
@@ -1,6 +1,5 @@
 package com.verlumen.tradestream.marketdata;
 
-import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -39,7 +38,8 @@ public class DefaultTradeGenerator extends PTransform<PCollection<KV<String, Voi
         public void processElement(@Element KV<String, Void> element, OutputReceiver<KV<String, Trade>> out) {
             String key = element.getKey();  // Expecting a key like "BTC/USD"
             Instant now = Instant.now();
-            Timestamp ts = Timestamps.fromMillis(now.getMillis());
+            // Fully qualify the Timestamp to ensure we use the protobuf type.
+            com.google.protobuf.Timestamp ts = Timestamps.fromMillis(now.getMillis());
             Trade trade = Trade.newBuilder()
                     .setTimestamp(ts)
                     .setExchange("DEFAULT")

--- a/src/main/java/com/verlumen/tradestream/marketdata/DefaultTradeGenerator.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/DefaultTradeGenerator.java
@@ -1,0 +1,58 @@
+package com.verlumen.tradestream.marketdata;
+
+import com.google.protobuf.Timestamp;
+import com.verlumen.tradestream.marketdata.Trade;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.joda.time.Instant;
+import java.math.BigDecimal;
+
+/**
+ * DefaultTradeGenerator generates synthetic Trade messages for a given key.
+ * The generated trade has zero volume and uses a default price.
+ */
+public class DefaultTradeGenerator extends PTransform<PCollection<KV<String, Void>>, PCollection<KV<String, Trade>>> {
+
+    private final BigDecimal defaultPrice;
+
+    public DefaultTradeGenerator(BigDecimal defaultPrice) {
+        this.defaultPrice = defaultPrice;
+    }
+
+    @Override
+    public PCollection<KV<String, Trade>> expand(PCollection<KV<String, Void>> input) {
+        return input.apply("GenerateDefaultTrades", ParDo.of(new DefaultTradeGeneratorFn(defaultPrice)));
+    }
+
+    public static class DefaultTradeGeneratorFn extends DoFn<KV<String, Void>, KV<String, Trade>> {
+        private final BigDecimal defaultPrice;
+
+        public DefaultTradeGeneratorFn(BigDecimal defaultPrice) {
+            this.defaultPrice = defaultPrice;
+        }
+
+        @ProcessElement
+        public void processElement(@Element KV<String, Void> element, OutputReceiver<KV<String, Trade>> out) {
+            String key = element.getKey();
+            String[] parts = key.split("/");
+            CurrencyPair pair = CurrencyPair.newBuilder()
+                    .setBase(parts[0])
+                    .setQuote(parts[1])
+                    .build();
+            Instant now = Instant.now();
+            Timestamp ts = Timestamp.newBuilder().setSeconds(now.getMillis() / 1000).build();
+            Trade trade = Trade.newBuilder()
+                    .setTimestamp(ts)
+                    .setExchange("DEFAULT")
+                    .setCurrencyPair(pair)
+                    .setPrice(defaultPrice)
+                    .setVolume(BigDecimal.ZERO)
+                    .setTradeId("DEFAULT-" + key + "-" + now.getMillis())
+                    .build();
+            out.output(KV.of(key, trade));
+        }
+    }
+}

--- a/src/main/java/com/verlumen/tradestream/marketdata/DefaultTradeGenerator.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/DefaultTradeGenerator.java
@@ -1,6 +1,7 @@
 package com.verlumen.tradestream.marketdata;
 
 import com.google.protobuf.Timestamp;
+import com.google.protobuf.util.Timestamps;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;

--- a/src/main/java/com/verlumen/tradestream/marketdata/DefaultTradeGenerator.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/DefaultTradeGenerator.java
@@ -37,9 +37,8 @@ public class DefaultTradeGenerator extends PTransform<PCollection<KV<String, Voi
         @ProcessElement
         public void processElement(@Element KV<String, Void> element, OutputReceiver<KV<String, Trade>> out) {
             String key = element.getKey();  // Expecting a key like "BTC/USD"
-            // Use the key itself as the currency pair string.
             Instant now = Instant.now();
-            Timestamp ts = Timestamp.newBuilder().setSeconds(now.getMillis() / 1000).build();
+            Timestamp ts = Timestamps.fromMillis(now.getMillis());
             Trade trade = Trade.newBuilder()
                     .setTimestamp(ts)
                     .setExchange("DEFAULT")

--- a/src/test/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/test/java/com/verlumen/tradestream/marketdata/BUILD
@@ -27,6 +27,7 @@ java_test(
     name = "DefaultTradeGeneratorTest",
     srcs = ["DefaultTradeGeneratorTest.java"],
     deps = [
+        "//protos:marketdata_java_proto",
         "//src/main/java/com/verlumen/tradestream/marketdata:default_trade_generator",
         "//third_party:beam_sdks_java_core",
         "//third_party:beam_sdks_java_extensions_protobuf",

--- a/src/test/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/test/java/com/verlumen/tradestream/marketdata/BUILD
@@ -31,6 +31,10 @@ java_test(
         "//third_party:beam_sdk",
         "//third_party:junit",
     ],
+    runtime_deps = [
+        "//third_party:beam_runners_direct_java",
+        "//third_party:hamcrest",
+    ],
 )
 
 java_test(

--- a/src/test/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/test/java/com/verlumen/tradestream/marketdata/BUILD
@@ -29,6 +29,7 @@ java_test(
     deps = [
         "//src/main/java/com/verlumen/tradestream/marketdata:default_trade_generator",
         "//third_party:beam_sdks_java_core",
+        "//third_party:beam_sdks_java_extensions_protobuf",
         "//third_party:junit",
     ],
     runtime_deps = [

--- a/src/test/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/test/java/com/verlumen/tradestream/marketdata/BUILD
@@ -22,6 +22,17 @@ java_test(
     ],
 )
 
+
+java_test(
+    name = "DefaultTradeGeneratorTest",
+    srcs = ["DefaultTradeGeneratorTest.java"],
+    deps = [
+        "//src/main/java/com/verlumen/tradestream/marketdata:default_trade_generator",
+        "//third_party:beam_sdk",
+        "//third_party:junit",
+    ],
+)
+
 java_test(
     name = "LastCandlesFnTest",
     srcs = ["LastCandlesFnTest.java"],

--- a/src/test/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/test/java/com/verlumen/tradestream/marketdata/BUILD
@@ -28,7 +28,7 @@ java_test(
     srcs = ["DefaultTradeGeneratorTest.java"],
     deps = [
         "//src/main/java/com/verlumen/tradestream/marketdata:default_trade_generator",
-        "//third_party:beam_sdk",
+        "//third_party:beam_sdks_java_core",
         "//third_party:junit",
     ],
     runtime_deps = [

--- a/src/test/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/test/java/com/verlumen/tradestream/marketdata/BUILD
@@ -30,7 +30,9 @@ java_test(
         "//src/main/java/com/verlumen/tradestream/marketdata:default_trade_generator",
         "//third_party:beam_sdks_java_core",
         "//third_party:beam_sdks_java_extensions_protobuf",
+        "//third_party:joda_time",
         "//third_party:junit",
+        "//third_party:protobuf_java",
     ],
     runtime_deps = [
         "//third_party:beam_runners_direct_java",

--- a/src/test/java/com/verlumen/tradestream/marketdata/DefaultTradeGeneratorTest.java
+++ b/src/test/java/com/verlumen/tradestream/marketdata/DefaultTradeGeneratorTest.java
@@ -39,7 +39,7 @@ public class DefaultTradeGeneratorTest {
             assertEquals(0.0, trade.getVolume(), 1e-6);
             // Since the key is used directly as the currency pair, we expect:
             assertEquals("BTC/USD", trade.getCurrencyPair());
-            return iterable;
+            return null;
         });
         pipeline.run().waitUntilFinish();
     }
@@ -63,7 +63,7 @@ public class DefaultTradeGeneratorTest {
             assertEquals(defaultPrice, trade.getPrice(), 1e-6);
             assertEquals(0.0, trade.getVolume(), 1e-6);
             assertEquals("ETH/USD", trade.getCurrencyPair());
-            return iterable;
+            return null;
         });
         pipeline.run().waitUntilFinish();
     }
@@ -83,7 +83,7 @@ public class DefaultTradeGeneratorTest {
             assertEquals(key, kv.getKey());
             Trade trade = kv.getValue();
             assertEquals(customDefaultPrice, trade.getPrice(), 1e-6);
-            return iterable;
+            return null;
         });
         pipeline.run().waitUntilFinish();
     }

--- a/src/test/java/com/verlumen/tradestream/marketdata/DefaultTradeGeneratorTest.java
+++ b/src/test/java/com/verlumen/tradestream/marketdata/DefaultTradeGeneratorTest.java
@@ -1,0 +1,90 @@
+package com.verlumen.tradestream.marketdata;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.verlumen.tradestream.marketdata.Trade;
+import com.verlumen.tradestream.marketdata.CurrencyPair;
+import java.math.BigDecimal;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.values.KV;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class DefaultTradeGeneratorTest {
+
+    @Rule 
+    public final TestPipeline pipeline = TestPipeline.create();
+
+    @Test
+    public void testGenerateDefaultTrade() {
+        // Arrange
+        String key = "BTC/USD";
+        BigDecimal defaultPrice = new BigDecimal("10000");
+
+        // Act & Assert
+        PAssert.that(
+            pipeline.apply(Create.of(KV.of(key, (Void) null)))
+                    .apply(new DefaultTradeGenerator(defaultPrice)))
+        ).satisfies(iterable -> {
+            KV<String, Trade> kv = iterable.iterator().next();
+            assertEquals(key, kv.getKey());
+            Trade trade = kv.getValue();
+            assertTrue(trade.getTradeId().startsWith("DEFAULT-"));
+            assertEquals(defaultPrice, trade.getPrice());
+            assertEquals(BigDecimal.ZERO, trade.getVolume());
+            assertEquals("DEFAULT", trade.getExchange());
+            assertEquals("BTC", trade.getCurrencyPair().getBase());
+            assertEquals("USD", trade.getCurrencyPair().getQuote());
+            return iterable;
+        });
+        pipeline.run().waitUntilFinish();
+    }
+
+    @Test
+    public void testGenerateDefaultTradeDifferentKey() {
+        // Arrange
+        String key = "ETH/USD";
+        BigDecimal defaultPrice = new BigDecimal("10000");
+
+        // Act & Assert
+        PAssert.that(
+            pipeline.apply(Create.of(KV.of(key, (Void) null)))
+                    .apply(new DefaultTradeGenerator(defaultPrice)))
+        ).satisfies(iterable -> {
+            KV<String, Trade> kv = iterable.iterator().next();
+            assertEquals(key, kv.getKey());
+            Trade trade = kv.getValue();
+            assertTrue(trade.getTradeId().startsWith("DEFAULT-"));
+            assertEquals(defaultPrice, trade.getPrice());
+            assertEquals(BigDecimal.ZERO, trade.getVolume());
+            assertEquals("DEFAULT", trade.getExchange());
+            assertEquals("ETH", trade.getCurrencyPair().getBase());
+            assertEquals("USD", trade.getCurrencyPair().getQuote());
+            return iterable;
+        });
+        pipeline.run().waitUntilFinish();
+    }
+
+    @Test
+    public void testDefaultPriceConfiguration() {
+        // Arrange
+        String key = "BTC/USD";
+        BigDecimal customDefaultPrice = new BigDecimal("12345.67");
+
+        // Act & Assert
+        PAssert.that(
+            pipeline.apply(Create.of(KV.of(key, (Void) null)))
+                    .apply(new DefaultTradeGenerator(customDefaultPrice)))
+        ).satisfies(iterable -> {
+            KV<String, Trade> kv = iterable.iterator().next();
+            assertEquals(key, kv.getKey());
+            Trade trade = kv.getValue();
+            assertEquals(customDefaultPrice, trade.getPrice());
+            return iterable;
+        });
+        pipeline.run().waitUntilFinish();
+    }
+}


### PR DESCRIPTION
This PR adds the `DefaultTradeGenerator` transform that produces synthetic (default) Trade messages for a given key. These synthetic trades have zero volume and use a configurable default price. They are identified by a trade ID prefix `"DEFAULT-"`.