### PR TITLE
Improve Windowing for Buffered Candles Using Processing-Time Trigger

### DIFF
--- a/src/main/java/com/verlumen/tradestream/marketdata/CandleStreamWithDefaults.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/CandleStreamWithDefaults.java
@@ -12,6 +12,8 @@ import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.Reshuffle;
 import org.apache.beam.sdk.transforms.SimpleFunction;
 import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.windowing.AfterProcessingTime;
+import org.apache.beam.sdk.transforms.windowing.Repeatedly;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
 import org.apache.beam.sdk.transforms.windowing.Window;
@@ -96,7 +98,8 @@ public class CandleStreamWithDefaults extends PTransform<PCollection<KV<String, 
         PCollection<KV<String, ImmutableList<Candle>>> rewindowedBuffered =
             buffered.apply("RewindowBuffered", 
                 Window.<KV<String, ImmutableList<Candle>>>into(new GlobalWindows())
-                      .triggering(AfterProcessingTime.pastFirstElementInPane().plusDelayOf(Duration.standardSeconds(1)))
+                      .triggering(Repeatedly.forever(
+                          AfterProcessingTime.pastFirstElementInPane().plusDelayOf(Duration.standardSeconds(1))))
                       .discardingFiredPanes()
                       .withAllowedLateness(Duration.ZERO)
             );

--- a/src/main/java/com/verlumen/tradestream/marketdata/CandleStreamWithDefaults.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/CandleStreamWithDefaults.java
@@ -12,10 +12,10 @@ import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.Reshuffle;
 import org.apache.beam.sdk.transforms.SimpleFunction;
 import org.apache.beam.sdk.transforms.PTransform;
-import org.apache.beam.sdk.transforms.windowing.DefaultTrigger;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
 import org.apache.beam.sdk.transforms.windowing.Window;
+import org.apache.beam.sdk.transforms.windowing.AfterProcessingTime;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionList;
@@ -29,7 +29,7 @@ import org.joda.time.Duration;
  *  3. Aggregates trades into candles via SlidingCandleAggregator.
  *  4. Re-windows the aggregated candle stream into a GlobalWindow.
  *  5. Buffers the last N candles per key via LastCandlesFn.BufferLastCandles.
- *  6. Re-windows the buffered output into GlobalWindows so that GroupByKey can be applied.
+ *  6. Re-windows the buffered output into GlobalWindows with a trigger so that GroupByKey can be applied.
  *  7. Groups by key to consolidate multiple outputs into one output per key.
  * 
  * For keys that have no real trades, the default trade is used to trigger candle creation
@@ -92,11 +92,14 @@ public class CandleStreamWithDefaults extends PTransform<PCollection<KV<String, 
         PCollection<KV<String, ImmutableList<Candle>>> buffered =
             globalCandles.apply("BufferLastCandles", ParDo.of(new LastCandlesFn.BufferLastCandles(bufferSize)));
 
-        // 7. Re-window the buffered output into GlobalWindows so that GroupByKey can merge by key.
+        // 7. Re-window the buffered output into GlobalWindows with a trigger so that GroupByKey can be applied.
         PCollection<KV<String, ImmutableList<Candle>>> rewindowedBuffered =
-            buffered.apply("RewindowBuffered", Window.<KV<String, ImmutableList<Candle>>>into(new GlobalWindows())
-                .triggering(DefaultTrigger.of())
-                .discardingFiredPanes());
+            buffered.apply("RewindowBuffered", 
+                Window.<KV<String, ImmutableList<Candle>>>into(new GlobalWindows())
+                      .triggering(AfterProcessingTime.pastFirstElementInPane().plusDelayOf(Duration.standardSeconds(1)))
+                      .discardingFiredPanes()
+                      .withAllowedLateness(Duration.ZERO)
+            );
 
         // 8. Group by key to consolidate outputs from multiple windows into one element per key.
         PCollection<KV<String, Iterable<ImmutableList<Candle>>>> grouped = rewindowedBuffered.apply("GroupByKey", GroupByKey.create());


### PR DESCRIPTION
This PR **enhances the windowing mechanism** in `CandleStreamWithDefaults` by introducing **processing-time triggers** for buffered candle aggregation within **GlobalWindows**.  

---

### **Key Changes:**  

✅ **Updated Rewindowing Logic for Buffered Candles**  
- **Uses `Repeatedly.forever(AfterProcessingTime.pastFirstElementInPane().plusDelayOf(1s))`**  
  - Ensures **low-latency emission** while avoiding unnecessary accumulation.  
  - Provides a **consistent cadence** for candle updates.  
- **Explicitly sets `withAllowedLateness(Duration.ZERO)`**  
  - Prevents outdated elements from lingering in the pipeline.  
  - Ensures strict adherence to real-time processing.  

✅ **Improved Grouping Efficiency**  
- `GroupByKey` now operates **only on recently emitted elements** rather than accumulating indefinitely.  

✅ **Better Scalability and Performance**  
- **Avoids excessive recomputation** while ensuring candles remain **up-to-date** in high-frequency markets.  

---

### **Why This Matters:**  
✔ **Ensures predictable and low-latency candle updates.**  
✔ **Prevents delayed outputs while maintaining correctness.**  
✔ **Optimizes event-time handling in a streaming context.**  

🚀 **This change improves TradeStream's ability to process real-time market data efficiently.**