### PR TITLE
Add Serializable Support and Factory Interface to StrategyState

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyState.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyState.java
@@ -2,13 +2,14 @@ package com.verlumen.tradestream.strategies;
 
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
+import java.io.Serializable;
 import org.ta4j.core.BarSeries;
 
 /**
  * Interface for maintaining the state for the current strategy and
  * recording performance for all available strategies.
  */
-interface StrategyState {    
+interface StrategyState extends Serializable {    
     /**
      * Reconstruct or return the current strategy.
      *
@@ -55,4 +56,21 @@ interface StrategyState {
      * @return the current strategy type
      */
     StrategyType getCurrentStrategyType();
+
+    /**
+     * Factory interface for creating instances of {@link StrategyState}.
+     * <p>
+     * Implementations of this interface should provide a method to
+     * create a new instance of {@code StrategyState}, which is used to
+     * initialize the state for a trading strategy.
+     * </p>
+     */
+    interface Factory extends Serializable {
+        /**
+         * Creates and returns a new instance of {@link StrategyState}.
+         *
+         * @return a new instance of {@code StrategyState}
+         */
+        StrategyState create();
+    }
 }


### PR DESCRIPTION
This update enhances `StrategyState` by making it `Serializable`, allowing instances to be serialized for persistence or distributed processing. Additionally, a new `Factory` interface is introduced within `StrategyState`, providing a structured way to create instances of `StrategyState`. This ensures a standardized approach to instantiating strategy state objects, which is beneficial for dependency injection and strategy initialization.

#### Changes:
- Implemented `Serializable` in `StrategyState` to support serialization.
- Added an inner `Factory` interface that also extends `Serializable`, providing a method to create new `StrategyState` instances.
- Updated JavaDocs to document the new interface and its intended use.

These changes improve the flexibility and maintainability of the strategy state management system.