### PR TITLE
Add `Serializable` to `TradeSignalPublisher` interface  

### DIFF
--- a/src/main/java/com/verlumen/tradestream/signals/TradeSignalPublisher.java
+++ b/src/main/java/com/verlumen/tradestream/signals/TradeSignalPublisher.java
@@ -1,6 +1,8 @@
 package com.verlumen.tradestream.signals;
 
-public interface TradeSignalPublisher {
+import java.io.Serializable;
+
+public interface TradeSignalPublisher extends Serializable {
     void publish(TradeSignal signal);
 
     void close();


### PR DESCRIPTION
This PR updates the `TradeSignalPublisher` interface to extend `Serializable`. This change ensures that instances of implementing classes can be serialized, which may be necessary for distributed processing, persistence, or network communication.  

#### Changes  
- Added `import java.io.Serializable;`  
- Modified `TradeSignalPublisher` to extend `Serializable`  

#### Rationale  
- Enables serialization for classes implementing `TradeSignalPublisher`  
- Supports potential use cases such as distributed messaging or caching  

No functional changes were introduced, and existing behavior remains unaffected.