### PR TITLE
Use Fixed 1-Day Windows for Buffered Candles Instead of GlobalWindows 

### DIFF
--- a/src/main/java/com/verlumen/tradestream/marketdata/CandleStreamWithDefaults.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/CandleStreamWithDefaults.java
@@ -30,7 +30,7 @@ import org.joda.time.Duration;
  *  3. Aggregates trades into candles via SlidingCandleAggregator.
  *  4. Re-windows the aggregated candle stream into a GlobalWindow.
  *  5. Buffers the last N candles per key via LastCandlesFn.BufferLastCandles.
- *  6. Re-windows the buffered output into a GlobalWindow with a safe (repeated) trigger so that GroupByKey can be applied.
+ *  6. Re-windows the buffered output into a FixedWindow (here, 1 day) so that GroupByKey can be applied.
  *  7. Groups by key to consolidate multiple outputs into one output per key.
  * 
  * For keys that have no real trades, the default trade is used to trigger candle creation
@@ -93,16 +93,11 @@ public class CandleStreamWithDefaults extends PTransform<PCollection<KV<String, 
         PCollection<KV<String, ImmutableList<Candle>>> buffered =
             globalCandles.apply("BufferLastCandles", ParDo.of(new LastCandlesFn.BufferLastCandles(bufferSize)));
 
-        // 7. Re-window the buffered output into a GlobalWindow with a safe (repeated) trigger so that GroupByKey can be applied.
+        // 7. Re-window the buffered output into a FixedWindow (e.g., 1 day) so that GroupByKey can be applied.
         PCollection<KV<String, ImmutableList<Candle>>> rewindowedBuffered =
             buffered.apply("RewindowBuffered", 
-                Window.<KV<String, ImmutableList<Candle>>>into(new GlobalWindows())
-                      .triggering(Repeatedly.forever(
-                          AfterProcessingTime.pastFirstElementInPane().plusDelayOf(Duration.standardSeconds(1))))
-                      .discardingFiredPanes()
-                      .withAllowedLateness(Duration.ZERO)
-            );
-
+                Window.<KV<String, ImmutableList<Candle>>>into(FixedWindows.of(Duration.standardDays(1))));
+        
         // 8. Group by key to consolidate outputs from multiple windows into one element per key.
         PCollection<KV<String, Iterable<ImmutableList<Candle>>>> grouped = rewindowedBuffered.apply("GroupByKey", GroupByKey.create());
         PCollection<KV<String, ImmutableList<Candle>>> finalOutput =

--- a/src/main/java/com/verlumen/tradestream/marketdata/CandleStreamWithDefaults.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/CandleStreamWithDefaults.java
@@ -57,7 +57,6 @@ public class CandleStreamWithDefaults extends PTransform<PCollection<KV<String, 
     @Override
     public PCollection<KV<String, ImmutableList<Candle>>> expand(PCollection<KV<String, Trade>> input) {
         // 1. Create keys for all currency pairs.
-        // ... (steps 1-6 remain the same up to 'buffered' PCollection) ...
         PCollection<KV<String, Void>> keys = input.getPipeline()
             .apply("CreateCurrencyPairKeys", Create.of(currencyPairs))
             .apply("PairWithVoid", MapElements.via(new SimpleFunction<String, KV<String, Void>>() {

--- a/src/main/java/com/verlumen/tradestream/marketdata/CandleStreamWithDefaults.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/CandleStreamWithDefaults.java
@@ -30,7 +30,7 @@ import org.joda.time.Duration;
  *  3. Aggregates trades into candles via SlidingCandleAggregator.
  *  4. Re-windows the aggregated candle stream into a GlobalWindow.
  *  5. Buffers the last N candles per key via LastCandlesFn.BufferLastCandles.
- *  6. Re-windows the buffered output into a FixedWindow so that GroupByKey can be applied.
+ *  6. Re-windows the buffered output into a GlobalWindow with a safe (repeated) trigger so that GroupByKey can be applied.
  *  7. Groups by key to consolidate multiple outputs into one output per key.
  * 
  * For keys that have no real trades, the default trade is used to trigger candle creation
@@ -93,12 +93,12 @@ public class CandleStreamWithDefaults extends PTransform<PCollection<KV<String, 
         PCollection<KV<String, ImmutableList<Candle>>> buffered =
             globalCandles.apply("BufferLastCandles", ParDo.of(new LastCandlesFn.BufferLastCandles(bufferSize)));
 
-        // 7. Re-window the buffered output into a FixedWindow (e.g., 60 minutes) so that GroupByKey can be applied.
-        // Adjust the duration as needed so that all buffered data in your test is in one window.
+        // 7. Re-window the buffered output into a GlobalWindow with a safe (repeated) trigger so that GroupByKey can be applied.
         PCollection<KV<String, ImmutableList<Candle>>> rewindowedBuffered =
             buffered.apply("RewindowBuffered", 
-                Window.<KV<String, ImmutableList<Candle>>>into(FixedWindows.of(Duration.standardMinutes(60)))
-                      .triggering(AfterProcessingTime.pastFirstElementInPane().plusDelayOf(Duration.standardSeconds(1)))
+                Window.<KV<String, ImmutableList<Candle>>>into(new GlobalWindows())
+                      .triggering(Repeatedly.forever(
+                          AfterProcessingTime.pastFirstElementInPane().plusDelayOf(Duration.standardSeconds(1))))
                       .discardingFiredPanes()
                       .withAllowedLateness(Duration.ZERO)
             );


### PR DESCRIPTION
This PR **replaces GlobalWindows with 1-day FixedWindows** in `CandleStreamWithDefaults` to improve **data partitioning, parallelism, and resource efficiency** in Beam's streaming pipeline.  

---

### **Key Changes:**  

✅ **Replaced GlobalWindows with `FixedWindows.of(Duration.standardDays(1))`**  
- **Why?**  
  - GlobalWindows required **triggers and complex state management** for bounded processing.  
  - FixedWindows **naturally partition** candle updates while still grouping per key.  
- **Benefit:**  
  - **Better parallel processing** – candles for different days can be computed independently.  
  - **Reduced stateful processing overhead** – Beam **manages retention efficiently**.  

✅ **Simplified Re-windowing Logic**  
- **Old:**  
  - Used **GlobalWindows** + a **processing-time trigger** (`AfterProcessingTime.pastFirstElementInPane().plusDelayOf(1s)`).  
- **New:**  
  - Simply **assigns candles to a 1-day window**, letting Beam manage **lateness and windowing natively**.  

---

### **Why This Matters:**  
✔ **More efficient streaming aggregation and storage.**  
✔ **Parallel computation of historical candles.**  
✔ **Avoids unnecessary triggers and complex state retention logic.**  

🚀 **This makes TradeStream's pipeline cleaner, more scalable, and optimized for time-partitioned candle aggregation!**