### PR TITLE
Add `StrategyRecord` for strategy parameter and performance tracking  

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -161,6 +161,16 @@ java_library(
 )
 
 java_library(
+    name = "strategy_record",
+    srcs = ["StrategyRecord.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//third_party:guava",
+        "//third_party:protobuf_java",
+    ],
+)
+
+java_library(
     name = "strategy_state",
     srcs = ["StrategyState.java"],
     deps = [

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyRecord.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyRecord.java
@@ -1,0 +1,16 @@
+package com.verlumen.tradestream.strategies;
+
+import com.google.protobuf.Any;
+import java.io.Serializable;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Immutable record of a strategy's parameters and performance score.
+ */
+record StrategyRecord(StrategyType strategyType, Any parameters, double score)
+    implements Serializable {
+  
+  public StrategyRecord {
+    checkNotNull(strategyType, "Strategy type cannot be null");
+  }
+}


### PR DESCRIPTION
This PR introduces a new `StrategyRecord` class in the `com.verlumen.tradestream.strategies` package. The class serves as an immutable record to encapsulate strategy parameters and performance scores.  

#### Changes  
- **Added `StrategyRecord.java`**  
  - Defines `StrategyRecord`, which implements `Serializable`.  
  - Stores a `StrategyType`, `Any` parameters, and a performance score (`double`).  
  - Enforces non-null strategy type using `Preconditions.checkNotNull()`.  
- **Updated `BUILD` file**  
  - Added a new `java_library` target named `strategy_record`.  
  - Included necessary dependencies (`guava`, `protobuf_java`, and `strategies_java_proto`).  

#### Rationale  
The introduction of `StrategyRecord` provides a structured way to store and track strategy configurations and their effectiveness, facilitating better strategy evaluation and comparison.