### PR TITLE
Add `StrategyState` interface for managing strategy state and performance tracking  

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -159,3 +159,14 @@ java_library(
         "//third_party:ta4j_core",
     ],
 )
+
+java_library(
+    name = "strategy_state",
+    srcs = ["StrategyState.java"],
+    deps = [
+        ":strategy_manager",
+        "//protos:strategies_java_proto",
+        "//third_party:protobuf_java",
+        "//third_party:ta4j_core",
+    ],
+)

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyState.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyState.java
@@ -1,4 +1,4 @@
-package com.verlumen.tradestream.pipeline.strategies;
+package com.verlumen.tradestream.strategies;
 
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyState.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyState.java
@@ -1,101 +1,65 @@
 package com.verlumen.tradestream.pipeline.strategies;
 
-import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.verlumen.tradestream.marketdata.Candle;
 import com.verlumen.tradestream.strategies.Strategy;
 import com.verlumen.tradestream.strategies.StrategyManager;
 import com.verlumen.tradestream.strategies.StrategyType;
 import org.ta4j.core.BarSeries;
 
-import java.io.Serializable;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
 /**
- * Maintains the state for the current strategy and records for all available strategies.
- * This class is serializable to support Beam state APIs.
+ * Interface for maintaining the state for the current strategy and
+ * recording performance for all available strategies.
  */
