### PR TITLE
Remove unused ExecutorService binding in StrategiesModule  

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.java
@@ -25,7 +25,6 @@ abstract class StrategiesModule extends AbstractModule {
   @Override
   protected void configure() {
     bind(CandleBuffer.class).to(CandleBufferImpl.class);
-    bind(ExecutorService.class).toProvider(Executors::newSingleThreadExecutor);
     bind(StrategyEngine.class).to(StrategyEngineImpl.class);
     bind(new TypeLiteral<ImmutableList<StrategyFactory<?>>>() {})
         .toInstance(StrategyFactories.ALL_FACTORIES);


### PR DESCRIPTION
This PR removes the binding of `ExecutorService` in `StrategiesModule`, as it is no longer required. The unnecessary dependency was previously instantiated using `Executors::newSingleThreadExecutor`, but it is now redundant and has been removed to simplify the module configuration.  

This change improves maintainability by eliminating unused bindings without affecting the existing strategy engine functionality.