### PR TITLE
Add Guava dependency and bind ParamConfigs in BacktestingModule

### DIFF
--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -42,7 +42,7 @@ java_library(
         ":genotype_converter",
         ":genotype_converter_impl",
         ":param_config",
-        ":param_configS",
+        ":param_configs",
         ":param_config_manager",
         ":param_config_manager_impl",
         "//third_party:guava",

--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -41,8 +41,11 @@ java_library(
         ":genetic_algorithm_orchestrator_impl",
         ":genotype_converter",
         ":genotype_converter_impl",
+        ":param_config",
+        ":param_configS",
         ":param_config_manager",
         ":param_config_manager_impl",
+        "//third_party:guava",
         "//third_party:guice",
     ],
 )

--- a/src/main/java/com/verlumen/tradestream/backtesting/BacktestingModule.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BacktestingModule.java
@@ -19,7 +19,7 @@ public final class BacktestingModule extends AbstractModule {
     bind(GeneticAlgorithmOrchestrator.class).to(GeneticAlgorithmOrchestratorImpl.class);
     bind(GenotypeConverter.class).to(GenotypeConverterImpl.class);
     bind(new TypeLiteral<ImmutableList<ParamConfig>>() {})
-        .toInstance(ParamConfigs.ALL_FACTORIES);
+        .toInstance(ParamConfigs.ALL_CONFIGS);
     bind(ParamConfigManager.class).to(ParamConfigManagerImpl.class);
   }
 }

--- a/src/main/java/com/verlumen/tradestream/backtesting/BacktestingModule.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BacktestingModule.java
@@ -3,6 +3,8 @@ package com.verlumen.tradestream.backtesting;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
+import com.google.inject.TypeLiteral;
+
 
 public final class BacktestingModule extends AbstractModule {
   public static BacktestingModule create() {
@@ -16,6 +18,8 @@ public final class BacktestingModule extends AbstractModule {
     bind(GAEngineFactory.class).to(GAEngineFactoryImpl.class);
     bind(GeneticAlgorithmOrchestrator.class).to(GeneticAlgorithmOrchestratorImpl.class);
     bind(GenotypeConverter.class).to(GenotypeConverterImpl.class);
+    bind(new TypeLiteral<ImmutableList<ParamConfig>>() {})
+        .toInstance(ParamConfigs.ALL_FACTORIES);
     bind(ParamConfigManager.class).to(ParamConfigManagerImpl.class);
   }
 }

--- a/src/main/java/com/verlumen/tradestream/backtesting/BacktestingModule.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BacktestingModule.java
@@ -1,10 +1,10 @@
 package com.verlumen.tradestream.backtesting;
 
+import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.TypeLiteral;
-
 
 public final class BacktestingModule extends AbstractModule {
   public static BacktestingModule create() {


### PR DESCRIPTION
- **Added Dependencies:**  
  - Included `//third_party:guava` in `BUILD` file to support the use of `ImmutableList`.  
  - Added `param_config` and `param_configs` dependencies.  

- **Updated `BacktestingModule`:**  
  - Imported `ImmutableList` from Guava.  
  - Used Guice’s `TypeLiteral` to bind `ImmutableList<ParamConfig>` to `ParamConfigs.ALL_CONFIGS`.  

These changes enhance dependency management and improve configuration binding for backtesting.