### PR TITLE
Remove unused import in `KafkaProducerProvider`  

### DIFF
--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaProducerProvider.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaProducerProvider.java
@@ -2,7 +2,6 @@ package com.verlumen.tradestream.kafka;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
-import com.verlumen.tradestream.kafka.KafkaProperties;
 import org.apache.kafka.clients.producer.KafkaProducer;
 
 final class KafkaProducerProvider implements Provider<KafkaProducer<String, byte[]>> {


### PR DESCRIPTION
This PR removes an unused import statement for `KafkaProperties` in `KafkaProducerProvider.java`. The import was unnecessary and has been cleaned up to improve code readability and maintainability. No functional changes were made.