### PR TITLE
Refactor `StrategyState` Interface: Remove `StrategyManager` Dependency  

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -164,7 +164,6 @@ java_library(
     name = "strategy_state",
     srcs = ["StrategyState.java"],
     deps = [
-        ":strategy_manager",
         "//protos:strategies_java_proto",
         "//third_party:protobuf_java",
         "//third_party:ta4j_core",

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyState.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyState.java
@@ -8,17 +8,16 @@ import org.ta4j.core.BarSeries;
  * Interface for maintaining the state for the current strategy and
  * recording performance for all available strategies.
  */
-public interface StrategyState {
+interface StrategyState {
     
     /**
      * Reconstruct or return the current strategy.
      *
-     * @param strategyManager the strategy manager
      * @param series the market data series
      * @return the current TA4J strategy
      * @throws InvalidProtocolBufferException if the strategy parameters are invalid
      */
-    org.ta4j.core.Strategy getCurrentStrategy(StrategyManager strategyManager, BarSeries series)
+    org.ta4j.core.Strategy getCurrentStrategy(BarSeries series)
             throws InvalidProtocolBufferException;
     
     /**
@@ -33,11 +32,10 @@ public interface StrategyState {
     /**
      * Select and initialize the best strategy from the recorded strategies.
      *
-     * @param strategyManager the strategy manager
      * @param series the market data series
      * @return the updated strategy state
      */
-    StrategyState selectBestStrategy(StrategyManager strategyManager, BarSeries series);
+    StrategyState selectBestStrategy(BarSeries series);
     
     /**
      * Convert the current state to a strategy message.


### PR DESCRIPTION
This PR removes the `StrategyManager` dependency from the `StrategyState` interface, streamlining its design by reducing unnecessary coupling.  

#### Changes:  
- **Modified `StrategyState` Interface:**  
  - Removed `StrategyManager` parameter from `getCurrentStrategy` and `selectBestStrategy` methods.  
  - Updated method signatures accordingly.  
  - Changed interface visibility from `public` to package-private for better encapsulation.  
- **Updated BUILD File:**  
  - Removed `:strategy_manager` dependency from `strategy_state` target.  

These changes improve modularity and maintainability by ensuring `StrategyState` does not directly depend on `StrategyManager`, making it easier to manage and test.