### PR TITLE
Refactor Backtest Execution: Replace `BacktestServiceClient` with `BacktestRunner`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -28,14 +28,6 @@ java_library(
 )
 
 java_library(
-    name = "backtest_service_client",
-    srcs = ["BacktestServiceClient.java"],
-    deps = [
-        "//protos:backtesting_java_proto",
-    ],
-)
-
-java_library(
     name = "backtesting_module",
     srcs = ["BacktestingModule.java"],
     deps = [
@@ -63,6 +55,8 @@ java_library(
     name = "genetic_algorithm_orchestrator_impl",
     srcs = ["GeneticAlgorithmOrchestratorImpl.java"],
     deps = [
+        ":backtest_runner",
+        ":genetic_algorithm_orchestrator",
         "//protos:backtesting_java_proto",
         "//protos:marketdata_java_proto", 
         "//protos:strategies_java_proto",
@@ -73,8 +67,6 @@ java_library(
         "//third_party:jenetics",
         "//third_party:protobuf_java",
         "//third_party:ta4j_core",
-        ":backtest_service_client",
-        ":genetic_algorithm_orchestrator",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/backtesting/BacktestServiceClient.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BacktestServiceClient.java
@@ -1,8 +1,0 @@
-package com.verlumen.tradestream.backtesting;
-
-import com.verlumen.tradestream.backtesting.BacktestRequest;
-import com.verlumen.tradestream.backtesting.BacktestResult;
-
-interface BacktestServiceClient {
-    BacktestResult runBacktest(BacktestRequest request);
-}

--- a/src/main/java/com/verlumen/tradestream/backtesting/GeneticAlgorithmOrchestratorImpl.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/GeneticAlgorithmOrchestratorImpl.java
@@ -29,19 +29,13 @@ final class GeneticAlgorithmOrchestratorImpl implements GeneticAlgorithmOrchestr
     private static final double MUTATION_PROBABILITY = 0.15;
     private static final double CROSSOVER_PROBABILITY = 0.35;
 
-    private final BacktestServiceClient backtestServiceClient;
+    private final BacktestRunner backtestRunner;
     private final ParamConfigManager paramConfigManager;
 
-    /**
-     * Constructs a new GeneticAlgorithmOrchestratorImpl.
-     *
-     * @param backtestServiceClient the client used to run backtests
-     * @param paramConfigManager the manager for parameter configurations
-     */
     @Inject
     GeneticAlgorithmOrchestratorImpl(
-        BacktestServiceClient backtestServiceClient, ParamConfigManager paramConfigManager) {
-        this.backtestServiceClient = backtestServiceClient;
+        BacktestRunner backtestRunner, ParamConfigManager paramConfigManager) {
+        this.backtestRunner = backtestRunner;
         this.paramConfigManager = paramConfigManager;
     }
 
@@ -116,7 +110,7 @@ final class GeneticAlgorithmOrchestratorImpl implements GeneticAlgorithmOrchestr
                     .setStrategy(Strategy.newBuilder().setType(request.getStrategyType()).setParameters(params))
                     .build();
 
-                BacktestResult result = backtestServiceClient.runBacktest(backtestRequest);
+                BacktestResult result = backtestRunner.runBacktest(backtestRequest);
                 return result.getOverallScore();
             } catch (Exception e) {
                 // Penalize any invalid genotype by assigning the lowest possible fitness

--- a/src/test/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/test/java/com/verlumen/tradestream/backtesting/BUILD
@@ -30,7 +30,7 @@ java_test(
         "//protos:backtesting_java_proto",
         "//protos:marketdata_java_proto",
         "//protos:strategies_java_proto",
-        "//src/main/java/com/verlumen/tradestream/backtesting:backtest_service_client",
+        "//src/main/java/com/verlumen/tradestream/backtesting:backtest_runner",
         "//src/main/java/com/verlumen/tradestream/backtesting:genetic_algorithm_orchestrator",
         "//src/main/java/com/verlumen/tradestream/backtesting:genetic_algorithm_orchestrator_impl",
         "//src/main/java/com/verlumen/tradestream/backtesting/params:params_lib",

--- a/src/test/java/com/verlumen/tradestream/backtesting/GeneticAlgorithmOrchestratorImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/backtesting/GeneticAlgorithmOrchestratorImplTest.java
@@ -36,7 +36,7 @@ public class GeneticAlgorithmOrchestratorImplTest {
     public MockitoRule mockito = MockitoJUnit.rule();
 
     @Bind @Mock
-    private BacktestServiceClient mockBacktestServiceClient;
+    private BacktestRunner mockBacktestRunner;
 
     @Bind @Mock
     private ParamConfigManager mockParamConfigManager;
@@ -57,8 +57,8 @@ public class GeneticAlgorithmOrchestratorImplTest {
             .setOverallScore(0.75)
             .build();
 
-        // Stub the BacktestServiceClient
-        when(mockBacktestServiceClient.runBacktest(any()))
+        // Stub the BacktestRunner
+        when(mockBacktestRunner.runBacktest(any()))
             .thenReturn(mockBacktestResult);
 
         // Return test ChromosomeSpecs
@@ -87,12 +87,12 @@ public class GeneticAlgorithmOrchestratorImplTest {
 
         // Assert
         // Verify that backtest was called at least once
-        verify(mockBacktestServiceClient, atLeastOnce()).runBacktest(any());
+        verify(mockBacktestRunner, atLeastOnce()).runBacktest(any());
 
         // Capture and verify one of the backtest requests
         ArgumentCaptor<BacktestRequest> backtestCaptor = 
             ArgumentCaptor.forClass(BacktestRequest.class);
-        verify(mockBacktestServiceClient, atLeastOnce())
+        verify(mockBacktestRunner, atLeastOnce())
             .runBacktest(backtestCaptor.capture());
         
         BacktestRequest capturedRequest = backtestCaptor.getValue();
@@ -119,7 +119,7 @@ public class GeneticAlgorithmOrchestratorImplTest {
         assertThat(thrown).hasMessageThat().contains("Candles list cannot be empty");
         
         // Verify no backtests were run
-        verify(mockBacktestServiceClient, never()).runBacktest(any());
+        verify(mockBacktestRunner, never()).runBacktest(any());
     }
 
     @Test
@@ -138,7 +138,7 @@ public class GeneticAlgorithmOrchestratorImplTest {
 
         // Assert
         // Verify backtests occurred but don't enforce exact count
-        verify(mockBacktestServiceClient, atLeastOnce()).runBacktest(any());
+        verify(mockBacktestRunner, atLeastOnce()).runBacktest(any());
         assertThat(response.hasBestStrategyParameters()).isTrue();
         
         // Could add additional assertions about number of generations/population

--- a/src/test/java/com/verlumen/tradestream/backtesting/GeneticAlgorithmOrchestratorImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/backtesting/GeneticAlgorithmOrchestratorImplTest.java
@@ -51,7 +51,7 @@ public class GeneticAlgorithmOrchestratorImplTest {
     private BacktestResult mockBacktestResult;
 
     @Before
-    public void setUp() {
+    public void setUp() throws Exception {
         // Create a mock backtest result
         mockBacktestResult = BacktestResult.newBuilder()
             .setOverallScore(0.75)
@@ -81,7 +81,7 @@ public class GeneticAlgorithmOrchestratorImplTest {
     }
 
     @Test
-    public void runOptimization_withValidRequest_returnsOptimizedParameters() {
+    public void runOptimization_withValidRequest_returnsOptimizedParameters() throws Exception {
         // Act
         BestStrategyResponse response = orchestrator.runOptimization(request);
 
@@ -103,7 +103,7 @@ public class GeneticAlgorithmOrchestratorImplTest {
     }
 
     @Test
-    public void runOptimization_withEmptyCandles_throwsException() {
+    public void runOptimization_withEmptyCandles_throwsException() throws Exception {
         // Arrange
         GAOptimizationRequest emptyCandleRequest = GAOptimizationRequest.newBuilder()
             .setStrategyType(StrategyType.SMA_RSI)
@@ -123,7 +123,7 @@ public class GeneticAlgorithmOrchestratorImplTest {
     }
 
     @Test
-    public void runOptimization_withCustomGenerationsAndPopulation_usesCustomValues() {
+    public void runOptimization_withCustomGenerationsAndPopulation_usesCustomValues() throws Exception {
         // Arrange
         int customGenerations = 5;
         int customPopulation = 10;


### PR DESCRIPTION
This PR refactors the backtesting execution flow by removing `BacktestServiceClient` and replacing it with `BacktestRunner`. The key changes include:

- **Removed `BacktestServiceClient.java`** and its associated `java_library` target from the build files.
- **Updated `GeneticAlgorithmOrchestratorImpl`** to use `BacktestRunner` instead of `BacktestServiceClient` for running backtests.
- **Modified test files**:
  - Replaced references to `BacktestServiceClient` with `BacktestRunner`.
  - Adjusted Mockito-based stubbing and verifications accordingly.
- **Updated BUILD dependencies** to remove `backtest_service_client` and add `backtest_runner`.

This change simplifies the backtesting workflow by directly integrating `BacktestRunner`, reducing unnecessary abstraction.