### PR TITLE
(MINOR) Remove unused dependencies from backtesting module  

### DIFF
--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -7,11 +7,7 @@ java_library(
     srcs = ["BacktestRunner.java"],
     deps = [
         "//protos:backtesting_java_proto",
-        "//protos:strategies_java_proto",
-        "//third_party:auto_value",
-        "//third_party:guice",
         "//third_party:protobuf_java",
-        "//third_party:ta4j_core",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/backtesting/BacktestRunner.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BacktestRunner.java
@@ -1,11 +1,7 @@
 package com.verlumen.tradestream.backtesting;
 
-import com.google.auto.value.AutoValue;
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.verlumen.tradestream.strategies.StrategyType;
 import java.io.Serializable;
-import org.ta4j.core.BarSeries;
-import org.ta4j.core.Strategy;
 
 /**
  * Interface for running backtests on trading strategies.


### PR DESCRIPTION
This PR removes unused dependencies from the backtesting module to streamline the build and reduce unnecessary imports.  

#### Changes:
- **BUILD file cleanup**: Removed dependencies on:
  - `//protos:strategies_java_proto`
  - `//third_party:auto_value`
  - `//third_party:guice`
  - `//third_party:ta4j_core`
- **Code cleanup**: Removed unused imports from `BacktestRunner.java`, specifically:
  - `com.google.auto.value.AutoValue`
  - `com.verlumen.tradestream.strategies.StrategyType`
  - `org.ta4j.core.BarSeries`
  - `org.ta4j.core.Strategy`

This update improves maintainability by eliminating unused dependencies, reducing potential build overhead, and making the codebase cleaner.