-public class StrategyState implements Serializable {
-  private final Map<StrategyType, StrategyRecord> strategyRecords;
-  private StrategyType currentStrategyType;
-  private transient org.ta4j.core.Strategy currentStrategy;
-  
-  // Strategy state can be initialized with empty records, or with predefined records
-  private StrategyState(Map<StrategyType, StrategyRecord> strategyRecords,
-                        StrategyType currentStrategyType) {
-    this.strategyRecords = strategyRecords;
-    this.currentStrategyType = currentStrategyType;
-    // Note: currentStrategy is transient and will be reconstructed as needed
-  }
-  
-  // Initialize with default parameters from the StrategyManager
-  public static StrategyState initialize(StrategyManager strategyManager, BarSeries series) {
-    Map<StrategyType, StrategyRecord> records = new ConcurrentHashMap<>();
-    for (StrategyType type : strategyManager.getStrategyTypes()) {
-      records.put(type, new StrategyRecord(type, 
-          strategyManager.getDefaultParameters(type), Double.NEGATIVE_INFINITY));
-    }
+public interface StrategyState {
     
-    StrategyType defaultType = StrategyType.SMA_RSI;
-    StrategyState state = new StrategyState(records, defaultType);
+    /**
+     * Reconstruct or return the current strategy.
+     *
+     * @param strategyManager the strategy manager
+     * @param series the market data series
+     * @return the current TA4J strategy
+     * @throws InvalidProtocolBufferException if the strategy parameters are invalid
+     */
+    org.ta4j.core.Strategy getCurrentStrategy(StrategyManager strategyManager, BarSeries series)
+            throws InvalidProtocolBufferException;
     
-    // Initialize the current strategy
-    try {
-      state.currentStrategy = strategyManager.createStrategy(series, defaultType);
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to initialize default strategy", e);
-    }
+    /**
+     * Update the record for a given strategy type.
+     *
+     * @param type the strategy type
+     * @param parameters the parameters for the strategy
+     * @param score the performance score
+     */
+    void updateRecord(StrategyType type, Any parameters, double score);
     
-    return state;
-  }
-  
-  // Reconstruct the current strategy if needed (e.g., after deserialization)
-  public org.ta4j.core.Strategy getCurrentStrategy(StrategyManager strategyManager, 
-                                                 BarSeries series) 
-                                                 throws InvalidProtocolBufferException {
-    if (currentStrategy == null) {
-      StrategyRecord record = strategyRecords.get(currentStrategyType);
-      currentStrategy = strategyManager.createStrategy(
-          series, currentStrategyType, record.parameters());
-    }
-    return currentStrategy;
-  }
-  
-  public void updateRecord(StrategyType type, Any parameters, double score) {
-    strategyRecords.put(type, new StrategyRecord(type, parameters, score));
-  }
-  
-  public StrategyState selectBestStrategy(StrategyManager strategyManager, BarSeries series) {
-    StrategyRecord bestRecord = strategyRecords.values().stream()
-        .max((r1, r2) -> Double.compare(r1.score(), r2.score()))
-        .orElseThrow(() -> new IllegalStateException("No optimized strategy found"));
+    /**
+     * Select and initialize the best strategy from the recorded strategies.
+     *
+     * @param strategyManager the strategy manager
+     * @param series the market data series
+     * @return the updated strategy state
+     */
+    StrategyState selectBestStrategy(StrategyManager strategyManager, BarSeries series);
     
-    this.currentStrategyType = bestRecord.strategyType();
-    try {
-      this.currentStrategy = strategyManager.createStrategy(
-          series, currentStrategyType, bestRecord.parameters());
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to create strategy", e);
-    }
+    /**
+     * Convert the current state to a strategy message.
+     *
+     * @return the strategy message
+     */
+    Strategy toStrategyMessage();
     
-    return this;
-  }
-  
-  public Strategy toStrategyMessage() {
-    StrategyRecord record = strategyRecords.get(currentStrategyType);
-    return Strategy.newBuilder()
-        .setType(currentStrategyType)
-        .setParameters(record.parameters())
-        .build();
-  }
-  
-  public Iterable<StrategyType> getStrategyTypes() {
-    return strategyRecords.keySet();
-  }
-  
-  public StrategyType getCurrentStrategyType() {
-    return currentStrategyType;
-  }
+    /**
+     * Get all strategy types recorded.
+     *
+     * @return an iterable of strategy types
+     */
+    Iterable<StrategyType> getStrategyTypes();
+    
+    /**
+     * Get the type of the currently active strategy.
+     *
+     * @return the current strategy type
+     */
+    StrategyType getCurrentStrategyType();
 }

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyState.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyState.java
@@ -2,9 +2,6 @@ package com.verlumen.tradestream.pipeline.strategies;
 
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.verlumen.tradestream.strategies.Strategy;
-import com.verlumen.tradestream.strategies.StrategyManager;
-import com.verlumen.tradestream.strategies.StrategyType;
 import org.ta4j.core.BarSeries;
 
 /**

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyState.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyState.java
@@ -1,0 +1,101 @@
+package com.verlumen.tradestream.pipeline.strategies;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.verlumen.tradestream.marketdata.Candle;
+import com.verlumen.tradestream.strategies.Strategy;
+import com.verlumen.tradestream.strategies.StrategyManager;
+import com.verlumen.tradestream.strategies.StrategyType;
+import org.ta4j.core.BarSeries;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Maintains the state for the current strategy and records for all available strategies.
+ * This class is serializable to support Beam state APIs.
+ */
+public class StrategyState implements Serializable {
+  private final Map<StrategyType, StrategyRecord> strategyRecords;
+  private StrategyType currentStrategyType;
+  private transient org.ta4j.core.Strategy currentStrategy;
+  
+  // Strategy state can be initialized with empty records, or with predefined records
+  private StrategyState(Map<StrategyType, StrategyRecord> strategyRecords,
+                        StrategyType currentStrategyType) {
+    this.strategyRecords = strategyRecords;
+    this.currentStrategyType = currentStrategyType;
+    // Note: currentStrategy is transient and will be reconstructed as needed
+  }
+  
+  // Initialize with default parameters from the StrategyManager
+  public static StrategyState initialize(StrategyManager strategyManager, BarSeries series) {
+    Map<StrategyType, StrategyRecord> records = new ConcurrentHashMap<>();
+    for (StrategyType type : strategyManager.getStrategyTypes()) {
+      records.put(type, new StrategyRecord(type, 
+          strategyManager.getDefaultParameters(type), Double.NEGATIVE_INFINITY));
+    }
+    
+    StrategyType defaultType = StrategyType.SMA_RSI;
+    StrategyState state = new StrategyState(records, defaultType);
+    
+    // Initialize the current strategy
+    try {
+      state.currentStrategy = strategyManager.createStrategy(series, defaultType);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to initialize default strategy", e);
+    }
+    
+    return state;
+  }
+  
+  // Reconstruct the current strategy if needed (e.g., after deserialization)
+  public org.ta4j.core.Strategy getCurrentStrategy(StrategyManager strategyManager, 
+                                                 BarSeries series) 
+                                                 throws InvalidProtocolBufferException {
+    if (currentStrategy == null) {
+      StrategyRecord record = strategyRecords.get(currentStrategyType);
+      currentStrategy = strategyManager.createStrategy(
+          series, currentStrategyType, record.parameters());
+    }
+    return currentStrategy;
+  }
+  
+  public void updateRecord(StrategyType type, Any parameters, double score) {
+    strategyRecords.put(type, new StrategyRecord(type, parameters, score));
+  }
+  
+  public StrategyState selectBestStrategy(StrategyManager strategyManager, BarSeries series) {
+    StrategyRecord bestRecord = strategyRecords.values().stream()
+        .max((r1, r2) -> Double.compare(r1.score(), r2.score()))
+        .orElseThrow(() -> new IllegalStateException("No optimized strategy found"));
+    
+    this.currentStrategyType = bestRecord.strategyType();
+    try {
+      this.currentStrategy = strategyManager.createStrategy(
+          series, currentStrategyType, bestRecord.parameters());
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to create strategy", e);
+    }
+    
+    return this;
+  }
+  
+  public Strategy toStrategyMessage() {
+    StrategyRecord record = strategyRecords.get(currentStrategyType);
+    return Strategy.newBuilder()
+        .setType(currentStrategyType)
+        .setParameters(record.parameters())
+        .build();
+  }
+  
+  public Iterable<StrategyType> getStrategyTypes() {
+    return strategyRecords.keySet();
+  }
+  
+  public StrategyType getCurrentStrategyType() {
+    return currentStrategyType;
+  }
+}


### PR DESCRIPTION
This PR introduces the `StrategyState` interface, which provides a standardized way to manage and persist the state of trading strategies in the `tradestream` module. It enables tracking strategy performance, selecting the best-performing strategy, and reconstructing a strategy based on stored parameters.  

#### Key Changes  
- **Added `StrategyState.java`**  
  - Defines methods for retrieving and selecting strategies.  
  - Supports performance tracking via `updateRecord`.  
  - Converts strategy state to a message format for persistence.  
- **Updated `BUILD` file**  
  - Added a new `strategy_state` Java library with dependencies on `strategy_manager`, `protobuf_java`, and `ta4j_core`.  

#### Rationale  
This change enhances the flexibility of the trading strategy module by enabling strategy persistence and selection based on performance metrics. This is particularly useful for adaptive or machine-learning-driven strategy selection.