### PR TITLE
Refactor `StrategyFactories` Visibility for Encapsulation  

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyFactories.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyFactories.java
@@ -9,11 +9,11 @@ import com.verlumen.tradestream.strategies.oscillators.OscillatorStrategies;
  * This class aggregates factories from child packages (moving averages, oscillators, etc.)
  * and is immutable and thread-safe.
  */
-public final class StrategyFactories {
+final class StrategyFactories {
     /**
      * An immutable list of all strategy factories across all categories.
      */
-    public static final ImmutableList<StrategyFactory<?>> ALL_FACTORIES = 
+    static final ImmutableList<StrategyFactory<?>> ALL_FACTORIES = 
         ImmutableList.<StrategyFactory<?>>builder()
             .addAll(MovingAverageStrategies.ALL_FACTORIES)
             .addAll(OscillatorStrategies.ALL_FACTORIES)


### PR DESCRIPTION
This update modifies the visibility of the `StrategyFactories` class and its `ALL_FACTORIES` field:  
- **Removed `public` modifier** from `StrategyFactories`, making it package-private to enforce better encapsulation.  
- **Removed `public` modifier** from `ALL_FACTORIES`**, limiting access within the package to prevent unintended external usage.  

These changes improve encapsulation and maintainability by restricting direct access to internal strategy factory aggregation.