### PR TITLE
Update OCI image base from Flink Java 17 to OpenJDK

### DIFF
--- a/src/main/java/com/verlumen/tradestream/pipeline/BUILD
+++ b/src/main/java/com/verlumen/tradestream/pipeline/BUILD
@@ -50,7 +50,7 @@ genrule(
 
 oci_image(
     name = "image",
-    base = "@flink_java17",
+    base = "@openjdk_java",
     entrypoint = [
         "java",
         "-jar",


### PR DESCRIPTION
This update modifies the OCI image base in the BUILD file, replacing `@flink_java17` with `@openjdk_java`. The change ensures compatibility with OpenJDK instead of the previously used Flink-specific Java runtime. 

#### Changes:
- Updated the `oci_image` rule to use `@openjdk_java` as the base.
- Maintains the same entry point configuration.

This update may impact runtime behavior depending on differences between Flink's Java distribution and OpenJDK. Reviewers should verify compatibility with the application’s dependencies.