### PR TITLE
Extend `StrategyManager` to Implement `Serializable` Interface (MINOR)

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyManager.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyManager.java
@@ -3,6 +3,7 @@ package com.verlumen.tradestream.strategies;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
+import java.io.Serializable;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Strategy;
 
@@ -13,7 +14,7 @@ import org.ta4j.core.Strategy;
  * {@link StrategyType} and {@link BarSeries}. It leverages a corresponding {@link StrategyFactory}
  * to supply both the strategy instance and its default configuration parameters.
  */
-public interface StrategyManager {
+public interface StrategyManager extends Serializable {
 
   /**
    * Creates a new Ta4j {@link Strategy} instance for the specified strategy type and bar series,


### PR DESCRIPTION
This update modifies the `StrategyManager` interface to extend `Serializable`. 

#### Changes:
- Added `java.io.Serializable` import.
- Updated `StrategyManager` to implement `Serializable`, enabling object serialization.

#### Rationale:
- Ensuring `StrategyManager` is serializable facilitates its use in distributed systems, caching mechanisms, or scenarios where instances need to be persisted or transmitted.

This change introduces new behavior, so it's marked as a **minor version update**.