### PR TITLE
Refactor `BacktestRunnerImplTest` to use Guice dependency injection

### DIFF
--- a/src/test/java/com/verlumen/tradestream/backtesting/BacktestRunnerImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/backtesting/BacktestRunnerImplTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.inject.Guice;
+import com.google.inject.Inject;
 import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import com.verlumen.tradestream.strategies.StrategyType;
@@ -26,15 +27,16 @@ import org.ta4j.core.Trade;
 
 @RunWith(JUnit4.class)
 public class BacktestRunnerImplTest {
-    private BacktestRunnerImpl backtestRunner;
     private BaseBarSeries series;
     private Strategy strategy;
     private ZonedDateTime startTime;
 
+    @Inject private BacktestRunnerImpl backtestRunner;
+
     @Before
     public void setUp() {
         MockitoAnnotations.openMocks(this);
-        backtestRunner = new BacktestRunnerImpl();
+        Guice.createInjector().injectMembers(this);
 
         // Initialize test data
         series = new BaseBarSeries("test series");


### PR DESCRIPTION
This PR updates `BacktestRunnerImplTest` to use Guice for dependency injection instead of manually instantiating `BacktestRunnerImpl`. Key changes include:

- Adding `@Inject` annotation to `backtestRunner` to allow Guice to inject dependencies.
- Removing the manual instantiation of `BacktestRunnerImpl` in `setUp()`.
- Using `Guice.createInjector().injectMembers(this);` to initialize dependencies.

These changes improve test maintainability and ensure consistency with Guice-based dependency management in the codebase.