### PR TITLE
Add `ga_constants` Java library to Backtesting module

### DIFF
--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -45,6 +45,11 @@ java_library(
 )
 
 java_library(
+    name = "ga_constants",
+    srcs = ["GAConstants.java"],
+)
+
+java_library(
     name = "ga_engine_factory",
     srcs = ["GAEngineFactory.java"],
     deps = [


### PR DESCRIPTION
This PR introduces a new Java library, `ga_constants`, to the `backtesting` module. The library includes `GAConstants.java` as a source file. 

#### Changes:
- Added a new `java_library` target named `ga_constants` in `BUILD`
- Included `GAConstants.java` as the source for the `ga_constants` library

This change improves modularity by separating constant definitions into a dedicated library, which can be reused across other components in the `backtesting` module.