### PR TITLE
Add `Serializable` to `GenotypeConverter` interface for compatibility  

### DIFF
--- a/src/main/java/com/verlumen/tradestream/backtesting/GenotypeConverter.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/GenotypeConverter.java
@@ -4,13 +4,13 @@ import com.google.protobuf.Any;
 import com.verlumen.tradestream.strategies.StrategyType;
 import io.jenetics.DoubleGene;
 import io.jenetics.Genotype;
+import java.io.Serializable;
 
 /**
  * Converts genotypes from the genetic algorithm into strategy parameters.
  * Encapsulates the conversion logic to make it reusable and testable.
  */
-interface GenotypeConverter {
-
+interface GenotypeConverter extends Serializable {
   /**
    * Converts the genotype from the genetic algorithm into strategy parameters.
    *


### PR DESCRIPTION
This change updates the `GenotypeConverter` interface by making it extend `Serializable`. This modification ensures that implementations of `GenotypeConverter` can be serialized, which may be necessary for distributed processing, caching, or persistence.  

#### Changes:
- Updated `GenotypeConverter` to implement `Serializable`.  
- No functional changes; this is purely a structural improvement for future compatibility.  

This change enhances the flexibility of `GenotypeConverter` in scenarios requiring serialization.