### PR TITLE
Add `BarSeriesBuilder` for converting `Candle` data to `BarSeries`  

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ta4j/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ta4j/BUILD
@@ -1,0 +1,8 @@
+java_library(
+  name = "bar_series_builder",
+  srcs = ["BarSeriesBuilder.java"],
+  deps = [
+    "//third_party:guava",
+    "//third_party:ta4j_core",
+  ],
+)

--- a/src/main/java/com/verlumen/tradestream/ta4j/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ta4j/BUILD
@@ -2,6 +2,7 @@ java_library(
   name = "bar_series_builder",
   srcs = ["BarSeriesBuilder.java"],
   deps = [
+    "//protos:marketdata_java_proto",
     "//third_party:guava",
     "//third_party:protobuf_java",
     "//third_party:protobuf_java_util",

--- a/src/main/java/com/verlumen/tradestream/ta4j/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ta4j/BUILD
@@ -3,6 +3,7 @@ java_library(
   srcs = ["BarSeriesBuilder.java"],
   deps = [
     "//third_party:guava",
+    "//third_party:protobuf_java",
     "//third_party:ta4j_core",
   ],
 )

--- a/src/main/java/com/verlumen/tradestream/ta4j/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ta4j/BUILD
@@ -4,6 +4,7 @@ java_library(
   deps = [
     "//third_party:guava",
     "//third_party:protobuf_java",
+    "//third_party:protobuf_java_util",
     "//third_party:ta4j_core",
   ],
 )

--- a/src/main/java/com/verlumen/tradestream/ta4j/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ta4j/BUILD
@@ -1,3 +1,7 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
+package(default_visibility = ["//visibility:public"])
+
 java_library(
   name = "bar_series_builder",
   srcs = ["BarSeriesBuilder.java"],

--- a/src/main/java/com/verlumen/tradestream/ta4j/BarSeriesBuilder.java
+++ b/src/main/java/com/verlumen/tradestream/ta4j/BarSeriesBuilder.java
@@ -3,6 +3,7 @@ package com.verlumen.tradestream.ta4j;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
+import com.verlumen.tradestream.marketdata.Candle;
 import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseBar;
@@ -21,7 +22,7 @@ public class BarSeriesBuilder {
 
     candles.forEach(candle ->
         series.addBar(ONE_MINUTE,
-            BarSeriesBuilder.toZonedDateTime(candle.getTimestamp()),
+            BarSeriesBuilder.getZonedDateTime(candle),
             candle.getOpen(),
             candle.getHigh(),
             candle.getLow(),
@@ -32,8 +33,8 @@ public class BarSeriesBuilder {
     return series;
   }
 
-  private static ZonedDateTime toZonedDateTime(Timestamp timestamp) {
-    long epochMillis = Timestamps.toMillis(timestamp);
+  private static ZonedDateTime getZonedDateTime(Candle candle) {
+    long epochMillis = Timestamps.toMillis(candle.getTimestamp());
     ZonedDateTime zonedDateTime = Instant.ofEpochMilli(epochMillis).atZone(UTC);
   }
 }

--- a/src/main/java/com/verlumen/tradestream/ta4j/BarSeriesBuilder.java
+++ b/src/main/java/com/verlumen/tradestream/ta4j/BarSeriesBuilder.java
@@ -1,6 +1,6 @@
 package com.verlumen.tradestream.ta4j;
 
-import static org.ta4j.core.num.DoubleNum.valueOf;
+import static org.ta4j.core.num.DecimalNum.valueOf;
 
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Timestamp;

--- a/src/main/java/com/verlumen/tradestream/ta4j/BarSeriesBuilder.java
+++ b/src/main/java/com/verlumen/tradestream/ta4j/BarSeriesBuilder.java
@@ -1,5 +1,7 @@
 package com.verlumen.tradestream.ta4j;
 
+import static org.ta4j.core.num.DoubleNum.valueOf;
+
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
@@ -8,7 +10,6 @@ import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseBar;
 import org.ta4j.core.BaseBarSeries;
-import org.ta4j.core.num.DoubleNum;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZonedDateTime;
@@ -34,11 +35,11 @@ public class BarSeriesBuilder {
     return BaseBar.builder()
         .timePeriod(ONE_MINUTE)
         .endTime(dateTime.plus(ONE_MINUTE))
-        .openPrice(DoubleNum.valueOf(candle.getOpen()))
-        .highPrice(DoubleNum.valueOf(candle.getHigh()))
-        .lowPrice(DoubleNum.valueOf(candle.getLow()))
-        .closePrice(DoubleNum.valueOf(candle.getClose()))
-        .volume(DoubleNum.valueOf(candle.getVolume()))
+        .openPrice(valueOf(candle.getOpen()))
+        .highPrice(valueOf(candle.getHigh()))
+        .lowPrice(valueOf(candle.getLow()))
+        .closePrice(valueOf(candle.getClose()))
+        .volume(valueOf(candle.getVolume()))
         .build();
   }
 

--- a/src/main/java/com/verlumen/tradestream/ta4j/BarSeriesBuilder.java
+++ b/src/main/java/com/verlumen/tradestream/ta4j/BarSeriesBuilder.java
@@ -1,0 +1,28 @@
+package com.verlumen.tradestream.ta4j;
+
+import com.verlumen.tradestream.backtesting.GAOptimizationRequest;
+import org.ta4j.core.Bar;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
+import org.ta4j.core.BaseBarSeries;
+import java.time.ZonedDateTime;
+import java.time.Duration;
+
+public class BarSeriesBuilder {
+  public static BarSeries createBarSeries(ImmutableList<Candle> candles) {
+    BaseBarSeries series = new BaseBarSeries();
+    ZonedDateTime now = ZonedDateTime.now();
+
+    candles.forEach(candle ->
+        series.addBar(Duration.ofMinutes(1),
+            now.plusMinutes(series.getBarCount()),
+            candle.getOpen(),
+            candle.getHigh(),
+            candle.getLow(),
+            candle.getClose(),
+            candle.getVolume())
+    );
+
+    return series;
+  }
+}

--- a/src/main/java/com/verlumen/tradestream/ta4j/BarSeriesBuilder.java
+++ b/src/main/java/com/verlumen/tradestream/ta4j/BarSeriesBuilder.java
@@ -20,17 +20,25 @@ public class BarSeriesBuilder {
   public static BarSeries createBarSeries(ImmutableList<Candle> candles) {
     BaseBarSeries series = new BaseBarSeries();
 
-    candles.forEach(candle ->
-        series.addBar(ONE_MINUTE,
-            BarSeriesBuilder.getZonedDateTime(candle),
-            candle.getOpen(),
-            candle.getHigh(),
-            candle.getLow(),
-            candle.getClose(),
-            candle.getVolume())
-    );
+    candles
+      .stream()
+      .map(BarSeriesBuilder::createBar)
+      .forEach(series::addBar);
 
     return series;
+  }
+
+  private static Bar createBar(Candle candle) {
+    ZonedDateTime dateTime = getZonedDateTime(candle);
+    return BaseBar.builder()
+        .timePeriod(ONE_MINUTE)
+        .endTime(dateTime.plus(ONE_MINUTE))
+        .openPrice(candle.getOpen())
+        .highPrice(candle.getHigh())
+        .lowPrice(candle.getLow())
+        .closePrice(candle.getClose())
+        .volume(candle.getVolume())
+        .build();
   }
 
   private static ZonedDateTime getZonedDateTime(Candle candle) {

--- a/src/main/java/com/verlumen/tradestream/ta4j/BarSeriesBuilder.java
+++ b/src/main/java/com/verlumen/tradestream/ta4j/BarSeriesBuilder.java
@@ -1,21 +1,25 @@
 package com.verlumen.tradestream.ta4j;
 
-import com.verlumen.tradestream.backtesting.GAOptimizationRequest;
+import com.google.common.collect.ImmutableList;
 import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseBar;
 import org.ta4j.core.BaseBarSeries;
-import java.time.ZonedDateTime;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.ZoneId;
 
 public class BarSeriesBuilder {
+  private static Duration ONE_MINUTE = Duration.ofMinutes(1);
+  private static ZoneId UTC = ZoneId.of("UTC");
+
   public static BarSeries createBarSeries(ImmutableList<Candle> candles) {
     BaseBarSeries series = new BaseBarSeries();
-    ZonedDateTime now = ZonedDateTime.now();
 
     candles.forEach(candle ->
-        series.addBar(Duration.ofMinutes(1),
-            now.plusMinutes(series.getBarCount()),
+        series.addBar(ONE_MINUTE,
+            BarSeriesBuilder.toZonedDateTime(candle.getTimestamp()),
             candle.getOpen(),
             candle.getHigh(),
             candle.getLow(),
@@ -24,5 +28,10 @@ public class BarSeriesBuilder {
     );
 
     return series;
+  }
+
+  private static ZonedDateTime toZonedDateTime(Timestamp timestamp) {
+    long epochMillis = Timestamps.toMillis(timestamp);
+    ZonedDateTime zonedDateTime = Instant.ofEpochMilli(epochMillis).atZone(UTC);
   }
 }

--- a/src/main/java/com/verlumen/tradestream/ta4j/BarSeriesBuilder.java
+++ b/src/main/java/com/verlumen/tradestream/ta4j/BarSeriesBuilder.java
@@ -1,6 +1,8 @@
 package com.verlumen.tradestream.ta4j;
 
 import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.util.Timestamps;
 import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseBar;

--- a/src/main/java/com/verlumen/tradestream/ta4j/BarSeriesBuilder.java
+++ b/src/main/java/com/verlumen/tradestream/ta4j/BarSeriesBuilder.java
@@ -8,6 +8,7 @@ import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseBar;
 import org.ta4j.core.BaseBarSeries;
+import org.ta4j.core.num.DoubleNum;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZonedDateTime;
@@ -33,11 +34,11 @@ public class BarSeriesBuilder {
     return BaseBar.builder()
         .timePeriod(ONE_MINUTE)
         .endTime(dateTime.plus(ONE_MINUTE))
-        .openPrice(candle.getOpen())
-        .highPrice(candle.getHigh())
-        .lowPrice(candle.getLow())
-        .closePrice(candle.getClose())
-        .volume(candle.getVolume())
+        .openPrice(DoubleNum.valueOf(candle.getOpen()))
+        .highPrice(DoubleNum.valueOf(candle.getHigh()))
+        .lowPrice(DoubleNum.valueOf(candle.getLow()))
+        .closePrice(DoubleNum.valueOf(candle.getClose()))
+        .volume(DoubleNum.valueOf(candle.getVolume()))
         .build();
   }
 

--- a/src/main/java/com/verlumen/tradestream/ta4j/BarSeriesBuilder.java
+++ b/src/main/java/com/verlumen/tradestream/ta4j/BarSeriesBuilder.java
@@ -35,6 +35,6 @@ public class BarSeriesBuilder {
 
   private static ZonedDateTime getZonedDateTime(Candle candle) {
     long epochMillis = Timestamps.toMillis(candle.getTimestamp());
-    ZonedDateTime zonedDateTime = Instant.ofEpochMilli(epochMillis).atZone(UTC);
+    return Instant.ofEpochMilli(epochMillis).atZone(UTC);
   }
 }

--- a/src/test/java/com/verlumen/tradestream/ta4j/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ta4j/BUILD
@@ -1,0 +1,13 @@
+java_test(
+    name = "BarSeriesBuilderTest",
+    srcs = ["BarSeriesBuilderTest.java"],
+    deps = [
+        ":bar_series_builder",
+        "//third_party:junit",
+        "//third_party:guava",
+        "//third_party:protobuf_java",
+        "//third_party:protobuf_java_util",
+        "//third_party:ta4j_core",
+        "//protos:marketdata_java_proto",
+    ],
+)

--- a/src/test/java/com/verlumen/tradestream/ta4j/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ta4j/BUILD
@@ -2,7 +2,7 @@ java_test(
     name = "BarSeriesBuilderTest",
     srcs = ["BarSeriesBuilderTest.java"],
     deps = [
-        ":bar_series_builder",
+        "//src/main/java/com/verlumen/tradestream/ta4j:bar_series_builder",
         "//third_party:junit",
         "//third_party:guava",
         "//third_party:protobuf_java",

--- a/src/test/java/com/verlumen/tradestream/ta4j/BarSeriesBuilderTest.java
+++ b/src/test/java/com/verlumen/tradestream/ta4j/BarSeriesBuilderTest.java
@@ -1,0 +1,157 @@
+package com.verlumen.tradestream.ta4j;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.util.Timestamps;
+import com.verlumen.tradestream.marketdata.Candle;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import org.junit.Test;
+import org.ta4j.core.Bar;
+import org.ta4j.core.BarSeries;
+
+/**
+ * Unit tests for BarSeriesBuilder.
+ * Each test uses the AAA pattern with one assertion per test case.
+ */
+public class BarSeriesBuilderTest {
+
+  /**
+   * Helper method to build a real Candle using its protobuf builder.
+   *
+   * @param epochMillis timestamp in milliseconds
+   * @param open        open value
+   * @param high        high value
+   * @param low         low value
+   * @param close       close value
+   * @param volume      volume value
+   * @return a Candle protobuf message
+   */
+  private Candle buildCandle(long epochMillis, double open, double high, double low, double close, double volume) {
+    Timestamp ts = Timestamps.fromMillis(epochMillis);
+    return Candle.newBuilder()
+        .setTimestamp(ts)
+        .setOpen(open)
+        .setHigh(high)
+        .setLow(low)
+        .setClose(close)
+        .setVolume(volume)
+        .build();
+  }
+
+  @Test
+  public void testEmptyCandleListReturnsEmptySeries() {
+    // Arrange: create an empty list of candles
+    ImmutableList<Candle> candles = ImmutableList.of();
+    // Act: build the bar series from an empty list
+    BarSeries series = BarSeriesBuilder.createBarSeries(candles);
+    // Assert: the series should have no bars
+    assertEquals("Bar series should be empty", 0, series.getBarCount());
+  }
+
+  @Test
+  public void testSingleCandleAddsOneBar() {
+    // Arrange: create one real candle
+    Candle candle = buildCandle(1609459200000L, 100.0, 110.0, 90.0, 105.0, 1000.0);
+    ImmutableList<Candle> candles = ImmutableList.of(candle);
+    // Act: build the bar series
+    BarSeries series = BarSeriesBuilder.createBarSeries(candles);
+    // Assert: the series should contain exactly one bar
+    assertEquals("Bar series should contain one bar", 1, series.getBarCount());
+  }
+
+  @Test
+  public void testBarOpenValueMatchesCandle() {
+    // Arrange
+    double open = 50.0;
+    Candle candle = buildCandle(1609459200000L, open, 55.0, 45.0, 52.0, 500.0);
+    ImmutableList<Candle> candles = ImmutableList.of(candle);
+    // Act
+    BarSeries series = BarSeriesBuilder.createBarSeries(candles);
+    Bar bar = series.getBar(0);
+    // Assert: bar open value equals candle open value
+    assertEquals("Bar open value should match", open, bar.getOpenPrice().doubleValue(), 0.0001);
+  }
+
+  @Test
+  public void testBarHighValueMatchesCandle() {
+    // Arrange
+    double high = 120.0;
+    Candle candle = buildCandle(1609459200000L, 100.0, high, 80.0, 110.0, 1500.0);
+    ImmutableList<Candle> candles = ImmutableList.of(candle);
+    // Act
+    BarSeries series = BarSeriesBuilder.createBarSeries(candles);
+    Bar bar = series.getBar(0);
+    // Assert: bar high value equals candle high value
+    assertEquals("Bar high value should match", high, bar.getHighPrice().doubleValue(), 0.0001);
+  }
+
+  @Test
+  public void testBarLowValueMatchesCandle() {
+    // Arrange
+    double low = 70.0;
+    Candle candle = buildCandle(1609459200000L, 90.0, 100.0, low, 95.0, 800.0);
+    ImmutableList<Candle> candles = ImmutableList.of(candle);
+    // Act
+    BarSeries series = BarSeriesBuilder.createBarSeries(candles);
+    Bar bar = series.getBar(0);
+    // Assert: bar low value equals candle low value
+    assertEquals("Bar low value should match", low, bar.getLowPrice().doubleValue(), 0.0001);
+  }
+
+  @Test
+  public void testBarCloseValueMatchesCandle() {
+    // Arrange
+    double close = 102.0;
+    Candle candle = buildCandle(1609459200000L, 98.0, 105.0, 95.0, close, 900.0);
+    ImmutableList<Candle> candles = ImmutableList.of(candle);
+    // Act
+    BarSeries series = BarSeriesBuilder.createBarSeries(candles);
+    Bar bar = series.getBar(0);
+    // Assert: bar close value equals candle close value
+    assertEquals("Bar close value should match", close, bar.getClosePrice().doubleValue(), 0.0001);
+  }
+
+  @Test
+  public void testBarVolumeMatchesCandle() {
+    // Arrange
+    double volume = 2000.0;
+    Candle candle = buildCandle(1609459200000L, 100.0, 110.0, 95.0, 105.0, volume);
+    ImmutableList<Candle> candles = ImmutableList.of(candle);
+    // Act
+    BarSeries series = BarSeriesBuilder.createBarSeries(candles);
+    Bar bar = series.getBar(0);
+    // Assert: bar volume equals candle volume
+    assertEquals("Bar volume should match", volume, bar.getVolume().doubleValue(), 0.0001);
+  }
+
+  @Test
+  public void testMultipleCandlesCreatesMultipleBars() {
+    // Arrange: create two candles with sequential timestamps
+    Candle candle1 = buildCandle(1609459200000L, 100.0, 110.0, 90.0, 105.0, 1000.0);
+    Candle candle2 = buildCandle(1609459260000L, 105.0, 115.0, 95.0, 110.0, 1500.0);
+    ImmutableList<Candle> candles = ImmutableList.of(candle1, candle2);
+    // Act
+    BarSeries series = BarSeriesBuilder.createBarSeries(candles);
+    // Assert: series should have two bars
+    assertEquals("Bar series should contain two bars", 2, series.getBarCount());
+  }
+
+  @Test
+  public void testZonedDateTimeConversionIsCorrect() {
+    // Arrange: create a candle with a known timestamp
+    long epochMillis = 1609459200000L; // Jan 1, 2021 00:00:00 UTC
+    Candle candle = buildCandle(epochMillis, 100.0, 110.0, 90.0, 105.0, 1000.0);
+    ImmutableList<Candle> candles = ImmutableList.of(candle);
+    // Act
+    BarSeries series = BarSeriesBuilder.createBarSeries(candles);
+    Bar bar = series.getBar(0);
+    ZonedDateTime actualDateTime = bar.getBeginTime();
+    ZonedDateTime expectedDateTime = Instant.ofEpochMilli(epochMillis).atZone(ZoneId.of("UTC"));
+    // Assert: the bar's start time is correctly converted to UTC ZonedDateTime
+    assertEquals("Bar start time should be correctly converted", expectedDateTime, actualDateTime);
+  }
+}


### PR DESCRIPTION
This PR introduces the `BarSeriesBuilder` class, which converts a list of `Candle` protobuf objects into a TA4J `BarSeries`.  

#### Changes  
- Added `BarSeriesBuilder.java` to create `BarSeries` from `Candle` data.  
  - Uses `BaseBarSeries` and `BaseBar` from TA4J.  
  - Converts `Candle` timestamps to `ZonedDateTime` using UTC.  
  - Maps `Candle` fields to `Bar` properties.  
- Added unit tests in `BarSeriesBuilderTest.java`.  
  - Verifies correct conversion of `Candle` fields to `Bar`.  
  - Tests various scenarios including empty lists, single/multiple candles, and timestamp conversion.  
- Added corresponding `BUILD` files for both main and test sources.  

#### Dependencies  
- Added dependencies on TA4J, Protobuf, and Guava in `BUILD` files.  

#### Testing  
- Unit tests cover multiple edge cases.  
- All tests pass, confirming expected behavior.  

### Motivation  
This implementation allows seamless integration of market data into TA4J for technical analysis, improving usability in trading applications.  