### PR TITLE
Refactor test dependencies in trade signal test BUILD file

### DIFF
--- a/src/test/java/com/verlumen/tradestream/signals/BUILD
+++ b/src/test/java/com/verlumen/tradestream/signals/BUILD
@@ -6,6 +6,8 @@ java_test(
     deps = [
         "//protos:trade_signals_java_proto",
         "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/signals:trade_signal_publisher",
+        "//src/main/java/com/verlumen/tradestream/signals:trade_signal_publisher_impl",
         "//third_party:guice",
         "//third_party:guice_assistedinject",
         "//third_party:guice_testlib",
@@ -13,7 +15,5 @@ java_test(
         "//third_party:kafka_clients",
         "//third_party:mockito_core",
         "//third_party:truth",
-        "//src/main/java/com/verlumen/tradestream/signals:trade_signal_publisher",
-        "//src/main/java/com/verlumen/tradestream/signals:trade_signal_publisher_impl",
     ],
 )


### PR DESCRIPTION
This PR modifies the `BUILD` file for trade signal tests by adjusting the dependencies:
- Moves `trade_signal_publisher` and `trade_signal_publisher_impl` within the `deps` list to maintain proper ordering.
- Ensures consistency and readability in the test dependencies.

This change improves maintainability without affecting functionality.