### PR TITLE
Increase Kafka Replicas to 3 & Optimize Resource Requests

### DIFF
--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -1,5 +1,5 @@
 kafka:
-  replicaCount: 2
+  replicaCount: 3
   persistence:
     enabled: true
     size: 10Gi
@@ -10,6 +10,18 @@ kafka:
       protocol: PLAINTEXT
     controller:
       protocol: PLAINTEXT
+  configurationOverrides:
+    "controller.quorum.voters": "0@kafka-0.kafka-headless:9093,1@kafka-1.kafka-headless:9093,2@kafka-2.kafka-headless:9093"
+  podSecurityContext:
+    runAsUser: 1001
+    fsGroup: 1001
+  resources:
+    requests:
+      cpu: "1"
+      memory: "2Gi"
+    limits:
+      cpu: "2"
+      memory: "4Gi"
 kafkaUi:
   replicaCount: 1
   image:


### PR DESCRIPTION
This PR **increases Kafka replicas from 2 to 3**, configures **controller quorum voters**, adds **pod security context**, and sets **resource limits** to enhance **Kafka cluster resilience, security, and performance**.  

---

### **Key Changes:**  

✅ **Increased Kafka replicas from 2 ➝ 3**  
- **Why?**  
  - Avoids **split-brain scenarios** in a 2-node setup.  
  - Ensures a **majority (quorum) can be reached** during failures.  
- **Benefit:**  
  - **More resilient leader elections & higher availability.**  

✅ **Defined `controller.quorum.voters` for the new 3-node setup**  
- **Why?**  
  - Kafka **KRaft mode** needs explicit voter configuration.  
- **Benefit:**  
  - Prevents misconfigurations in **controller elections**.  

✅ **Added `podSecurityContext` to enforce `runAsUser: 1001` and `fsGroup: 1001`**  
- **Why?**  
  - Enhances **security by running Kafka as a non-root user**.  
- **Benefit:**  
  - Reduces security risks from **privileged execution**.  

✅ **Set resource requests & limits (`cpu: 1-2`, `memory: 2-4Gi`)**  
- **Why?**  
  - Ensures **predictable Kafka performance** under load.  
- **Benefit:**  
  - **Prevents resource starvation** while allowing **scalability**.  

---

### **Why This Matters:**  
✔ **More resilient Kafka cluster with 3-node fault tolerance.**  
✔ **Stronger security by running Kafka as a non-root user.**  
✔ **More predictable performance via CPU/memory requests & limits.**  

🚀 **These changes help TradeStream handle high-throughput streaming more reliably!**