### PR TITLE
Increase allowed timestamp skew to 15 minutes in PipelineConfig  

### DIFF
--- a/src/main/java/com/verlumen/tradestream/pipeline/PipelineConfig.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/PipelineConfig.java
@@ -3,17 +3,18 @@ package com.verlumen.tradestream.pipeline;
 import org.joda.time.Duration;
 
 record PipelineConfig(
-  String bootstrapServers,
-  String tradeTopic,
-  String runMode,
-  Duration allowedLateness,
-  Duration windowDuration,
-  Duration allowedTimestampSkew) {
-  private static final Duration FIVE_MINUTES = Duration.standardMinutes(5);
+    String bootstrapServers,
+    String tradeTopic,
+    String runMode,
+    Duration allowedLateness,
+    Duration windowDuration,
+    Duration allowedTimestampSkew) {
+  private static final Duration FIFTEEN_MINUTES = Duration.standardMinutes(15);
   private static final Duration FIVE_SECONDS = Duration.standardSeconds(5);
   private static final Duration ONE_MINUTE = Duration.standardMinutes(1);
 
   static PipelineConfig create(String bootstrapServers, String tradeTopic, String runMode) {
-    return new PipelineConfig(bootstrapServers, tradeTopic, runMode, FIVE_SECONDS, ONE_MINUTE, FIVE_MINUTES);
+    return new PipelineConfig(
+        bootstrapServers, tradeTopic, runMode, FIVE_SECONDS, ONE_MINUTE, FIFTEEN_MINUTES);
   }
 }


### PR DESCRIPTION
This change updates the `PipelineConfig` class to increase the `allowedTimestampSkew` duration from 5 minutes to 15 minutes. This adjustment ensures greater tolerance for out-of-order events while processing trade streams.  

#### Changes:  
- Updated the constant `FIVE_MINUTES` to `FIFTEEN_MINUTES` (15 minutes).  
- Modified the `create` factory method to use the new `FIFTEEN_MINUTES` value.  

This change is intended to improve resilience in scenarios where trades arrive with higher delays. Let me know if further adjustments are needed!