### PR TITLE
Add GAEngineFactory interface for genetic algorithm engine creation

### DIFF
--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -41,7 +41,7 @@ java_library(
     deps = [
         "//protos:backtesting_java_proto",
         "//third_party:jenetics",
-        "//third_party:ta4j",
+        "//third_party:ta4j_core",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -36,6 +36,16 @@ java_library(
 )
 
 java_library(
+    name = "ga_engine_factory",
+    srcs = ["GAEngineFactory.java"],
+    deps = [
+        "//protos:backtesting_java_proto",
+        "//third_party:jenetics",
+        "//third_party:ta4j",
+    ],
+)
+
+java_library(
     name = "ga_service_client",
     srcs = ["GAServiceClient.java"],
     deps = [

--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -41,7 +41,6 @@ java_library(
     deps = [
         "//protos:backtesting_java_proto",
         "//third_party:jenetics",
-        "//third_party:ta4j_core",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/backtesting/GAEngineFactory.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/GAEngineFactory.java
@@ -1,0 +1,23 @@
+package com.verlumen.tradestream.backtesting;
+
+import io.jenetics.DoubleGene;
+import io.jenetics.engine.Engine;
+import org.ta4j.core.BarSeries;
+
+/**
+ * Defines the contract for creating genetic algorithm engines.
+ */
+interface GAEngineFactory {
+    /**
+     * Creates a genetic algorithm engine configured for the given request.
+     *
+     * @param request the GA optimization request
+     * @param series the bar series for backtesting
+     * @param backtestRunner the backtest runner for fitness evaluation
+     * @return a configured GA engine
+     */
+    Engine<DoubleGene, Double> createEngine(
+            GAOptimizationRequest request,
+            BarSeries series,
+            BacktestRunner backtestRunner);
+}

--- a/src/main/java/com/verlumen/tradestream/backtesting/GAEngineFactory.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/GAEngineFactory.java
@@ -2,7 +2,6 @@ package com.verlumen.tradestream.backtesting;
 
 import io.jenetics.DoubleGene;
 import io.jenetics.engine.Engine;
-import org.ta4j.core.BarSeries;
 
 /**
  * Defines the contract for creating genetic algorithm engines.
@@ -16,8 +15,5 @@ interface GAEngineFactory {
      * @param backtestRunner the backtest runner for fitness evaluation
      * @return a configured GA engine
      */
-    Engine<DoubleGene, Double> createEngine(
-            GAOptimizationRequest request,
-            BarSeries series,
-            BacktestRunner backtestRunner);
+    Engine<DoubleGene, Double> createEngine(GAOptimizationRequest request);
 }

--- a/src/main/java/com/verlumen/tradestream/backtesting/GAEngineFactory.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/GAEngineFactory.java
@@ -11,8 +11,6 @@ interface GAEngineFactory {
      * Creates a genetic algorithm engine configured for the given request.
      *
      * @param request the GA optimization request
-     * @param series the bar series for backtesting
-     * @param backtestRunner the backtest runner for fitness evaluation
      * @return a configured GA engine
      */
     Engine<DoubleGene, Double> createEngine(GAOptimizationRequest request);


### PR DESCRIPTION
- Introduced `GAEngineFactory` interface to define a contract for creating genetic algorithm engines.  
- Added `GAEngineFactory.java`, which specifies a method `createEngine(GAOptimizationRequest request)` returning a configured `Engine<DoubleGene, Double>`.  
- Updated `BUILD` file to include a new `java_library` target (`ga_engine_factory`), with dependencies on `//protos:backtesting_java_proto` and `//third_party:jenetics`.  

These changes facilitate the modularization of genetic algorithm engine creation, improving extensibility and maintainability within the backtesting module.