### PR TITLE
Refactor Kafka Producer to Use Supplier for Improved Caching and Dependency Management (MINOR)

### DIFF
--- a/src/main/java/com/verlumen/tradestream/kafka/BUILD
+++ b/src/main/java/com/verlumen/tradestream/kafka/BUILD
@@ -27,6 +27,7 @@ java_library(
         ":kafka_read_transform",
         ":kafka_read_transform_factory",
         "//third_party:auto_value",
+        "//third_party:guava",
         "//third_party:guice",
         "//third_party:guice_assistedinject",
         "//third_party:kafka_clients",

--- a/src/main/java/com/verlumen/tradestream/kafka/BUILD
+++ b/src/main/java/com/verlumen/tradestream/kafka/BUILD
@@ -22,7 +22,7 @@ java_library(
     name = "kafka_module",
     srcs = ["KafkaModule.java"],
     deps = [
-        ":kafka_producer_provider",
+        ":kafka_producer_supplier",
         ":kafka_properties",
         ":kafka_read_transform",
         ":kafka_read_transform_factory",
@@ -34,8 +34,8 @@ java_library(
 )
 
 java_library(
-    name = "kafka_producer_provider",
-    srcs = ["KafkaProducerProvider.java"],
+    name = "kafka_producer_supplier",
+    srcs = ["KafkaProducerSupplier.java"],
     deps = [
         ":kafka_properties",
         "//third_party:guice",

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaModule.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaModule.java
@@ -1,8 +1,10 @@
 package com.verlumen.tradestream.kafka;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Suppliers;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
 import com.google.inject.TypeLiteral;
 import java.util.function.Supplier;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -17,8 +19,12 @@ public abstract class KafkaModule extends AbstractModule {
   
   @Override
   protected void configure() {
-    bind(new TypeLiteral<Supplier<KafkaProducer<String, byte[]>>>() {}).to(KafkaProducerSupplier.class);
     bind(KafkaProperties.class).toInstance(KafkaProperties.create(bootstrapServers()));
     bind(KafkaReadTransform.Factory.class).to(KafkaReadTransformFactory.class);
+  }
+
+  @Provides
+  Supplier<KafkaProducer<String, byte[]>> provideKafkaProducerSupplier(KafkaProducerSupplier supplier) {
+    return Suppliers.memoize(supplier);
   }
 }

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaModule.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaModule.java
@@ -16,7 +16,7 @@ public abstract class KafkaModule extends AbstractModule {
   }
 
   abstract String bootstrapServers();
-  
+
   @Override
   protected void configure() {
     bind(KafkaProperties.class).toInstance(KafkaProperties.create(bootstrapServers()));
@@ -25,6 +25,6 @@ public abstract class KafkaModule extends AbstractModule {
 
   @Provides
   Supplier<KafkaProducer<String, byte[]>> provideKafkaProducerSupplier(KafkaProducerSupplier supplier) {
-    return Suppliers.<KafkaProducer<String, byte[]>>memoize(supplier);
+    return Suppliers.memoize((Supplier<KafkaProducer<String, byte[]>>) supplier);
   }
 }

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaModule.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaModule.java
@@ -25,6 +25,6 @@ public abstract class KafkaModule extends AbstractModule {
 
   @Provides
   Supplier<KafkaProducer<String, byte[]>> provideKafkaProducerSupplier(KafkaProducerSupplier supplier) {
-    return Suppliers.memoize(supplier);
+    return Suppliers.<KafkaProducer<String, byte[]>>memoize(supplier);
   }
 }

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaModule.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaModule.java
@@ -4,6 +4,7 @@ import com.google.auto.value.AutoValue;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.AbstractModule;
 import com.google.inject.TypeLiteral;
+import java.util.function.Supplier;
 import org.apache.kafka.clients.producer.KafkaProducer;
 
 @AutoValue
@@ -16,8 +17,7 @@ public abstract class KafkaModule extends AbstractModule {
   
   @Override
   protected void configure() {
-    bind(new TypeLiteral<KafkaProducer<String, byte[]>>() {})
-        .toProvider(KafkaProducerProvider.class);
+    bind(new TypeLiteral<Supplier<KafkaProducer<String, byte[]>>>() {}).to(KafkaProducerSupplier.class);
     bind(KafkaProperties.class).toInstance(KafkaProperties.create(bootstrapServers()));
     bind(KafkaReadTransform.Factory.class).to(KafkaReadTransformFactory.class);
   }

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaModule.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaModule.java
@@ -25,6 +25,6 @@ public abstract class KafkaModule extends AbstractModule {
 
   @Provides
   Supplier<KafkaProducer<String, byte[]>> provideKafkaProducerSupplier(KafkaProducerSupplier supplier) {
-    return Suppliers.memoize((Supplier<KafkaProducer<String, byte[]>>) supplier);
+    return Suppliers.memoize(supplier::get);
   }
 }

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaProducerSupplier.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaProducerSupplier.java
@@ -1,15 +1,14 @@
 package com.verlumen.tradestream.kafka;
 
 import com.google.inject.Inject;
-import com.google.inject.Provider;
 import java.util.function.Supplier;
 import org.apache.kafka.clients.producer.KafkaProducer;
 
-final class KafkaProducerProvider implements Supplier<KafkaProducer<String, byte[]>> {
+final class KafkaProducerSupplier implements Supplier<KafkaProducer<String, byte[]>> {
   private final KafkaProperties properties;
 
   @Inject
-  KafkaProducerProvider(KafkaProperties properties) {
+  KafkaProducerSupplier(KafkaProperties properties) {
     this.properties = properties;
   }
 

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaProducerSupplier.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaProducerSupplier.java
@@ -2,10 +2,10 @@ package com.verlumen.tradestream.kafka;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
-import com.verlumen.tradestream.kafka.KafkaProperties;
+import java.util.function.Supplier;
 import org.apache.kafka.clients.producer.KafkaProducer;
 
-final class KafkaProducerProvider implements Provider<KafkaProducer<String, byte[]>> {
+final class KafkaProducerProvider implements Supplier<KafkaProducer<String, byte[]>> {
   private final KafkaProperties properties;
 
   @Inject

--- a/src/main/java/com/verlumen/tradestream/marketdata/TradePublisherImpl.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/TradePublisherImpl.java
@@ -7,6 +7,7 @@ import com.google.protobuf.util.Timestamps;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import java.time.Duration;
+import java.util.function.Supplier;
 
 final class TradePublisherImpl implements TradePublisher {
     private static final FluentLogger logger = FluentLogger.forEnclosingClass();

--- a/src/main/java/com/verlumen/tradestream/signals/TradeSignalPublisherImpl.java
+++ b/src/main/java/com/verlumen/tradestream/signals/TradeSignalPublisherImpl.java
@@ -7,18 +7,19 @@ import com.google.protobuf.util.Timestamps;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import java.time.Duration;
+import java.util.funtion.Supplier;
 
 /**
  * Kafka-based implementation of TradeSignalPublisher that publishes trade signals to a specified topic.
  */
 final class TradeSignalPublisherImpl implements TradeSignalPublisher {
     private static final FluentLogger logger = FluentLogger.forEnclosingClass();
-    private final KafkaProducer<String, byte[]> kafkaProducer;
+    private final Supplier<KafkaProducer<String, byte[]>> kafkaProducer;
     private final String topic;
 
     @Inject
     TradeSignalPublisherImpl(
-        KafkaProducer<String, byte[]> kafkaProducer,
+        Supplier<KafkaProducer<String, byte[]>> kafkaProducer,
         @Assisted String topic
     ) {
         logger.atInfo().log("Initializing TradeSignalPublisher for topic: %s", topic);
@@ -47,7 +48,7 @@ final class TradeSignalPublisherImpl implements TradeSignalPublisher {
             signalBytes
         );
 
-        kafkaProducer.send(record, (metadata, exception) -> {
+        kafkaProducer.get().send(record, (metadata, exception) -> {
             if (exception != null) {
                 logger.atSevere().withCause(exception)
                     .log("Failed to publish trade signal for %s to topic %s", 
@@ -67,9 +68,9 @@ final class TradeSignalPublisherImpl implements TradeSignalPublisher {
         logger.atInfo().log("Initiating Kafka producer shutdown");
         try {
             logger.atInfo().log("Flushing any pending messages...");
-            kafkaProducer.flush();
+            kafkaProducer.get().flush();
             logger.atInfo().log("Starting graceful shutdown with 5 second timeout");
-            kafkaProducer.close(Duration.ofSeconds(5));
+            kafkaProducer.get().close(Duration.ofSeconds(5));
             logger.atInfo().log("Kafka producer closed successfully");
         } catch (Exception e) {
             logger.atSevere().withCause(e).log("Error during Kafka producer shutdown");

--- a/src/main/java/com/verlumen/tradestream/signals/TradeSignalPublisherImpl.java
+++ b/src/main/java/com/verlumen/tradestream/signals/TradeSignalPublisherImpl.java
@@ -7,7 +7,7 @@ import com.google.protobuf.util.Timestamps;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import java.time.Duration;
-import java.util.funtion.Supplier;
+import java.util.function.Supplier;
 
 /**
  * Kafka-based implementation of TradeSignalPublisher that publishes trade signals to a specified topic.

--- a/src/test/java/com/verlumen/tradestream/marketdata/TradePublisherImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/marketdata/TradePublisherImplTest.java
@@ -11,6 +11,7 @@ import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import java.time.Duration; 
+import java.util.function.Supplier;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.Before;
 import org.junit.Rule;
@@ -27,7 +28,8 @@ public class TradePublisherImplTest {
 
     private static final String TOPIC = "test-topic";
 
-    @Mock @Bind private KafkaProducer<String, byte[]> mockProducer;
+    @Mock private KafkaProducer<String, byte[]> mockProducer;
+    @Bind private Supplier<KafkaProducer<String, byte[]>> kafkaProducerSupplier = () -> mockProducer;
     @Inject private TradePublisher.Factory factory;
 
     @Before

--- a/src/test/java/com/verlumen/tradestream/signals/TradeSignalPublisherImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/signals/TradeSignalPublisherImplTest.java
@@ -32,7 +32,8 @@ public class TradeSignalPublisherImplTest {
 
     private static final String TOPIC = "test-topic";
     
-    @Mock @Bind private KafkaProducer<String, byte[]> mockProducer;
+    @Mock private KafkaProducer<String, byte[]> mockProducer;
+    @Bind private Supplier<KafkaProducer<String, byte[]>> kafkaProducerSupplier = () -> mockProducer;
     @Inject private TradeSignalPublisher.Factory factory;
 
     @Before

--- a/src/test/java/com/verlumen/tradestream/signals/TradeSignalPublisherImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/signals/TradeSignalPublisherImplTest.java
@@ -12,6 +12,8 @@ import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import com.verlumen.tradestream.strategies.Strategy;
 import com.verlumen.tradestream.strategies.StrategyType;
+import java.time.Duration;
+import java.util.function.Supplier;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.Before;
@@ -23,8 +25,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-
-import java.time.Duration;
 
 @RunWith(JUnit4.class)
 public class TradeSignalPublisherImplTest {


### PR DESCRIPTION
This update refactors the Kafka producer dependency to use `Supplier<KafkaProducer<String, byte[]>>` instead of direct `KafkaProducer` injection. The primary changes include:

- **Renamed** `KafkaProducerProvider` to `KafkaProducerSupplier`, implementing `Supplier<KafkaProducer<String, byte[]>>` instead of `Provider`.
- **Updated** `KafkaModule`:
  - Replaced direct `KafkaProducer` binding with a `@Provides` method supplying a memoized supplier using `Suppliers.memoize()`.
  - Added `//third_party:guava` dependency to support memoization.
- **Refactored** `TradePublisherImpl` and `TradeSignalPublisherImpl`:
  - Changed Kafka producer field to `Supplier<KafkaProducer<String, byte[]>>`.
  - Updated method calls to `kafkaProducer.get()` for lazy evaluation.
- **Updated tests** to reflect the supplier-based approach, ensuring that the mock producer is wrapped in a `Supplier`.

This change improves performance by enabling memoization, reducing redundant Kafka producer instantiations, and ensuring more flexible dependency management.