### PR TITLE
Refactor oscillator strategy factory initialization for improved readability  

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/oscillators/OscillatorStrategies.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/oscillators/OscillatorStrategies.java
@@ -12,10 +12,10 @@ public final class OscillatorStrategies {
     /**
      * An immutable list of all oscillator strategy factories.
      */
-    public static final ImmutableList<StrategyFactory<?>> ALL_FACTORIES = ImmutableList.of(
-        AdxStochasticStrategyFactory.create(),
-        SmaRsiStrategyFactory.create()
-    );
+    public static final ImmutableList<StrategyFactory<?>> ALL_FACTORIES = ImmutableList.builder()
+        .add(AdxStochasticStrategyFactory.create())
+        .add(SmaRsiStrategyFactory.create())
+        .build();
 
     // Prevent instantiation
     private OscillatorStrategies() {}

--- a/src/main/java/com/verlumen/tradestream/strategies/oscillators/OscillatorStrategies.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/oscillators/OscillatorStrategies.java
@@ -12,10 +12,11 @@ public final class OscillatorStrategies {
     /**
      * An immutable list of all oscillator strategy factories.
      */
-    public static final ImmutableList<StrategyFactory<?>> ALL_FACTORIES = ImmutableList.builder()
-        .add(AdxStochasticStrategyFactory.create())
-        .add(SmaRsiStrategyFactory.create())
-        .build();
+    public static final ImmutableList<StrategyFactory<?>> ALL_FACTORIES =
+        ImmutableList.<StrategyFactory<?>>builder()
+            .add(AdxStochasticStrategyFactory.create())
+            .add(SmaRsiStrategyFactory.create())
+            .build();
 
     // Prevent instantiation
     private OscillatorStrategies() {}


### PR DESCRIPTION
Refactored the initialization of `ALL_FACTORIES` in `OscillatorStrategies` to use an explicit builder pattern (`ImmutableList.builder()`). This improves readability and maintainability, especially if additional factories need to be added in the future.  

#### Changes:  
- Replaced direct `ImmutableList.of(...)` instantiation with `ImmutableList.builder().add(...).build()`.  
- Ensured the code remains functionally identical while improving structure.  

No changes in behavior; this is a readability and maintainability improvement.