### PR TITLE
Enhance `StrategyFactory` with `Serializable` Interface  

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyFactory.java
@@ -4,6 +4,7 @@ import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import com.verlumen.tradestream.strategies.StrategyType;
+import java.io.Serializable;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import org.ta4j.core.BarSeries;
@@ -17,7 +18,7 @@ import org.ta4j.core.Strategy;
  *
  * @param <T> The specific type of {@link Message} that holds the parameters for the strategy.
  */
-public interface StrategyFactory<T extends Message> {
+public interface StrategyFactory<T extends Message> extends Serializable {
   /**
    * Creates a Ta4j Strategy object from the provided {@link BarSeries} and parameters.
    *


### PR DESCRIPTION
This PR updates the `StrategyFactory` interface to extend `Serializable`, ensuring that strategy implementations can be serialized when needed.  

#### Changes:
- **Updated** `StrategyFactory<T>` to extend `Serializable`.
- **Added** the necessary `java.io.Serializable` import.  

#### Rationale:
- Allows instances of `StrategyFactory` to be serialized, which is useful for distributed processing, caching, or persistence.  
- Aligns with best practices for interfaces that may be used in serialization-sensitive contexts.  

This is a **patch-level** update as it does not introduce new functionality but improves compatibility.