### PR TITLE
Refactor: Move ChromosomeSpec classes and update dependencies

### DIFF
--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -53,8 +53,6 @@ java_library(
         "IntegerChromosomeSpec.java",
     ],
     deps = [
-        ":double_chromosome_spec",
-        ":integer_chromosome_spec",
         "//third_party:guava",
         "//third_party:jenetics",
     ],

--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -49,6 +49,8 @@ java_library(
     name = "chromosome_spec",
     srcs = ["ChromosomeSpec.java"],
     deps = [
+        ":dounle_chromosome_spec",
+        ":integer_chromosome_spec",
         "//third_party:guava",
         "//third_party:jenetics",
     ],

--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -100,6 +100,7 @@ java_library(
     name = "ga_engine_factory_impl",
     srcs = ["GAEngineFactoryImpl.java"],
     deps = [
+        ":chromosome_spec",
         ":fitness_calculator",
         ":ga_constants",
         ":ga_engine_factory",

--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -55,6 +55,15 @@ java_library(
 )
 
 java_library(
+    name = "double_chromosome_spec",
+    srcs = ["DoubleChromosomeSpec.java"],
+    deps = [
+        "//third_party:guava",
+        "//third_party:jenetics",
+    ],
+)
+
+java_library(
     name = "fitness_calculator",
     srcs = ["FitnessCalculator.java"],
     deps = [
@@ -151,6 +160,15 @@ java_library(
         "//third_party:guice",
         "//third_party:jenetics",
         "//third_party:protobuf_java",
+    ],
+)
+
+java_library(
+    name = "integer_chromosome_spec",
+    srcs = ["IntegerChromosomeSpec.java"],
+    deps = [
+        "//third_party:guava",
+        "//third_party:jenetics",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -47,19 +47,14 @@ java_library(
 
 java_library(
     name = "chromosome_spec",
-    srcs = ["ChromosomeSpec.java"],
+    srcs = [
+        "ChromosomeSpec.java",
+        "DoubleChromosomeSpec.java",
+        "IntegerChromosomeSpec.java",
+    ],
     deps = [
         ":double_chromosome_spec",
         ":integer_chromosome_spec",
-        "//third_party:guava",
-        "//third_party:jenetics",
-    ],
-)
-
-java_library(
-    name = "double_chromosome_spec",
-    srcs = ["DoubleChromosomeSpec.java"],
-    deps = [
         "//third_party:guava",
         "//third_party:jenetics",
     ],
@@ -162,15 +157,6 @@ java_library(
         "//third_party:guice",
         "//third_party:jenetics",
         "//third_party:protobuf_java",
-    ],
-)
-
-java_library(
-    name = "integer_chromosome_spec",
-    srcs = ["IntegerChromosomeSpec.java"],
-    deps = [
-        "//third_party:guava",
-        "//third_party:jenetics",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -46,6 +46,15 @@ java_library(
 )
 
 java_library(
+    name = "chromosome_spec",
+    srcs = ["ChromosomeSpec.java"],
+    deps = [
+        "//third_party:guava",
+        "//third_party:jenetics",
+    ],
+)
+
+java_library(
     name = "fitness_calculator",
     srcs = ["FitnessCalculator.java"],
     deps = [

--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -49,7 +49,7 @@ java_library(
     name = "chromosome_spec",
     srcs = ["ChromosomeSpec.java"],
     deps = [
-        ":dounle_chromosome_spec",
+        ":double_chromosome_spec",
         ":integer_chromosome_spec",
         "//third_party:guava",
         "//third_party:jenetics",

--- a/src/main/java/com/verlumen/tradestream/backtesting/ChromosomeSpec.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/ChromosomeSpec.java
@@ -1,4 +1,4 @@
-package com.verlumen.tradestream.backtesting.params;
+package com.verlumen.tradestream.backtesting;
 
 import com.google.common.collect.Range;
 import io.jenetics.NumericChromosome;

--- a/src/main/java/com/verlumen/tradestream/backtesting/DoubleChromosomeSpec.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/DoubleChromosomeSpec.java
@@ -1,4 +1,4 @@
-package com.verlumen.tradestream.backtesting.params;
+package com.verlumen.tradestream.backtesting;
 
 import com.google.common.collect.Range;
 import io.jenetics.DoubleChromosome;

--- a/src/main/java/com/verlumen/tradestream/backtesting/GAEngineFactoryImpl.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/GAEngineFactoryImpl.java
@@ -1,7 +1,7 @@
 package com.verlumen.tradestream.backtesting;
 
 import com.google.inject.Inject;
-import com.verlumen.tradestream.backtesting.params.ChromosomeSpec;
+import com.verlumen.tradestream.backtesting.ChromosomeSpec;
 import com.verlumen.tradestream.backtesting.params.ParamConfig;
 import com.verlumen.tradestream.backtesting.params.ParamConfigManager;
 import io.jenetics.DoubleChromosome;

--- a/src/main/java/com/verlumen/tradestream/backtesting/IntegerChromosomeSpec.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/IntegerChromosomeSpec.java
@@ -1,4 +1,4 @@
-package com.verlumen.tradestream.backtesting.params;
+package com.verlumen.tradestream.backtesting;
 
 import com.google.common.collect.Range;
 import io.jenetics.IntegerChromosome;

--- a/src/main/java/com/verlumen/tradestream/backtesting/params/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/params/BUILD
@@ -7,6 +7,7 @@ java_library(
     srcs = glob(["*.java"]),
     deps = [
         "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/backtesting:chromosome_spec",
         "//third_party:guava",
         "//third_party:jenetics",
         "//third_party:protobuf_java",

--- a/src/main/java/com/verlumen/tradestream/backtesting/params/ParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/params/ParamConfig.java
@@ -2,6 +2,7 @@ package com.verlumen.tradestream.backtesting.params;
 
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;
+import com.verlumen.tradestream.backtesting.ChromosomeSpec;
 import com.verlumen.tradestream.strategies.StrategyType;
 import io.jenetics.Gene;
 import io.jenetics.NumericChromosome;

--- a/src/main/java/com/verlumen/tradestream/backtesting/params/SmaRsiParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/params/SmaRsiParamConfig.java
@@ -2,6 +2,7 @@ package com.verlumen.tradestream.backtesting.params;
 
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;
+import com.verlumen.tradestream.backtesting.ChromosomeSpec;
 import com.verlumen.tradestream.strategies.SmaRsiParameters;
 import com.verlumen.tradestream.strategies.StrategyType;
 import io.jenetics.IntegerChromosome;

--- a/src/test/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/test/java/com/verlumen/tradestream/backtesting/BUILD
@@ -97,6 +97,7 @@ java_test(
     srcs = ["GenotypeConverterImplTest.java"],
     deps = [
         "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/backtesting:chromosome_spec",
         "//src/main/java/com/verlumen/tradestream/backtesting:genotype_converter",
         "//src/main/java/com/verlumen/tradestream/backtesting:genotype_converter_impl",
         "//src/main/java/com/verlumen/tradestream/backtesting/params:params_lib",

--- a/src/test/java/com/verlumen/tradestream/backtesting/GenotypeConverterImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/backtesting/GenotypeConverterImplTest.java
@@ -11,7 +11,7 @@ import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import com.google.protobuf.Any;
 import com.google.protobuf.Int32Value;
-import com.verlumen.tradestream.backtesting.params.ChromosomeSpec;
+import com.verlumen.tradestream.backtesting.ChromosomeSpec;
 import com.verlumen.tradestream.backtesting.params.ParamConfig;
 import com.verlumen.tradestream.backtesting.params.ParamConfigManager;
 import com.verlumen.tradestream.strategies.StrategyType;

--- a/src/test/java/com/verlumen/tradestream/backtesting/params/BUILD
+++ b/src/test/java/com/verlumen/tradestream/backtesting/params/BUILD
@@ -6,6 +6,7 @@ java_test(
     srcs = ["SmaRsiParamConfigTest.java"],
     deps = [
         "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/backtesting:chromosome_spec",
         "//src/main/java/com/verlumen/tradestream/backtesting/params:params_lib",
         "//third_party:guava",
         "//third_party:guice",

--- a/src/test/java/com/verlumen/tradestream/backtesting/params/SmaRsiParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/backtesting/params/SmaRsiParamConfigTest.java
@@ -3,6 +3,7 @@ package com.verlumen.tradestream.backtesting.params;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import com.verlumen.tradestream.backtesting.ChromosomeSpec;
 import com.verlumen.tradestream.strategies.SmaRsiParameters;
 import io.jenetics.DoubleChromosome;
 import io.jenetics.IntegerChromosome;


### PR DESCRIPTION
This PR refactors the `ChromosomeSpec` classes by moving them from the `params` package to the main `backtesting` package. The changes include:

- **File Relocation**:  
  - `ChromosomeSpec.java`, `DoubleChromosomeSpec.java`, and `IntegerChromosomeSpec.java` have been moved from `backtesting/params` to `backtesting`.
  - Their package declarations have been updated accordingly.

- **Build System Updates**:  
  - A new `chromosome_spec` Java library target is added in `BUILD` files to group related classes.
  - Dependencies in `backtesting/BUILD` and `params/BUILD` have been updated to reference `chromosome_spec`.

- **Import Adjustments**:  
  - All references to `com.verlumen.tradestream.backtesting.params.ChromosomeSpec` have been updated to `com.verlumen.tradestream.backtesting.ChromosomeSpec` in various files.

- **Test Updates**:  
  - Tests have been modified to reflect the new package structure.
  - Test dependencies now include `chromosome_spec` where needed.

This change improves the organization of chromosome-related classes by placing them in a more appropriate package and centralizing their dependencies.