### PR TITLE
Optimize CI workflow by removing unnecessary tools folder  

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,9 @@ jobs:
         ports:
           - 5000:5000
     steps:
+      - name: Delete huge unnecessary tools folder
+        run: rm -rf /opt/hostedtoolcache
+
       - name: Checkout Code
         uses: actions/checkout@v4
 


### PR DESCRIPTION
This update modifies the CI workflow to improve efficiency by deleting the `/opt/hostedtoolcache` directory before checking out the code. This folder contains cached tools that are not required for the build process and can take up significant space. Removing it helps optimize disk usage and potentially speeds up CI runs.  

No changes to the build logic or test execution were made.