### PR TITLE
Add factory methods for StrategyRecord instantiation  

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyRecord.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyRecord.java
@@ -1,16 +1,24 @@
 package com.verlumen.tradestream.strategies;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.protobuf.Any;
 import java.io.Serializable;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Immutable record of a strategy's parameters and performance score.
  */
 record StrategyRecord(StrategyType strategyType, Any parameters, double score)
     implements Serializable {
-  
-  public StrategyRecord {
-    checkNotNull(strategyType, "Strategy type cannot be null");
+  static StrategyRecord create(StrategyType strategyType, Any parameters) {
+      return create(strategyType, parameters, Double.NEGATIVE_INFINITY);    
+  }
+
+  static StrategyRecord create(StrategyType strategyType, Any parameters, double score) {
+      return new StrategyRecord(strategyType, parameters, score);    
+  }
+
+  StrategyRecord {
+    checkNotNull(strategyType, "Strategy strategyType cannot be null");
   }
 }


### PR DESCRIPTION
This PR introduces factory methods to simplify the instantiation of `StrategyRecord`. The changes include:  

- Adding a `create` method with default score initialization (`Double.NEGATIVE_INFINITY`).
- Providing an overloaded `create` method that allows setting a custom score.
- Moving the `checkNotNull` validation inside the constructor for `strategyType`.
- Reordering imports to align with convention.  

These changes improve usability by providing a more flexible way to create `StrategyRecord` instances while ensuring immutability remains intact.