### PR TITLE
Enhance Javadoc Documentation for `StrategyManager` Interface  

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManager.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManager.java
@@ -3,18 +3,26 @@ package com.verlumen.tradestream.strategies;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.verlumen.tradestream.strategies.StrategyType;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Strategy;
 
+/**
+ * Manages the creation and configuration of trading strategies for the TradeStream system.
+ * <p>
+ * This interface provides methods to create Ta4j {@link Strategy} instances based on a specified
+ * {@link StrategyType} and {@link BarSeries}. It leverages a corresponding {@link StrategyFactory}
+ * to supply both the strategy instance and its default configuration parameters.
+ */
 public interface StrategyManager {
+
   /**
-   * Creates a Ta4j Strategy object from the provided parameters.
+   * Creates a new Ta4j {@link Strategy} instance for the specified strategy type and bar series,
+   * using the default parameters.
    *
-   * @param strategyType The type of strategy to create
-   * @param barSeries The bar series to associate with the created strategy
-   * @return The created Strategy object
-   * @throws InvalidProtocolBufferException If there is an error unpacking the parameters
+   * @param strategyType the type of strategy to create
+   * @param barSeries    the bar series to associate with the strategy
+   * @return a new instance of a Ta4j {@link Strategy} configured with the default parameters
+   * @throws InvalidProtocolBufferException if there is an error unpacking the default parameters
    */
   default Strategy createStrategy(StrategyType strategyType, BarSeries barSeries)
       throws InvalidProtocolBufferException {
@@ -22,29 +30,51 @@ public interface StrategyManager {
   }
 
   /**
-   * Creates a Ta4j Strategy object from the provided parameters.
+   * Creates a new Ta4j {@link Strategy} instance for the specified strategy type and bar series,
+   * using the provided configuration parameters.
    *
-   * @param strategyType The type of strategy to create
-   * @param barSeries The bar series to associate with the created strategy
-   * @param strategyParameters The parameters for configuring the strategy 
-   * @return The created Strategy object
-   * @throws InvalidProtocolBufferException If there is an error unpacking the parameters
+   * @param strategyType the type of strategy to create
+   * @param barSeries    the bar series to associate with the strategy
+   * @param parameters   the configuration parameters for the strategy, wrapped in an {@link Any} message
+   * @return a new instance of a Ta4j {@link Strategy} configured with the provided parameters
+   * @throws InvalidProtocolBufferException if there is an error unpacking the parameters
    */
   default Strategy createStrategy(StrategyType strategyType, BarSeries barSeries, Any parameters)
       throws InvalidProtocolBufferException {
     return getStrategyFactory(strategyType).createStrategy(barSeries, parameters);
   }
 
+  /**
+   * Retrieves the default configuration parameters for the specified strategy type.
+   * <p>
+   * This method obtains the default parameters from the associated {@link StrategyFactory}
+   * and packs them into a protocol buffers {@link Any} message.
+   *
+   * @param strategyType the type of strategy for which to retrieve the default parameters
+   * @return an {@link Any} message containing the default parameters for the given strategy type
+   */
   default Any getDefaultParameters(StrategyType strategyType) {
     return Any.pack(getStrategyFactory(strategyType).getDefaultParameters());
   }
 
+  /**
+   * Retrieves the {@link StrategyFactory} corresponding to the specified strategy type.
+   * <p>
+   * The returned factory is responsible for creating instances of the strategy as well as
+   * providing its default configuration parameters.
+   *
+   * @param strategyType the type of strategy for which to obtain the factory
+   * @return the {@link StrategyFactory} associated with the given strategy type
+   */
   StrategyFactory<?> getStrategyFactory(StrategyType strategyType);
 
   /**
    * Returns an immutable list of all supported strategy types.
+   * <p>
+   * This list includes every available {@link StrategyType} that can be used to create and
+   * configure trading strategies via this manager.
    *
-   * @return List of available strategy types
+   * @return an immutable list of supported {@link StrategyType} instances
    */
   ImmutableList<StrategyType> getStrategyTypes();
 }


### PR DESCRIPTION
This PR improves the Javadoc documentation for the `StrategyManager` interface by adding detailed descriptions, proper formatting, and clarifications for method parameters and return values. Key enhancements include:

- **Class-Level Javadoc**: Introduced a comprehensive overview of the `StrategyManager` interface, explaining its role in managing trading strategies within the TradeStream system.
- **Method Annotations & Formatting**: 
  - Improved clarity in method descriptions.
  - Ensured proper usage of `{@link}` for referencing related classes like `Strategy`, `StrategyType`, and `StrategyFactory`.
  - Standardized parameter descriptions and formatted return type explanations.
- **New Javadoc Additions**:
  - Added documentation for `getDefaultParameters()`, detailing its role in retrieving default strategy configurations.
  - Provided explanations for `getStrategyFactory()` and `getStrategyTypes()` to clarify their responsibilities in the strategy management process.

These enhancements improve code maintainability and make it easier for developers to understand and use the `StrategyManager` API effectively. No functional changes were made to the code.