### PR TITLE
Add centralized oscillator param configurations and factory method for SmaRsiParamConfig

### DIFF
--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -203,6 +203,7 @@ java_library(
     ],
     deps = [
         ":param_config",
+        "//src/main/java/com/verlumen/tradestream/backtesting/oscillators:oscillator_params",
         "//third_party:guava",
     ],
 )

--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -197,6 +197,17 @@ java_library(
 )
 
 java_library(
+    name = "param_configs",
+    srcs = [
+        "ParamConfigs.java",
+    ],
+    deps = [
+        ":param_config",
+        "//third_party:guava",
+    ],
+)
+
+java_library(
     name = "run_backtest",
     srcs = ["RunBacktest.java"],
     deps = [

--- a/src/main/java/com/verlumen/tradestream/backtesting/ParamConfigs.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/ParamConfigs.java
@@ -1,7 +1,7 @@
 package com.verlumen.tradestream.backtesting;
 
 import com.google.common.collect.ImmutableList;
-import com.verlumen.tradestream.backtesting.oscillators.OscillatorStrategies;
+import com.verlumen.tradestream.backtesting.oscillators.OscillatorParams;
 
 public final class ParamConfigs {
     public static final ImmutableList<ParamConfig> ALL_CONFIGS = 

--- a/src/main/java/com/verlumen/tradestream/backtesting/ParamConfigs.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/ParamConfigs.java
@@ -5,7 +5,7 @@ import com.verlumen.tradestream.backtesting.oscillators.OscillatorStrategies;
 
 public final class ParamConfigs {
     public static final ImmutableList<ParamConfig> ALL_CONFIGS = 
-        ImmutableList.<StrategyFactory<?>>builder()
+        ImmutableList.<ParamConfig<?>>builder()
             .addAll(OscillatorParams.ALL_CONFIGS)
             .build();
 

--- a/src/main/java/com/verlumen/tradestream/backtesting/ParamConfigs.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/ParamConfigs.java
@@ -5,7 +5,7 @@ import com.verlumen.tradestream.backtesting.oscillators.OscillatorParams;
 
 final class ParamConfigs {
     static final ImmutableList<ParamConfig> ALL_CONFIGS = 
-        ImmutableList.<ParamConfig<?>>builder()
+        ImmutableList.<ParamConfig>builder()
             .addAll(OscillatorParams.ALL_CONFIGS)
             .build();
 

--- a/src/main/java/com/verlumen/tradestream/backtesting/ParamConfigs.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/ParamConfigs.java
@@ -3,8 +3,8 @@ package com.verlumen.tradestream.backtesting;
 import com.google.common.collect.ImmutableList;
 import com.verlumen.tradestream.backtesting.oscillators.OscillatorParams;
 
-public final class ParamConfigs {
-    public static final ImmutableList<ParamConfig> ALL_CONFIGS = 
+final class ParamConfigs {
+    static final ImmutableList<ParamConfig> ALL_CONFIGS = 
         ImmutableList.<ParamConfig<?>>builder()
             .addAll(OscillatorParams.ALL_CONFIGS)
             .build();

--- a/src/main/java/com/verlumen/tradestream/backtesting/ParamConfigs.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/ParamConfigs.java
@@ -1,0 +1,14 @@
+package com.verlumen.tradestream.backtesting;
+
+import com.google.common.collect.ImmutableList;
+import com.verlumen.tradestream.backtesting.oscillators.OscillatorStrategies;
+
+public final class ParamConfigs {
+    public static final ImmutableList<ParamConfig> ALL_CONFIGS = 
+        ImmutableList.<StrategyFactory<?>>builder()
+            .addAll(OscillatorParams.ALL_CONFIGS)
+            .build();
+
+    // Prevent instantiation
+    private ParamConfigs() {}
+}

--- a/src/main/java/com/verlumen/tradestream/backtesting/oscillators/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/oscillators/BUILD
@@ -6,6 +6,7 @@ java_library(
     name = "oscillator_params",
     srcs = ["OscillatorParams.java"],
     deps = [
+        ":sma_rsi_param_config",
         "//src/main/java/com/verlumen/tradestream/backtesting:param_config",
         "//third_party:guava",
     ],

--- a/src/main/java/com/verlumen/tradestream/backtesting/oscillators/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/oscillators/BUILD
@@ -6,7 +6,6 @@ java_library(
     name = "oscillator_params",
     srcs = ["OscillatorParams.java"],
     deps = [
-        "//protos:strategies_java_proto",
         "//src/main/java/com/verlumen/tradestream/backtesting:param_config",
         "//third_party:guava",
     ],

--- a/src/main/java/com/verlumen/tradestream/backtesting/oscillators/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/oscillators/BUILD
@@ -3,6 +3,16 @@ load("@rules_java//java:defs.bzl", "java_library")
 package(default_visibility = ["//visibility:public"])
 
 java_library(
+    name = "oscillator_params",
+    srcs = ["OscillatorParams.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/backtesting:param_config",
+        "//third_party:guava",
+    ],
+)
+
+java_library(
     name = "sma_rsi_param_config",
     srcs = ["SmaRsiParamConfig.java"],
     deps = [

--- a/src/main/java/com/verlumen/tradestream/backtesting/oscillators/OscillatorParams.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/oscillators/OscillatorParams.java
@@ -12,9 +12,10 @@ public final class OscillatorParams {
     /**
      * An immutable list of all oscillator param configs.
      */
-    public static final ImmutableList<ParamConfig<?>> ALL_CONFIGS = ImmutableList.of(
-        SmaRsiParamConfig.create()
-    );
+    public static final ImmutableList<ParamConfig> ALL_CONFIGS = 
+        ImmutableList.<ParamConfig>builder()
+            .add(SmaRsiParamConfig.create())
+            .build();
 
     // Prevent instantiation
     private OscillatorParams() {}

--- a/src/main/java/com/verlumen/tradestream/backtesting/oscillators/OscillatorParams.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/oscillators/OscillatorParams.java
@@ -1,0 +1,21 @@
+package com.verlumen.tradestream.backtesting.oscillators;
+
+import com.google.common.collect.ImmutableList;
+import com.verlumen.tradestream.backtesting.ParamConfig;
+
+/**
+ * Provides a centralized collection of all available oscillator-based param configs.
+ * This class is immutable and thread-safe. As more oscillator strategies are added,
+ * they should be included in ALL_CONFIGS.
+ */
+public final class OscillatorParams {
+    /**
+     * An immutable list of all oscillator param configs.
+     */
+    public static final ImmutableList<ParamConfig<?>> ALL_CONFIGS = ImmutableList.of(
+        SmaRsiParamConfig.create()
+    );
+
+    // Prevent instantiation
+    private OscillatorParams() {}
+}

--- a/src/main/java/com/verlumen/tradestream/backtesting/oscillators/SmaRsiParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/oscillators/SmaRsiParamConfig.java
@@ -20,6 +20,12 @@ final class SmaRsiParamConfig implements ParamConfig {
         ChromosomeSpec.ofDouble(15.0, 40.0)  // Oversold Threshold
     );
 
+    static SmaRsiParamConfig create() {
+        return new SmaRsiParamConfig();
+    }
+
+    private SmaRsiParamConfig() {}
+    
     @Override
     public ImmutableList<ChromosomeSpec<?>> getChromosomeSpecs() {
         return SPECS;

--- a/src/test/java/com/verlumen/tradestream/backtesting/oscillators/SmaRsiParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/backtesting/oscillators/SmaRsiParamConfigTest.java
@@ -21,7 +21,7 @@ public class SmaRsiParamConfigTest {
 
   @Before
   public void setUp() {
-    config = new SmaRsiParamConfig();
+    config = SmaRsiParamConfig.create();
   }
 
   @Test


### PR DESCRIPTION
- Introduced `ParamConfigs` and `OscillatorParams` to centralize param configurations for backtesting.
- Added `oscillator_params` and `param_configs` Java libraries in the `BUILD` files.
- Implemented `OscillatorParams` to maintain an immutable list of all oscillator-based parameter configurations.
- Refactored `SmaRsiParamConfig`:
  - Added a static factory method `create()` to enforce immutability.
  - Made the constructor private to prevent direct instantiation.
- Updated `SmaRsiParamConfigTest` to use `SmaRsiParamConfig.create()`.

These changes improve code organization, enhance immutability, and simplify the integration of new oscillator-based configurations.