### PR TITLE
Add Composite Transform CandleStreamWithDefaults

### DIFF
--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -9,6 +9,7 @@ java_library(
         ":sliding_candle_aggregator",
         ":default_trade_generator",
         ":last_candles_fn",
+        "//protos:marketdata_java_proto",
         "//third_party:beam_sdks_java_core",
         "//third_party:beam_sdks_java_extensions_protobuf",
         "//third_party:guava",

--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -3,6 +3,21 @@ load("@rules_java//java:defs.bzl", "java_library")
 package(default_visibility = ["//visibility:public"])
 
 java_library(
+    name = "candle_stream_with_defaults",
+    srcs = ["CandleStreamWithDefaults.java"],
+    deps = [
+        ":sliding_candle_aggregator",
+        ":default_trade_generator",
+        ":last_candles_fn",
+        "//third_party:beam_sdks_java_core",
+        "//third_party:beam_sdks_java_extensions_protobuf",
+        "//third_party:guava",
+        "//third_party:joda_time",
+        "//third_party:protobuf_java",
+    ],
+)
+
+java_library(
   name = "create_candles",
   srcs = ["CreateCandles.java"],
   deps = [

--- a/src/main/java/com/verlumen/tradestream/marketdata/CandleStreamWithDefaults.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/CandleStreamWithDefaults.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.Flatten;
+import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.Reshuffle;
@@ -23,12 +24,13 @@ import org.apache.beam.sdk.transforms.windowing.Window;
  *  1. Generates synthetic default trades for a list of currency pairs using DefaultTradeGenerator.
  *  2. Reshuffles and unions real trades with synthetic trades.
  *  3. Aggregates trades into candles via SlidingCandleAggregator.
- *  4. Re-windows the aggregated candle stream into a GlobalWindow so that each key appears only once.
+ *  4. Re-windows the aggregated candle stream into a GlobalWindow.
  *  5. Buffers the last N candles per key via LastCandlesFn.BufferLastCandles.
+ *  6. Groups by key to consolidate multiple outputs into one output per key.
  * 
- * For keys that have no real trades, the default trade is used to trigger candle creation.
- * (In that case, our CombineFn produces a default candle with all zero values.)
- * We also update the buffering DoFn to ignore duplicate default candles.
+ * For keys that have no real trades, the default trade is used to trigger candle creation
+ * (producing a default candle with all zero values). Duplicate default candles are deduplicated
+ * in LastCandlesFn.
  */
 public class CandleStreamWithDefaults extends PTransform<PCollection<KV<String, Trade>>, PCollection<KV<String, ImmutableList<Candle>>>> {
 
@@ -74,11 +76,27 @@ public class CandleStreamWithDefaults extends PTransform<PCollection<KV<String, 
         PCollection<KV<String, Candle>> candles = allTrades.apply("AggregateCandles",
             new SlidingCandleAggregator(windowDuration, slideDuration));
 
-        // 5.1 Re-window aggregated candles into a GlobalWindow to consolidate outputs per key.
+        // 5.1 Re-window aggregated candles into a GlobalWindow.
         PCollection<KV<String, Candle>> globalCandles =
             candles.apply("RewindowToGlobal", Window.<KV<String, Candle>>into(new GlobalWindows()));
 
         // 6. Buffer last N candles per key.
-        return globalCandles.apply("BufferLastCandles", ParDo.of(new LastCandlesFn.BufferLastCandles(bufferSize)));
+        PCollection<KV<String, ImmutableList<Candle>>> buffered =
+            globalCandles.apply("BufferLastCandles", ParDo.of(new LastCandlesFn.BufferLastCandles(bufferSize)));
+
+        // 7. Group by key to consolidate outputs from multiple sliding windows into one element per key.
+        PCollection<KV<String, Iterable<ImmutableList<Candle>>>> grouped = buffered.apply("GroupByKey", GroupByKey.create());
+        PCollection<KV<String, ImmutableList<Candle>>> finalOutput =
+            grouped.apply("ExtractLastBuffered", MapElements.via(new SimpleFunction<KV<String, Iterable<ImmutableList<Candle>>>, KV<String, ImmutableList<Candle>>>() {
+                @Override
+                public KV<String, ImmutableList<Candle>> apply(KV<String, Iterable<ImmutableList<Candle>>> input) {
+                    ImmutableList<Candle> last = null;
+                    for (ImmutableList<Candle> list : input.getValue()) {
+                        last = list; // Iterate and take the last list.
+                    }
+                    return KV.of(input.getKey(), last);
+                }
+            }));
+        return finalOutput;
     }
 }

--- a/src/main/java/com/verlumen/tradestream/marketdata/CandleStreamWithDefaults.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/CandleStreamWithDefaults.java
@@ -1,0 +1,78 @@
+package com.verlumen.tradestream.marketdata;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.Flatten;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.Reshuffle;
+import org.apache.beam.sdk.transforms.SimpleFunction;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionList;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.joda.time.Duration;
+
+/**
+ * CandleStreamWithDefaults is a composite transform that:
+ * 
+ *  1. Generates synthetic default trades for a list of currency pairs using DefaultTradeGenerator.
+ *  2. Reshuffles and unions real trades with synthetic trades.
+ *  3. Aggregates trades into candles via SlidingCandleAggregator.
+ *  4. Buffers the last N candles per key via LastCandlesFn.BufferLastCandles.
+ * 
+ * For keys that have no real trades, the default trade is used to trigger candle creation.
+ * Furthermore, if a window produces a default (dummy) candle, the buffering DoFn replaces it
+ * with a filled candle (using the previous real candle’s closing price for open/high/low/close, volume 0)
+ * provided a real candle exists in the buffer.
+ */
+public class CandleStreamWithDefaults extends PTransform<PCollection<KV<String, Trade>>, PCollection<KV<String, ImmutableList<Candle>>>> {
+
+    private final Duration windowDuration;
+    private final Duration slideDuration;
+    private final int bufferSize;
+    private final List<String> currencyPairs;
+    private final double defaultPrice;
+
+    public CandleStreamWithDefaults(Duration windowDuration, Duration slideDuration, int bufferSize, List<String> currencyPairs, double defaultPrice) {
+        this.windowDuration = windowDuration;
+        this.slideDuration = slideDuration;
+        this.bufferSize = bufferSize;
+        this.currencyPairs = currencyPairs;
+        this.defaultPrice = defaultPrice;
+    }
+
+    @Override
+    public PCollection<KV<String, ImmutableList<Candle>>> expand(PCollection<KV<String, Trade>> input) {
+        // 1. Create keys for all currency pairs.
+        PCollection<KV<String, Void>> keys = input.getPipeline()
+            .apply("CreateCurrencyPairKeys", Create.of(currencyPairs))
+            .apply("PairWithVoid", MapElements.via(new SimpleFunction<String, KV<String, Void>>() {
+                @Override
+                public KV<String, Void> apply(String input) {
+                    return KV.of(input, null);
+                }
+            }));
+
+        // 2. Generate synthetic default trades.
+        PCollection<KV<String, Trade>> defaultTrades = keys
+            .apply("GenerateDefaultTrades", new DefaultTradeGenerator(defaultPrice))
+            .apply("ReshardDefault", Reshuffle.viaRandomKey());
+
+        // 3. Reshard real trades.
+        PCollection<KV<String, Trade>> realTrades = input.apply("ReshardRealTrades", Reshuffle.viaRandomKey());
+
+        // 4. Flatten real and default trades.
+        PCollection<KV<String, Trade>> allTrades = PCollectionList.of(realTrades).and(defaultTrades)
+            .apply("FlattenTrades", Flatten.pCollections());
+
+        // 5. Aggregate trades into candles using sliding windows.
+        PCollection<KV<String, Candle>> candles = allTrades.apply("AggregateCandles",
+            new SlidingCandleAggregator(windowDuration, slideDuration));
+
+        // 6. Buffer last N candles per key.
+        return candles.apply("BufferLastCandles", ParDo.of(new LastCandlesFn.BufferLastCandles(bufferSize)));
+    }
+}

--- a/src/main/java/com/verlumen/tradestream/marketdata/SlidingCandleAggregator.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/SlidingCandleAggregator.java
@@ -59,6 +59,17 @@ public class SlidingCandleAggregator
 
         @Override
         public CandleAccumulator addInput(CandleAccumulator accumulator, Trade trade) {
+            // If the trade is synthetic (i.e. default) then ignore it if a real trade is already present.
+            if ("DEFAULT".equals(trade.getExchange())) {
+                // If we already have a real trade, do not update the accumulator.
+                if (!accumulator.firstTrade) {
+                    return accumulator;
+                }
+                // If no real trade is present, do not initialize the accumulator.
+                return accumulator;
+            }
+
+            // Process a real trade normally.
             if (accumulator.firstTrade) {
                 // First trade initializes the accumulator.
                 accumulator.open = trade.getPrice();
@@ -68,7 +79,7 @@ public class SlidingCandleAggregator
                 accumulator.volume = trade.getVolume();
                 accumulator.openTimestamp = trade.getTimestamp();
                 accumulator.closeTimestamp = trade.getTimestamp();
-                accumulator.currencyPair = trade.getCurrencyPair();
+                accumulator.currencyPair = trade.getCurrencyPair();  // Assumed to be a String in this version.
                 accumulator.firstTrade = false;
             } else {
                 // Update high, low, and volume.

--- a/src/test/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/test/java/com/verlumen/tradestream/marketdata/BUILD
@@ -14,6 +14,10 @@ java_test(
         "//third_party:junit",
         "//third_party:protobuf_java",
     ],
+    runtime_deps = [
+        "//third_party:beam_runners_direct_java",
+        "//third_party:hamcrest",
+    ],
 )
 
 java_test(

--- a/src/test/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/test/java/com/verlumen/tradestream/marketdata/BUILD
@@ -5,6 +5,7 @@ java_test(
     name = "CandleStreamWithDefaultsTest",
     srcs = ["CandleStreamWithDefaultsTest.java"],
     deps = [
+        "//protos:marketdata_java_proto",
         "//src/main/java/com/verlumen/tradestream/marketdata:candle_stream_with_defaults",
         "//third_party:beam_sdks_java_core",
         "//third_party:beam_sdks_java_extensions_protobuf",

--- a/src/test/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/test/java/com/verlumen/tradestream/marketdata/BUILD
@@ -8,6 +8,7 @@ java_test(
         "//src/main/java/com/verlumen/tradestream/marketdata:candle_stream_with_defaults",
         "//third_party:beam_sdks_java_core",
         "//third_party:beam_sdks_java_extensions_protobuf",
+        "//third_party:guava",
         "//third_party:joda_time",
         "//third_party:junit",
         "//third_party:protobuf_java",

--- a/src/test/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/test/java/com/verlumen/tradestream/marketdata/BUILD
@@ -1,5 +1,19 @@
 load("@rules_java//java:defs.bzl", "java_test")
 
+
+java_test(
+    name = "CandleStreamWithDefaultsTest",
+    srcs = ["CandleStreamWithDefaultsTest.java"],
+    deps = [
+        "//src/main/java/com/verlumen/tradestream/marketdata:candle_stream_with_defaults",
+        "//third_party:beam_sdks_java_core",
+        "//third_party:beam_sdks_java_extensions_protobuf",
+        "//third_party:joda_time",
+        "//third_party:junit",
+        "//third_party:protobuf_java",
+    ],
+)
+
 java_test(
     name = "CreateCandlesTest",
     srcs = [

--- a/src/test/java/com/verlumen/tradestream/marketdata/CandleStreamWithDefaultsTest.java
+++ b/src/test/java/com/verlumen/tradestream/marketdata/CandleStreamWithDefaultsTest.java
@@ -1,0 +1,146 @@
+package com.verlumen.tradestream.marketdata;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Arrays;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.transforms.Create;
+import org.joda.time.Duration;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Unit tests for CandleStreamWithDefaults.
+ */
+public class CandleStreamWithDefaultsTest {
+
+    @Rule
+    public final TestPipeline pipeline = TestPipeline.create();
+
+    @Test
+    public void testCompositeTransformEmitsCandlesWithRealTrade() {
+        // Arrange: Create a real trade for "BTC/USD".
+        com.google.protobuf.Timestamp ts = com.google.protobuf.Timestamp.newBuilder().setSeconds(1000).build();
+        Trade realTrade = Trade.newBuilder()
+            .setTimestamp(ts)
+            .setExchange("BINANCE")
+            .setCurrencyPair("BTC/USD")
+            .setPrice(10500.0)
+            .setVolume(1.0)
+            .setTradeId("trade-1")
+            .build();
+
+        // Act: Apply the composite transform with two currency pairs.
+        PAssert.that(
+            pipeline.apply("CreateRealTrade", Create.of(KV.of("BTC/USD", realTrade)))
+                    .apply("ApplyCompositeTransform", new CandleStreamWithDefaults(
+                        Duration.standardMinutes(1),
+                        Duration.standardSeconds(30),
+                        5,
+                        Arrays.asList("BTC/USD", "ETH/USD"),
+                        10000.0))
+        ).satisfies(iterable -> {
+            boolean foundBTC = false;
+            for (KV<String, ImmutableList<Candle>> kv : iterable) {
+                if (kv.getKey().equals("BTC/USD")) {
+                    foundBTC = true;
+                    // We expect that the aggregated candle for BTC/USD reflects the real trade's price.
+                    Candle candle = kv.getValue().get(0);
+                    assertEquals(10500.0, candle.getClose(), 1e-6);
+                }
+            }
+            assertTrue("Expected to find candle for BTC/USD", foundBTC);
+            return iterable;
+        });
+        pipeline.run().waitUntilFinish();
+    }
+
+    @Test
+    public void testCompositeTransformEmitsCandlesWithNoRealTrades() {
+        // Arrange: Provide an empty input for real trades.
+        PAssert.that(
+            pipeline.apply("CreateEmptyRealTrades", Create.empty(
+                    org.apache.beam.sdk.coders.KvCoder.of(
+                        org.apache.beam.sdk.coders.StringUtf8Coder.of(), 
+                        org.apache.beam.sdk.extensions.protobuf.ProtoCoder.of(Trade.class))))
+                .apply("ApplyCompositeTransform", new CandleStreamWithDefaults(
+                        Duration.standardMinutes(1),
+                        Duration.standardSeconds(30),
+                        5,
+                        Arrays.asList("BTC/USD", "ETH/USD"),
+                        10000.0))
+        ).satisfies(iterable -> {
+            int count = 0;
+            // When no real trades exist, the default trade is used.
+            for (KV<String, ImmutableList<Candle>> kv : iterable) {
+                count++;
+                Candle candle = kv.getValue().get(0);
+                // A default candle (from no real trade) will have 0.0 values.
+                assertEquals(0.0, candle.getClose(), 1e-6);
+            }
+            assertEquals("Expected candles for both currency pairs", 2, count);
+            return iterable;
+        });
+        pipeline.run().waitUntilFinish();
+    }
+
+    @Test
+    public void testCompositeTransformBufferSize() {
+        // Arrange: Create multiple real trades for "BTC/USD" with increasing timestamps.
+        com.google.protobuf.Timestamp ts1 = com.google.protobuf.Timestamp.newBuilder().setSeconds(1000).build();
+        com.google.protobuf.Timestamp ts2 = com.google.protobuf.Timestamp.newBuilder().setSeconds(1100).build();
+        com.google.protobuf.Timestamp ts3 = com.google.protobuf.Timestamp.newBuilder().setSeconds(1200).build();
+
+        Trade trade1 = Trade.newBuilder()
+            .setTimestamp(ts1)
+            .setExchange("BINANCE")
+            .setCurrencyPair("BTC/USD")
+            .setPrice(10500.0)
+            .setVolume(1.0)
+            .setTradeId("trade-1")
+            .build();
+        Trade trade2 = Trade.newBuilder()
+            .setTimestamp(ts2)
+            .setExchange("BINANCE")
+            .setCurrencyPair("BTC/USD")
+            .setPrice(10600.0)
+            .setVolume(1.0)
+            .setTradeId("trade-2")
+            .build();
+        Trade trade3 = Trade.newBuilder()
+            .setTimestamp(ts3)
+            .setExchange("BINANCE")
+            .setCurrencyPair("BTC/USD")
+            .setPrice(10700.0)
+            .setVolume(1.0)
+            .setTradeId("trade-3")
+            .build();
+
+        // Act: Apply composite transform with a buffer size of 2.
+        PAssert.that(
+            pipeline.apply("CreateRealTrades", Create.of(
+                KV.of("BTC/USD", trade1),
+                KV.of("BTC/USD", trade2),
+                KV.of("BTC/USD", trade3)))
+            .apply("ApplyCompositeTransform", new CandleStreamWithDefaults(
+                    Duration.standardMinutes(1),
+                    Duration.standardSeconds(30),
+                    2, // bufferSize = 2
+                    Arrays.asList("BTC/USD"),
+                    10000.0))
+        ).satisfies(iterable -> {
+            for (KV<String, ImmutableList<Candle>> kv : iterable) {
+                if (kv.getKey().equals("BTC/USD")) {
+                    // With a buffer size of 2 and 3 trades, only the last two candles should be buffered.
+                    assertEquals(2, kv.getValue().size());
+                }
+            }
+            return iterable;
+        });
+        pipeline.run().waitUntilFinish();
+    }
+}

--- a/src/test/java/com/verlumen/tradestream/marketdata/CandleStreamWithDefaultsTest.java
+++ b/src/test/java/com/verlumen/tradestream/marketdata/CandleStreamWithDefaultsTest.java
@@ -54,7 +54,7 @@ public class CandleStreamWithDefaultsTest {
                 }
             }
             assertTrue("Expected to find candle for BTC/USD", foundBTC);
-            return iterable;
+            return null;
         });
         pipeline.run().waitUntilFinish();
     }
@@ -83,7 +83,7 @@ public class CandleStreamWithDefaultsTest {
                 assertEquals(0.0, candle.getClose(), 1e-6);
             }
             assertEquals("Expected candles for both currency pairs", 2, count);
-            return iterable;
+            return null;
         });
         pipeline.run().waitUntilFinish();
     }
@@ -139,7 +139,7 @@ public class CandleStreamWithDefaultsTest {
                     assertEquals(2, kv.getValue().size());
                 }
             }
-            return iterable;
+            return null;
         });
         pipeline.run().waitUntilFinish();
     }


### PR DESCRIPTION
This composite transform, CandleStreamWithDefaults, unites real trades with synthetic default trades, aggregates them into candles using our SlidingCandleAggregator, and then buffers the last N candles using LastCandlesFn. (Missing candles are filled by using the previous candle’s close.) Its tests cover scenarios with real trades, with no real trades (thin markets), and buffer size enforcement.