### PR TITLE
Enhance `ParamConfigManager` with `Serializable` Implementation  

### DIFF
--- a/src/main/java/com/verlumen/tradestream/backtesting/params/ParamConfigManager.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/params/ParamConfigManager.java
@@ -1,7 +1,8 @@
 package com.verlumen.tradestream.backtesting.params;
 
 import com.verlumen.tradestream.strategies.StrategyType;
+import java.io.Serializable;
 
-public interface ParamConfigManager {
+public interface ParamConfigManager extends Serializable {
   ParamConfig getParamConfig(StrategyType strategyType);
 }


### PR DESCRIPTION
This PR updates the `ParamConfigManager` interface by extending `Serializable`. This change ensures that implementations of `ParamConfigManager` can be serialized, which may be necessary for distributed processing, caching, or persistence.  

#### Changes:  
- Modified `ParamConfigManager` to implement `Serializable`.  
- Added the necessary `java.io.Serializable` import.  

This change improves compatibility with frameworks or systems that require serialization of configuration managers.