### PR TITLE
Add `GenotypeConverter` interface for genotype-to-strategy parameter conversion  

### DIFF
--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -71,6 +71,16 @@ java_library(
 )
 
 java_library(
+    name = "genotype_converter",
+    srcs = ["GenotypeConverter.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//third_party:jenetics",
+        "//third_party:protobuf_java",
+    ],
+)
+
+java_library(
     name = "run_backtest",
     srcs = ["RunBacktest.java"],
     deps = [

--- a/src/main/java/com/verlumen/tradestream/backtesting/GenotypeConverter.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/GenotypeConverter.java
@@ -1,0 +1,22 @@
+package com.verlumen.tradestream.backtesting;
+
+import com.google.protobuf.Any;
+import com.verlumen.tradestream.strategies.StrategyType;
+import io.jenetics.DoubleGene;
+import io.jenetics.Genotype;
+
+/**
+ * Converts genotypes from the genetic algorithm into strategy parameters.
+ * Encapsulates the conversion logic to make it reusable and testable.
+ */
+interface GenotypeConverter {
+
+  /**
+   * Converts the genotype from the genetic algorithm into strategy parameters.
+   *
+   * @param genotype the genotype resulting from the GA optimization
+   * @param type the type of trading strategy being optimized
+   * @return an Any instance containing the strategy parameters
+   */
+  Any convertToParameters(Genotype<DoubleGene> genotype, StrategyType type);
+}


### PR DESCRIPTION
This PR introduces the `GenotypeConverter` interface in the `backtesting` package. The interface defines a method for converting genotypes from a genetic algorithm into strategy parameters, making the conversion logic reusable and testable.  

#### Changes  
- **Added `GenotypeConverter.java`**  
  - Defines an interface with a `convertToParameters` method to transform genetic algorithm-generated genotypes into strategy parameters.  
  - Uses `Genotype<DoubleGene>` from Jenetics and `Any` from Protobuf to enable flexible parameter conversion.  
- **Updated `BUILD` file**  
  - Added a new `java_library` target (`genotype_converter`) for `GenotypeConverter.java`.  
  - Declared dependencies on:  
    - `//protos:strategies_java_proto`  
    - `//third_party:jenetics`  
    - `//third_party:protobuf_java`  

#### Rationale  
- Facilitates strategy parameter extraction from genetic algorithm optimization results.  
- Encapsulates conversion logic to promote modularity and testability.  
- Enables easier integration with trading strategy execution.  

No breaking changes introduced.