### PR TITLE
Add genotype conversion support in backtesting module

### DIFF
--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -31,6 +31,8 @@ java_library(
     name = "backtesting_module",
     srcs = ["BacktestingModule.java"],
     deps = [
+        ":genotype_converter",
+        ":genotype_converter_impl",
         "//third_party:guice",
     ],
 )

--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -86,6 +86,7 @@ java_library(
     deps = [
         ":genotype_converter",
         "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/backtesting/params:params_lib",
         "//third_party:guava",
         "//third_party:guice",
         "//third_party:jenetics",

--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -84,6 +84,7 @@ java_library(
     name = "genotype_converter_impl",
     srcs = ["GenotypeConverterImpl.java"],
     deps = [
+        ":genotype_converter",
         "//protos:strategies_java_proto",
         "//third_party:guava",
         "//third_party:guice",

--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -71,6 +71,16 @@ java_library(
 )
 
 java_library(
+    name = "genotype_converter",
+    srcs = ["GenotypeConverter.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//third_party:jenetics",
+        "//third_party:protobuf_java",
+    ],
+)
+
+java_library(
     name = "run_backtest",
     srcs = ["RunBacktest.java"],
     deps = [

--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -81,6 +81,18 @@ java_library(
 )
 
 java_library(
+    name = "genotype_converter_impl",
+    srcs = ["GenotypeConverterImpl.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//third_party:guava",
+        "//third_party:guice",
+        "//third_party:jenetics",
+        "//third_party:protobuf_java",
+    ],
+)
+
+java_library(
     name = "run_backtest",
     srcs = ["RunBacktest.java"],
     deps = [

--- a/src/main/java/com/verlumen/tradestream/backtesting/BacktestingModule.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BacktestingModule.java
@@ -8,4 +8,9 @@ public final class BacktestingModule extends AbstractModule {
   public static BacktestingModule create() {
     return new BacktestingModule();
   }
+
+  @Override
+  protected void configure() {
+    bind(GenotypeConverter.class).to(GenotypeConverterImpl.class);
+  }
 }

--- a/src/main/java/com/verlumen/tradestream/backtesting/GenotypeConverter.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/GenotypeConverter.java
@@ -1,0 +1,22 @@
+package com.verlumen.tradestream.backtesting;
+
+import com.google.protobuf.Any;
+import com.verlumen.tradestream.strategies.StrategyType;
+import io.jenetics.DoubleGene;
+import io.jenetics.Genotype;
+
+/**
+ * Converts genotypes from the genetic algorithm into strategy parameters.
+ * Encapsulates the conversion logic to make it reusable and testable.
+ */
+interface GenotypeConverter {
+
+  /**
+   * Converts the genotype from the genetic algorithm into strategy parameters.
+   *
+   * @param genotype the genotype resulting from the GA optimization
+   * @param type the type of trading strategy being optimized
+   * @return an Any instance containing the strategy parameters
+   */
+  Any convertToParameters(Genotype<DoubleGene> genotype, StrategyType type);
+}

--- a/src/main/java/com/verlumen/tradestream/backtesting/GenotypeConverterImpl.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/GenotypeConverterImpl.java
@@ -7,7 +7,6 @@ import com.verlumen.tradestream.backtesting.params.NumericChromosome;
 import com.verlumen.tradestream.backtesting.params.ParamConfig;
 import com.verlumen.tradestream.backtesting.params.ParamConfigManager;
 import com.verlumen.tradestream.strategies.StrategyType;
-import io.jenetics.Chromosome;
 import io.jenetics.DoubleGene;
 import io.jenetics.Genotype;
 
@@ -16,28 +15,29 @@ import io.jenetics.Genotype;
  * Encapsulates the conversion logic to make it reusable and testable.
  */
 public class GenotypeConverterImpl implements GenotypeConverter {
-    private final ParamConfigManager paramConfigManager;
-    
-    @Inject
-    public GenotypeConverterImpl(ParamConfigManager paramConfigManager) {
-        this.paramConfigManager = paramConfigManager;
-    }
-    
-    /**
-     * Converts the genotype from the genetic algorithm into strategy parameters.
-     *
-     * @param genotype the genotype resulting from the GA optimization
-     * @param type the type of trading strategy being optimized
-     * @return an Any instance containing the strategy parameters
-     */
-    public Any convertToParameters(Genotype<DoubleGene> genotype, StrategyType type) {
-        ParamConfig config = paramConfigManager.getParamConfig(type);
-        
-        // Convert Jenetics chromosomes to numeric chromosomes
-        ImmutableList<NumericChromosome<?, ?>> numericChromosomes = genotype.stream()
+  private final ParamConfigManager paramConfigManager;
+
+  @Inject
+  public GenotypeConverterImpl(ParamConfigManager paramConfigManager) {
+    this.paramConfigManager = paramConfigManager;
+  }
+
+  /**
+   * Converts the genotype from the genetic algorithm into strategy parameters.
+   *
+   * @param genotype the genotype resulting from the GA optimization
+   * @param type the type of trading strategy being optimized
+   * @return an Any instance containing the strategy parameters
+   */
+  public Any convertToParameters(Genotype<DoubleGene> genotype, StrategyType type) {
+    ParamConfig config = paramConfigManager.getParamConfig(type);
+
+    // Convert Jenetics chromosomes to numeric chromosomes
+    ImmutableList<NumericChromosome<?, ?>> numericChromosomes =
+        genotype.stream()
             .map(chromosome -> (NumericChromosome<?, ?>) chromosome)
             .collect(ImmutableList.toImmutableList());
-            
-        return config.createParameters(numericChromosomes);
-    }
+
+    return config.createParameters(numericChromosomes);
+  }
 }

--- a/src/main/java/com/verlumen/tradestream/backtesting/GenotypeConverterImpl.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/GenotypeConverterImpl.java
@@ -29,6 +29,7 @@ public class GenotypeConverterImpl implements GenotypeConverter {
    * @param type the type of trading strategy being optimized
    * @return an Any instance containing the strategy parameters
    */
+  @Override
   public Any convertToParameters(Genotype<DoubleGene> genotype, StrategyType type) {
     ParamConfig config = paramConfigManager.getParamConfig(type);
 

--- a/src/main/java/com/verlumen/tradestream/backtesting/GenotypeConverterImpl.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/GenotypeConverterImpl.java
@@ -3,12 +3,12 @@ package com.verlumen.tradestream.backtesting;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import com.google.protobuf.Any;
-import com.verlumen.tradestream.backtesting.params.NumericChromosome;
 import com.verlumen.tradestream.backtesting.params.ParamConfig;
 import com.verlumen.tradestream.backtesting.params.ParamConfigManager;
 import com.verlumen.tradestream.strategies.StrategyType;
 import io.jenetics.DoubleGene;
 import io.jenetics.Genotype;
+import io.jenetics.NumericChromosome;
 
 /**
  * Converts genotypes from the genetic algorithm into strategy parameters.

--- a/src/main/java/com/verlumen/tradestream/backtesting/GenotypeConverterImpl.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/GenotypeConverterImpl.java
@@ -1,0 +1,43 @@
+package com.verlumen.tradestream.backtesting;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import com.google.protobuf.Any;
+import com.verlumen.tradestream.backtesting.params.NumericChromosome;
+import com.verlumen.tradestream.backtesting.params.ParamConfig;
+import com.verlumen.tradestream.backtesting.params.ParamConfigManager;
+import com.verlumen.tradestream.strategies.StrategyType;
+import io.jenetics.Chromosome;
+import io.jenetics.DoubleGene;
+import io.jenetics.Genotype;
+
+/**
+ * Converts genotypes from the genetic algorithm into strategy parameters.
+ * Encapsulates the conversion logic to make it reusable and testable.
+ */
+public class GenotypeConverterImpl implements GenotypeConverter {
+    private final ParamConfigManager paramConfigManager;
+    
+    @Inject
+    public GenotypeConverterImpl(ParamConfigManager paramConfigManager) {
+        this.paramConfigManager = paramConfigManager;
+    }
+    
+    /**
+     * Converts the genotype from the genetic algorithm into strategy parameters.
+     *
+     * @param genotype the genotype resulting from the GA optimization
+     * @param type the type of trading strategy being optimized
+     * @return an Any instance containing the strategy parameters
+     */
+    public Any convertToParameters(Genotype<DoubleGene> genotype, StrategyType type) {
+        ParamConfig config = paramConfigManager.getParamConfig(type);
+        
+        // Convert Jenetics chromosomes to numeric chromosomes
+        ImmutableList<NumericChromosome<?, ?>> numericChromosomes = genotype.stream()
+            .map(chromosome -> (NumericChromosome<?, ?>) chromosome)
+            .collect(ImmutableList.toImmutableList());
+            
+        return config.createParameters(numericChromosomes);
+    }
+}

--- a/src/main/java/com/verlumen/tradestream/backtesting/GenotypeConverterImpl.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/GenotypeConverterImpl.java
@@ -14,11 +14,11 @@ import io.jenetics.NumericChromosome;
  * Converts genotypes from the genetic algorithm into strategy parameters.
  * Encapsulates the conversion logic to make it reusable and testable.
  */
-public class GenotypeConverterImpl implements GenotypeConverter {
+final class GenotypeConverterImpl implements GenotypeConverter {
   private final ParamConfigManager paramConfigManager;
 
   @Inject
-  public GenotypeConverterImpl(ParamConfigManager paramConfigManager) {
+  GenotypeConverterImpl(ParamConfigManager paramConfigManager) {
     this.paramConfigManager = paramConfigManager;
   }
 

--- a/src/test/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/test/java/com/verlumen/tradestream/backtesting/BUILD
@@ -51,6 +51,7 @@ java_test(
     size = "small",
     srcs = ["GenotypeConverterImplTest.java"],
     deps = [
+        "//protos:strategies_java_proto",
         "//src/main/java/com/verlumen/tradestream/backtesting:genotype_converter",
         "//src/main/java/com/verlumen/tradestream/backtesting:genotype_converter_impl",
         "//src/main/java/com/verlumen/tradestream/backtesting/params:params_lib",
@@ -59,10 +60,9 @@ java_test(
         "//third_party:guice_testlib",
         "//third_party:junit",
         "//third_party:mockito_core",
-        "//third_party:truth",
         "//third_party:protobuf_java",
         "//third_party:jenetics",
-        "//protos:strategies_java_proto",
+        "//third_party:truth",
     ],
 )
 

--- a/src/test/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/test/java/com/verlumen/tradestream/backtesting/BUILD
@@ -54,6 +54,7 @@ java_test(
         "//src/main/java/com/verlumen/tradestream/backtesting:genotype_converter",
         "//src/main/java/com/verlumen/tradestream/backtesting:genotype_converter_impl",
         "//src/main/java/com/verlumen/tradestream/backtesting/params:params_lib",
+        "//third_party:guava",
         "//third_party:guice",
         "//third_party:guice_testlib",
         "//third_party:junit",

--- a/src/test/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/test/java/com/verlumen/tradestream/backtesting/BUILD
@@ -47,6 +47,25 @@ java_test(
 )
 
 java_test(
+    name = "GenotypeConverterImplTest",
+    size = "small",
+    srcs = ["GenotypeConverterImplTest.java"],
+    deps = [
+        "//src/main/java/com/verlumen/tradestream/backtesting:genotype_converter",
+        "//src/main/java/com/verlumen/tradestream/backtesting:genotype_converter_impl",
+        "//src/main/java/com/verlumen/tradestream/backtesting/params:params_lib",
+        "//third_party:guice",
+        "//third_party:guice_testlib",
+        "//third_party:junit",
+        "//third_party:mockito_core",
+        "//third_party:truth",
+        "//third_party:protobuf_java",
+        "//third_party:jenetics",
+        "//protos:strategies_java_proto",
+    ],
+)
+
+java_test(
     name = "RunBacktestTest",
     size = "small",
     srcs = ["RunBacktestTest.java"],

--- a/src/test/java/com/verlumen/tradestream/backtesting/GenotypeConverterImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/backtesting/GenotypeConverterImplTest.java
@@ -19,6 +19,7 @@ import io.jenetics.DoubleChromosome;
 import io.jenetics.DoubleGene;
 import io.jenetics.Genotype;
 import io.jenetics.IntegerChromosome;
+import io.jenetics.IntegerGene;
 import io.jenetics.NumericChromosome;
 import io.jenetics.util.IntRange;
 import org.junit.Before;
@@ -59,11 +60,17 @@ public class GenotypeConverterImplTest {
         when(mockParamConfig.getChromosomeSpecs()).thenReturn(chromosomeSpecs);
 
         // Create a sample Genotype (ensure it matches the ChromosomeSpecs)
+        IntegerChromosome maPeriodChromosome = IntegerChromosome.of(IntRange.of(5, 50));
+        IntegerChromosome rsiPeriodChromosome = IntegerChromosome.of(IntRange.of(2, 30));
+        DoubleChromosome overboughtChromosome = DoubleChromosome.of(60.0, 85.0);
+        DoubleChromosome oversoldChromosome = DoubleChromosome.of(15.0, 40.0);
+        
+        // Create the genotype with default values
         Genotype<DoubleGene> genotype = Genotype.of(
-                IntegerChromosome.of(5, 50).newInstance(10),     // MA Period = 10
-                IntegerChromosome.of(2, 30).newInstance(15),     // RSI Period = 15
-                DoubleChromosome.of(60.0, 85.0).newInstance(70.0), // Overbought = 70.0
-                DoubleChromosome.of(15.0, 40.0).newInstance(30.0)  // Oversold = 30.0
+                maPeriodChromosome,
+                rsiPeriodChromosome,
+                overboughtChromosome,
+                oversoldChromosome
         );
 
         // Create a sample Any (what your createParameters would return)
@@ -114,7 +121,7 @@ public class GenotypeConverterImplTest {
         // Create a Genotype with mismatching chromosome type (Double instead of Integer)
         Genotype<DoubleGene> invalidGenotype = Genotype.of(
                 // Invalid: using a DoubleChromosome where IntegerChromosome is expected.
-                DoubleChromosome.of(1.0, 10.0)  // This is invalid
+                DoubleChromosome.of(1.0, 10.0)
         );
 
         // Mock the exception when parameter creation is attempted with invalid chromosome types

--- a/src/test/java/com/verlumen/tradestream/backtesting/GenotypeConverterImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/backtesting/GenotypeConverterImplTest.java
@@ -1,0 +1,125 @@
+package com.verlumen.tradestream.backtesting;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.testing.fieldbinder.Bind;
+import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import com.google.protobuf.Any;
+import com.google.protobuf.Int32Value;
+import com.verlumen.tradestream.backtesting.params.ChromosomeSpec;
+import com.verlumen.tradestream.backtesting.params.ParamConfig;
+import com.verlumen.tradestream.backtesting.params.ParamConfigManager;
+import com.verlumen.tradestream.strategies.StrategyType;
+import io.jenetics.DoubleChromosome;
+import io.jenetics.DoubleGene;
+import io.jenetics.Genotype;
+import io.jenetics.IntegerChromosome;
+import io.jenetics.NumericChromosome;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+@RunWith(JUnit4.class)
+public class GenotypeConverterImplTest {
+    @Rule public MockitoRule rule = MockitoJUnit.rule();
+
+    @Bind @Mock private ParamConfigManager mockParamConfigManager;
+    @Bind @Mock private ParamConfig mockParamConfig;
+
+    @Inject private GenotypeConverterImpl converter;
+
+    @Before
+    public void setUp() {
+        Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+    }
+
+    @Test
+    public void convertToParameters_validGenotype_returnsCorrectParameters() {
+        // Arrange
+        StrategyType strategyType = StrategyType.SMA_RSI;
+        ImmutableList<ChromosomeSpec<?>> chromosomeSpecs = ImmutableList.of(
+                ChromosomeSpec.ofInteger(5, 50),    // Moving Average Period
+                ChromosomeSpec.ofInteger(2, 30),    // RSI Period
+                ChromosomeSpec.ofDouble(60.0, 85.0), // Overbought Threshold
+                ChromosomeSpec.ofDouble(15.0, 40.0)  // Oversold Threshold
+        );
+
+        when(mockParamConfigManager.getParamConfig(strategyType)).thenReturn(mockParamConfig);
+        when(mockParamConfig.getChromosomeSpecs()).thenReturn(chromosomeSpecs);
+
+        // Create a sample Genotype (ensure it matches the ChromosomeSpecs)
+        Genotype<DoubleGene> genotype = Genotype.of(
+                IntegerChromosome.of(10, 5, 50),     // MA Period = 10
+                IntegerChromosome.of(15, 2, 30),     // RSI Period = 15
+                DoubleChromosome.of(70.0, 60.0, 85.0), // Overbought = 70.0
+                DoubleChromosome.of(30.0, 15.0, 40.0)  // Oversold = 30.0
+        );
+
+        // Create a sample Any (what your createParameters would return)
+        Any expectedParameters = Any.pack(Int32Value.of(42)); // Dummy value
+        ImmutableList<NumericChromosome<?, ?>> numericChromosomes = ImmutableList.of(
+                (NumericChromosome<?, ?>) genotype.get(0),
+                (NumericChromosome<?, ?>) genotype.get(1),
+                (NumericChromosome<?, ?>) genotype.get(2),
+                (NumericChromosome<?, ?>) genotype.get(3)
+        );
+        when(mockParamConfig.createParameters(numericChromosomes)).thenReturn(expectedParameters);
+
+        // Act
+        Any actualParameters = converter.convertToParameters(genotype, strategyType);
+
+        // Assert
+        assertThat(actualParameters).isEqualTo(expectedParameters);
+    }
+
+    @Test
+    public void convertToParameters_nullGenotype_throwsNullPointerException() {
+        // Arrange
+        StrategyType strategyType = StrategyType.SMA_RSI;
+
+        // Act & Assert
+        assertThrows(NullPointerException.class, () -> converter.convertToParameters(null, strategyType));
+    }
+
+    @Test
+    public void convertToParameters_nullStrategyType_throwsNullPointerException() {
+        // Arrange
+        Genotype<DoubleGene> genotype = Genotype.of(DoubleChromosome.of(0.0, 1.0));
+
+        // Act & Assert
+        assertThrows(NullPointerException.class, () -> converter.convertToParameters(genotype, null));
+    }
+
+    @Test
+    public void convertToParameters_invalidGenotype_throwsIllegalArgumentException() {
+        // Arrange
+        StrategyType strategyType = StrategyType.SMA_RSI;
+        ImmutableList<ChromosomeSpec<?>> chromosomeSpecs = ImmutableList.of(
+            ChromosomeSpec.ofInteger(5, 50)
+        );
+        when(mockParamConfigManager.getParamConfig(strategyType)).thenReturn(mockParamConfig);
+        when(mockParamConfig.getChromosomeSpecs()).thenReturn(chromosomeSpecs);
+
+        // Create a Genotype with mismatching chromosome type (String instead of Integer/Double)
+        Genotype<DoubleGene> invalidGenotype = Genotype.of(
+                // Invalid: using a DoubleChromosome where IntegerChromosome is expected.
+                DoubleChromosome.of(1.0, 10.0)  // This is invalid
+        );
+
+        // Act and Assert
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> converter.convertToParameters(invalidGenotype, strategyType)
+        );
+    }
+}

--- a/src/test/java/com/verlumen/tradestream/backtesting/GenotypeConverterImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/backtesting/GenotypeConverterImplTest.java
@@ -20,6 +20,7 @@ import io.jenetics.DoubleGene;
 import io.jenetics.Genotype;
 import io.jenetics.IntegerChromosome;
 import io.jenetics.NumericChromosome;
+import io.jenetics.util.IntRange;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -59,10 +60,10 @@ public class GenotypeConverterImplTest {
 
         // Create a sample Genotype (ensure it matches the ChromosomeSpecs)
         Genotype<DoubleGene> genotype = Genotype.of(
-                IntegerChromosome.of(10, 5, 50),     // MA Period = 10
-                IntegerChromosome.of(15, 2, 30),     // RSI Period = 15
-                DoubleChromosome.of(70.0, 60.0, 85.0), // Overbought = 70.0
-                DoubleChromosome.of(30.0, 15.0, 40.0)  // Oversold = 30.0
+                IntegerChromosome.of(5, 50).newInstance(10),     // MA Period = 10
+                IntegerChromosome.of(2, 30).newInstance(15),     // RSI Period = 15
+                DoubleChromosome.of(60.0, 85.0).newInstance(70.0), // Overbought = 70.0
+                DoubleChromosome.of(15.0, 40.0).newInstance(30.0)  // Oversold = 30.0
         );
 
         // Create a sample Any (what your createParameters would return)
@@ -110,11 +111,16 @@ public class GenotypeConverterImplTest {
         when(mockParamConfigManager.getParamConfig(strategyType)).thenReturn(mockParamConfig);
         when(mockParamConfig.getChromosomeSpecs()).thenReturn(chromosomeSpecs);
 
-        // Create a Genotype with mismatching chromosome type (String instead of Integer/Double)
+        // Create a Genotype with mismatching chromosome type (Double instead of Integer)
         Genotype<DoubleGene> invalidGenotype = Genotype.of(
                 // Invalid: using a DoubleChromosome where IntegerChromosome is expected.
                 DoubleChromosome.of(1.0, 10.0)  // This is invalid
         );
+
+        // Mock the exception when parameter creation is attempted with invalid chromosome types
+        when(mockParamConfig.createParameters(
+            ImmutableList.of((NumericChromosome<?, ?>) invalidGenotype.get(0))))
+            .thenThrow(new IllegalArgumentException("Invalid chromosome type"));
 
         // Act and Assert
         assertThrows(


### PR DESCRIPTION
This PR introduces support for genotype conversion in the backtesting module by implementing `GenotypeConverterImpl`. The changes facilitate the transformation of genetic algorithm genotypes into strategy parameters, improving modularity and testability.

#### Changes
- **Added `GenotypeConverterImpl`**: Implements `GenotypeConverter` to convert genotypes into strategy parameters using `ParamConfigManager`.
- **Updated `BacktestingModule`**: Binds `GenotypeConverter` to `GenotypeConverterImpl` using Guice for dependency injection.
- **Updated `BUILD` files**:
  - Added `genotype_converter_impl` target.
  - Included necessary dependencies such as `protobuf_java`, `jenetics`, and `params_lib`.
- **Added unit tests (`GenotypeConverterImplTest`)**:
  - Validates correct genotype conversion behavior.
  - Ensures proper handling of null inputs and invalid genotype structures.
  - Uses Mockito for dependency mocking and Guice for dependency injection in tests.

These updates enhance the flexibility and maintainability of genotype conversion logic in the backtesting module.