### PR TITLE
Add Serializable Interface to BacktestRunner

### DIFF
--- a/src/main/java/com/verlumen/tradestream/backtesting/BacktestRunner.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BacktestRunner.java
@@ -3,13 +3,14 @@ package com.verlumen.tradestream.backtesting;
 import com.google.auto.value.AutoValue;
 import com.verlumen.tradestream.backtesting.BacktestResult;
 import com.verlumen.tradestream.strategies.StrategyType;
+import java.io.Serializable;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Strategy;
 
 /**
  * Interface for running backtests on trading strategies.
  */
-interface BacktestRunner {
+interface BacktestRunner extends Serializable {
   /**
    * Runs a backtest for the given strategy over the provided bar series.
    *


### PR DESCRIPTION
This update modifies the `BacktestRunner` interface to extend `Serializable`. This change ensures that implementations of `BacktestRunner` can be serialized, which may be useful for distributed processing, caching, or persistence purposes.

#### Changes:
- Updated `BacktestRunner` to implement `Serializable`.
- Added the corresponding import statement for `java.io.Serializable`.

This change improves the flexibility of `BacktestRunner` in scenarios requiring object serialization.