### PR TITLE
Refactor BacktestResult and Scoring Logic in BacktestRunner

### DIFF
--- a/protos/backtesting.proto
+++ b/protos/backtesting.proto
@@ -35,7 +35,7 @@ message BacktestResult {
   double average_trade_duration = 11;
   double alpha = 12;
   double beta = 13;
-  double overall_score = 14;
+  double strategy_score = 14;
 }
 
 // =========================

--- a/protos/backtesting.proto
+++ b/protos/backtesting.proto
@@ -20,8 +20,8 @@ message BacktestRequest {
   strategies.Strategy strategy = 2;
 }
 
-// Multi-timeframe results from the backtest
-message TimeframeResult {
+// The final result from a single backtest
+message BacktestResult {
   string timeframe = 1;
   double cumulative_return = 2;
   double annualized_return = 3;
@@ -35,18 +35,7 @@ message TimeframeResult {
   double average_trade_duration = 11;
   double alpha = 12;
   double beta = 13;
-}
-
-// The final result from a single backtest
-message BacktestResult {
-  repeated TimeframeResult timeframe_results = 1;
-  double overall_score = 2;
-}
-
-// The single service for all backtesting
-service BacktestService {
-  // Always requires strategy parameters, no “plain” concept
-  rpc RunBacktest (BacktestRequest) returns (BacktestResult);
+  double overall_score = 14;
 }
 
 // =========================
@@ -67,8 +56,4 @@ message GAOptimizationRequest {
 message BestStrategyResponse {
   google.protobuf.Any best_strategy_parameters = 1;
   double best_score = 2;
-}
-
-service GAService {
-  rpc RequestOptimization (GAOptimizationRequest) returns (BestStrategyResponse);
 }

--- a/src/main/java/com/verlumen/tradestream/backtesting/BacktestRunnerImpl.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BacktestRunnerImpl.java
@@ -70,7 +70,9 @@ final class BacktestRunnerImpl implements BacktestRunner {
         double alpha = 0.0; // TODO: Implement when benchmark data is available
         double beta = 1.0;  // TODO: Implement when benchmark data is available
 
-        BacktestResult result = BacktestResult.newBuilder()
+        double score = calculateScore(sharpeRatio, maxDrawdown, winRate, annualizedReturn, profitFactor);
+
+        return BacktestResult.newBuilder()
             .setCumulativeReturn(cumulativeReturn)
             .setAnnualizedReturn(annualizedReturn)
             .setSharpeRatio(sharpeRatio)
@@ -83,9 +85,8 @@ final class BacktestRunnerImpl implements BacktestRunner {
             .setAverageTradeDuration(averageTradeDuration)
             .setAlpha(alpha)
             .setBeta(beta)
+            .setScore(score)
             .build();
-
-        double score = calculateScore(result);
     }
 
     private TradingRecord runStrategy(BarSeries series, Strategy strategy) {

--- a/src/main/java/com/verlumen/tradestream/backtesting/BacktestRunnerImpl.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BacktestRunnerImpl.java
@@ -85,7 +85,7 @@ final class BacktestRunnerImpl implements BacktestRunner {
             .setAverageTradeDuration(averageTradeDuration)
             .setAlpha(alpha)
             .setBeta(beta)
-            .setScore(score)
+            .setStrategyScore(score)
             .build();
     }
 

--- a/src/main/java/com/verlumen/tradestream/backtesting/GeneticAlgorithmOrchestratorImpl.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/GeneticAlgorithmOrchestratorImpl.java
@@ -111,7 +111,7 @@ final class GeneticAlgorithmOrchestratorImpl implements GeneticAlgorithmOrchestr
                     .build();
 
                 BacktestResult result = backtestRunner.runBacktest(backtestRequest);
-                return result.getOverallScore();
+                return result.getStrategyScore();
             } catch (Exception e) {
                 // Penalize any invalid genotype by assigning the lowest possible fitness
                 return Double.NEGATIVE_INFINITY;

--- a/src/test/java/com/verlumen/tradestream/backtesting/BacktestRunnerImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/backtesting/BacktestRunnerImplTest.java
@@ -104,13 +104,12 @@ public class BacktestRunnerImplTest {
         assertThat(result.getStrategyScore()).isGreaterThan(0.0);
 
         // Check first backtest result
-        BacktestResult firstBacktest = result.getBacktestResults(0);
-        assertThat(firstBacktest.getCumulativeReturn()).isGreaterThan(0.0);
-        assertThat(firstBacktest.getNumberOfTrades()).isGreaterThan(0);
-        assertThat(firstBacktest.getMaxDrawdown()).isAtLeast(0.0);
-        assertThat(firstBacktest.getMaxDrawdown()).isAtMost(1.0);
-        assertThat(firstBacktest.getWinRate()).isAtLeast(0.0);
-        assertThat(firstBacktest.getWinRate()).isAtMost(1.0);
+        assertThat(result.getCumulativeReturn()).isGreaterThan(0.0);
+        assertThat(result.getNumberOfTrades()).isGreaterThan(0);
+        assertThat(result.getMaxDrawdown()).isAtLeast(0.0);
+        assertThat(result.getMaxDrawdown()).isAtMost(1.0);
+        assertThat(result.getWinRate()).isAtLeast(0.0);
+        assertThat(result.getWinRate()).isAtMost(1.0);
     }
 
     @Test
@@ -128,10 +127,9 @@ public class BacktestRunnerImplTest {
         BacktestResult result = backtestRunner.runBacktest(request);
 
         // Assert
-        BacktestResult firstBacktest = result.getBacktestResults(0);
-        assertThat(firstBacktest.getCumulativeReturn()).isLessThan(0.0);
-        assertThat(firstBacktest.getMaxDrawdown()).isGreaterThan(0.0);
-        assertThat(firstBacktest.getProfitFactor()).isAtMost(1.0);
+        assertThat(result.getCumulativeReturn()).isLessThan(0.0);
+        assertThat(result.getMaxDrawdown()).isGreaterThan(0.0);
+        assertThat(result.getProfitFactor()).isAtMost(1.0);
     }
 
     @Test
@@ -149,10 +147,9 @@ public class BacktestRunnerImplTest {
         BacktestResult result = backtestRunner.runBacktest(request);
 
         // Assert
-        BacktestResult firstBacktest = result.getBacktestResults(0);
-        assertThat(firstBacktest.getVolatility()).isGreaterThan(0.0);
+        assertThat(result.getVolatility()).isGreaterThan(0.0);
         // We use isWithin() instead of isEqualTo() as calculations might have small differences
-        assertThat(firstBacktest.getSharpeRatio()).isWithin(0.1).of(-41.43383146756991);
+        assertThat(result.getSharpeRatio()).isWithin(0.1).of(-41.43383146756991);
     }
 
     @Test
@@ -183,10 +180,9 @@ public class BacktestRunnerImplTest {
         BacktestResult result = backtestRunner.runBacktest(request);
 
         // Assert
-        BacktestResult firstBacktest = result.getBacktestResults(0);
-        assertThat(firstBacktest.getNumberOfTrades()).isEqualTo(0);
-        assertThat(firstBacktest.getWinRate()).isEqualTo(0.0);
-        assertThat(firstBacktest.getAverageTradeDuration()).isEqualTo(0.0);
+        assertThat(result.getNumberOfTrades()).isEqualTo(0);
+        assertThat(result.getWinRate()).isEqualTo(0.0);
+        assertThat(result.getAverageTradeDuration()).isEqualTo(0.0);
     }
 
     private void addTestBars(double... prices) {

--- a/src/test/java/com/verlumen/tradestream/backtesting/BacktestRunnerImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/backtesting/BacktestRunnerImplTest.java
@@ -101,17 +101,16 @@ public class BacktestRunnerImplTest {
         BacktestResult result = backtestRunner.runBacktest(request);
 
         // Assert
-        assertThat(result.getTimeframeResultsCount()).isGreaterThan(0);
-        assertThat(result.getOverallScore()).isGreaterThan(0.0);
+        assertThat(result.getStrategyScore()).isGreaterThan(0.0);
 
-        // Check first timeframe result
-        TimeframeResult firstTimeframe = result.getTimeframeResults(0);
-        assertThat(firstTimeframe.getCumulativeReturn()).isGreaterThan(0.0);
-        assertThat(firstTimeframe.getNumberOfTrades()).isGreaterThan(0);
-        assertThat(firstTimeframe.getMaxDrawdown()).isAtLeast(0.0);
-        assertThat(firstTimeframe.getMaxDrawdown()).isAtMost(1.0);
-        assertThat(firstTimeframe.getWinRate()).isAtLeast(0.0);
-        assertThat(firstTimeframe.getWinRate()).isAtMost(1.0);
+        // Check first backtest result
+        BacktestResult firstBacktest = result.getBacktestResults(0);
+        assertThat(firstBacktest.getCumulativeReturn()).isGreaterThan(0.0);
+        assertThat(firstBacktest.getNumberOfTrades()).isGreaterThan(0);
+        assertThat(firstBacktest.getMaxDrawdown()).isAtLeast(0.0);
+        assertThat(firstBacktest.getMaxDrawdown()).isAtMost(1.0);
+        assertThat(firstBacktest.getWinRate()).isAtLeast(0.0);
+        assertThat(firstBacktest.getWinRate()).isAtMost(1.0);
     }
 
     @Test
@@ -129,10 +128,10 @@ public class BacktestRunnerImplTest {
         BacktestResult result = backtestRunner.runBacktest(request);
 
         // Assert
-        TimeframeResult firstTimeframe = result.getTimeframeResults(0);
-        assertThat(firstTimeframe.getCumulativeReturn()).isLessThan(0.0);
-        assertThat(firstTimeframe.getMaxDrawdown()).isGreaterThan(0.0);
-        assertThat(firstTimeframe.getProfitFactor()).isAtMost(1.0);
+        BacktestResult firstBacktest = result.getBacktestResults(0);
+        assertThat(firstBacktest.getCumulativeReturn()).isLessThan(0.0);
+        assertThat(firstBacktest.getMaxDrawdown()).isGreaterThan(0.0);
+        assertThat(firstBacktest.getProfitFactor()).isAtMost(1.0);
     }
 
     @Test
@@ -150,10 +149,10 @@ public class BacktestRunnerImplTest {
         BacktestResult result = backtestRunner.runBacktest(request);
 
         // Assert
-        TimeframeResult firstTimeframe = result.getTimeframeResults(0);
-        assertThat(firstTimeframe.getVolatility()).isGreaterThan(0.0);
+        BacktestResult firstBacktest = result.getBacktestResults(0);
+        assertThat(firstBacktest.getVolatility()).isGreaterThan(0.0);
         // We use isWithin() instead of isEqualTo() as calculations might have small differences
-        assertThat(firstTimeframe.getSharpeRatio()).isWithin(0.1).of(-41.43383146756991);
+        assertThat(firstBacktest.getSharpeRatio()).isWithin(0.1).of(-41.43383146756991);
     }
 
     @Test
@@ -184,10 +183,10 @@ public class BacktestRunnerImplTest {
         BacktestResult result = backtestRunner.runBacktest(request);
 
         // Assert
-        TimeframeResult firstTimeframe = result.getTimeframeResults(0);
-        assertThat(firstTimeframe.getNumberOfTrades()).isEqualTo(0);
-        assertThat(firstTimeframe.getWinRate()).isEqualTo(0.0);
-        assertThat(firstTimeframe.getAverageTradeDuration()).isEqualTo(0.0);
+        BacktestResult firstBacktest = result.getBacktestResults(0);
+        assertThat(firstBacktest.getNumberOfTrades()).isEqualTo(0);
+        assertThat(firstBacktest.getWinRate()).isEqualTo(0.0);
+        assertThat(firstBacktest.getAverageTradeDuration()).isEqualTo(0.0);
     }
 
     private void addTestBars(double... prices) {

--- a/src/test/java/com/verlumen/tradestream/backtesting/GeneticAlgorithmOrchestratorImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/backtesting/GeneticAlgorithmOrchestratorImplTest.java
@@ -54,7 +54,7 @@ public class GeneticAlgorithmOrchestratorImplTest {
     public void setUp() throws Exception {
         // Create a mock backtest result
         mockBacktestResult = BacktestResult.newBuilder()
-            .setOverallScore(0.75)
+            .setStrategyScore(0.75)
             .build();
 
         // Stub the BacktestRunner
@@ -98,7 +98,7 @@ public class GeneticAlgorithmOrchestratorImplTest {
         BacktestRequest capturedRequest = backtestCaptor.getValue();
         assertThat(capturedRequest.getStrategy().getType()).isEqualTo(request.getStrategyType());
         assertThat(capturedRequest.getCandlesList()).isEqualTo(request.getCandlesList());
-        assertThat(response.getBestScore()).isEqualTo(mockBacktestResult.getOverallScore());
+        assertThat(response.getBestScore()).isEqualTo(mockBacktestResult.getStrategyScore());
         assertThat(response.hasBestStrategyParameters()).isTrue();
     }
 

--- a/src/test/java/com/verlumen/tradestream/backtesting/RunBacktestTest.java
+++ b/src/test/java/com/verlumen/tradestream/backtesting/RunBacktestTest.java
@@ -65,7 +65,7 @@ public class RunBacktestTest {
             .apply(runBacktest);
 
         PAssert.that(output)
-            .containsInAnyOrder(BacktestResult.newBuilder().setOverallScore(0.5).build());
+            .containsInAnyOrder(BacktestResult.newBuilder().setStrategyScore(0.5).build());
 
         pipeline.run().waitUntilFinish();
     }
@@ -84,9 +84,9 @@ public class RunBacktestTest {
 
         PAssert.that(output)
             .containsInAnyOrder(
-                BacktestResult.newBuilder().setOverallScore(0.5).build(),
-                BacktestResult.newBuilder().setOverallScore(0.5).build(),
-                BacktestResult.newBuilder().setOverallScore(0.5).build()
+                BacktestResult.newBuilder().setStrategyScore(0.5).build(),
+                BacktestResult.newBuilder().setStrategyScore(0.5).build(),
+                BacktestResult.newBuilder().setStrategyScore(0.5).build()
             );
 
         pipeline.run().waitUntilFinish();
@@ -168,7 +168,7 @@ public class RunBacktestTest {
     private static class FakeBacktestRunner implements BacktestRunner {
         @Override
         public BacktestResult runBacktest(BacktestRequest request) throws InvalidProtocolBufferException {
-            return BacktestResult.newBuilder().setOverallScore(0.5).build();
+            return BacktestResult.newBuilder().setStrategyScore(0.5).build();
         }
     }
 


### PR DESCRIPTION
This PR refactors the `BacktestResult` structure and modifies the scoring logic in `BacktestRunnerImpl`. Key changes include:

- **Proto Changes**:
  - Merged `TimeframeResult` into `BacktestResult`, eliminating multi-timeframe evaluations.
  - Introduced `strategy_score` as a primary evaluation metric.
  - Removed `BacktestService` and `GAService` definitions from `backtesting.proto`.

- **BacktestRunner Implementation Updates**:
  - Removed predefined timeframe evaluations and simplified backtest execution to focus on overall strategy performance.
  - Adjusted the scoring mechanism to compute a single `strategy_score` based on Sharpe ratio, drawdowns, win rate, annualized return, and profit factor.

- **Genetic Algorithm Integration**:
  - Updated `GeneticAlgorithmOrchestratorImpl` to use `strategy_score` instead of `overall_score`.

- **Test Suite Adjustments**:
  - Refactored tests to align with the new `BacktestResult` structure.
  - Replaced assertions for `overall_score` with `strategy_score`.
  - Updated mock expectations and validation logic.

This change simplifies backtesting evaluations, focusing on a unified scoring approach while removing redundant timeframe-based calculations.