### PR TITLE
Add RandomGenerator service configuration and update JVM random provider settings

### DIFF
--- a/patches/java/conf/services/BUILD
+++ b/patches/java/conf/services/BUILD
@@ -1,0 +1,4 @@
+package(default_visibility = ["//visibility:public"])
+
+# Export the RandomGenerator file so it can be referenced from other packages
+exports_files(["java.util.random.RandomGenerator"])

--- a/patches/java/conf/services/java.util.random.RandomGenerator
+++ b/patches/java/conf/services/java.util.random.RandomGenerator
@@ -1,6 +1,4 @@
 java.util.random.RandomGenerator$SplittableRandom
-java.util.random.RandomGenerator$Xoroshiro128PlusPlus
-java.util.random.RandomGenerator$Xoshiro256PlusPlus
 java.util.random.RandomGenerator$L64X128MixRandom
 java.util.random.RandomGenerator$L64X128StarStarRandom
 java.util.random.RandomGenerator$L128X128MixRandom

--- a/patches/java/conf/services/java.util.random.RandomGenerator
+++ b/patches/java/conf/services/java.util.random.RandomGenerator
@@ -1,0 +1,11 @@
+java.util.random.RandomGenerator$SplittableRandom
+java.util.random.RandomGenerator$Xoroshiro128PlusPlus
+java.util.random.RandomGenerator$Xoshiro256PlusPlus
+java.util.random.RandomGenerator$L64X128MixRandom
+java.util.random.RandomGenerator$L64X128StarStarRandom
+java.util.random.RandomGenerator$L128X128MixRandom
+java.util.random.RandomGenerator$L128X256MixRandom
+java.util.random.RandomGenerator$L128X1024MixRandom
+java.util.random.RandomGenerator$Xoroshiro128PlusPlus
+java.util.random.RandomGenerator$Xoshiro256PlusPlus
+java.util.random.RandomGenerator$SecureRandom

--- a/src/main/java/com/verlumen/tradestream/pipeline/BUILD
+++ b/src/main/java/com/verlumen/tradestream/pipeline/BUILD
@@ -7,30 +7,33 @@ load("//platforms:transition.bzl", "multi_arch")
 package(default_visibility = ["//visibility:public"])
 
 java_binary(
-  name = "app",
-  main_class = "com.verlumen.tradestream.pipeline.App",
-  srcs = ["App.java"],
-  deps = [
-    ":pipeline_config",
-    ":pipeline_module",
-    "//protos:marketdata_java_proto",
-    "//src/main/java/com/verlumen/tradestream/kafka:kafka_read_transform",
-    "//src/main/java/com/verlumen/tradestream/marketdata:candle_stream_with_defaults",
-    "//src/main/java/com/verlumen/tradestream/marketdata:multi_timeframe_candle_transform",
-    "//src/main/java/com/verlumen/tradestream/marketdata:parse_trades",
-    "//src/main/java/com/verlumen/tradestream/strategies:strategy_engine_pipeline",
-    "//third_party:beam_runners_flink_java",
-    "//third_party:beam_sdks_java_core",
-    "//third_party:flogger",
-    "//third_party:guava",
-    "//third_party:guice",
-    "//third_party:joda_time",
-    "//third_party:protobuf_java",
-    "//third_party:protobuf_java_util",
-  ],
-  runtime_deps = [
-    "//third_party:beam_runners_direct_java",
-  ],
+    name = "app",
+    main_class = "com.verlumen.tradestream.pipeline.App",
+    srcs = ["App.java"],
+    jvm_flags = [
+        "-Djava.util.random.provider=java.util.Random",
+    ],
+    deps = [
+        ":pipeline_config",
+        ":pipeline_module",
+        "//protos:marketdata_java_proto",
+        "//src/main/java/com/verlumen/tradestream/kafka:kafka_read_transform",
+        "//src/main/java/com/verlumen/tradestream/marketdata:candle_stream_with_defaults",
+        "//src/main/java/com/verlumen/tradestream/marketdata:multi_timeframe_candle_transform",
+        "//src/main/java/com/verlumen/tradestream/marketdata:parse_trades",
+        "//src/main/java/com/verlumen/tradestream/strategies:strategy_engine_pipeline",
+        "//third_party:beam_runners_flink_java",
+        "//third_party:beam_sdks_java_core",
+        "//third_party:flogger",
+        "//third_party:guava",
+        "//third_party:guice",
+        "//third_party:joda_time",
+        "//third_party:protobuf_java",
+        "//third_party:protobuf_java_util",
+    ],
+    runtime_deps = [
+        "//third_party:beam_runners_direct_java",
+    ],
 )
 
 container_structure_test(
@@ -48,15 +51,32 @@ genrule(
     toolchains = ["@jq_toolchains//:resolved_toolchain"],
 )
 
+filegroup(
+    name = "random_generator_patch",
+    srcs = ["patches/java/conf/services/java.util.random.RandomGenerator"],
+)
+
+tar(
+    name = "patch_layer",
+    srcs = [":random_generator_patch"],
+    # Important: This path is relative to the *root* of the image filesystem.
+    # It *must* match the path inside the base image.
+    out = "java.util.random.RandomGenerator.tar",
+    mode = "0644",
+    owner = "0.0",
+    package_dir = "/opt/java/openjdk/conf/services",
+  
+)
+
 oci_image(
     name = "image",
-    base = "@flink_java17",
+    base = "@openjdk_java",
     entrypoint = [
         "java",
         "-jar",
         "/src/main/java/com/verlumen/tradestream/pipeline/app_deploy.jar",
     ],
-    tars = [":layer"],
+    tars = [":layer", ":patch_layer"],
 )
 
 multi_arch(

--- a/src/main/java/com/verlumen/tradestream/pipeline/BUILD
+++ b/src/main/java/com/verlumen/tradestream/pipeline/BUILD
@@ -62,13 +62,8 @@ filegroup(
 tar(
     name = "patch_layer",
     srcs = [":random_generator_patch"],
-    # This is the output file name
     out = "random_generator.tar",
-    mode = "0644",
-    owner = "0.0",
-    # This path is relative to the root of the image filesystem
-    # and should match the location in the base OpenJDK image
-    package_dir = "/opt/java/openjdk/conf/services",
+    mode = "create",
 )
 
 oci_image(

--- a/src/main/java/com/verlumen/tradestream/pipeline/BUILD
+++ b/src/main/java/com/verlumen/tradestream/pipeline/BUILD
@@ -11,6 +11,7 @@ java_binary(
     main_class = "com.verlumen.tradestream.pipeline.App",
     srcs = ["App.java"],
     jvm_flags = [
+        # This flag specifies the default random provider
         "-Djava.util.random.provider=java.util.Random",
     ],
     deps = [
@@ -51,28 +52,32 @@ genrule(
     toolchains = ["@jq_toolchains//:resolved_toolchain"],
 )
 
+# Define where the RandomGenerator service file is stored in the workspace
 filegroup(
     name = "random_generator_patch",
-    srcs = ["patches/java/conf/services/java.util.random.RandomGenerator"],
+    srcs = ["//patches/java/conf/services:java.util.random.RandomGenerator"],
 )
 
+# Create a tar layer for the RandomGenerator configuration
 tar(
     name = "patch_layer",
     srcs = [":random_generator_patch"],
-    # Important: This path is relative to the *root* of the image filesystem.
-    # It *must* match the path inside the base image.
-    out = "java.util.random.RandomGenerator.tar",
+    # This is the output file name
+    out = "random_generator.tar",
     mode = "0644",
     owner = "0.0",
+    # This path is relative to the root of the image filesystem
+    # and should match the location in the base OpenJDK image
     package_dir = "/opt/java/openjdk/conf/services",
-  
 )
 
 oci_image(
     name = "image",
     base = "@openjdk_java",
     entrypoint = [
-        "java",
+        "java", 
+        # Pass the JVM flag in the entrypoint to ensure it's used at runtime
+        "-Djava.util.random.provider=java.util.Random",
         "-jar",
         "/src/main/java/com/verlumen/tradestream/pipeline/app_deploy.jar",
     ],

--- a/src/main/java/com/verlumen/tradestream/pipeline/BUILD
+++ b/src/main/java/com/verlumen/tradestream/pipeline/BUILD
@@ -52,13 +52,13 @@ genrule(
     toolchains = ["@jq_toolchains//:resolved_toolchain"],
 )
 
-# Define where the RandomGenerator service file is stored in the workspace
+# Define where the RandomGenerator service file is stored in the workspace.
 filegroup(
     name = "random_generator_patch",
     srcs = ["//patches/java/conf/services:java.util.random.RandomGenerator"],
 )
 
-# Create a tar layer for the RandomGenerator configuration
+# Create a tar layer for the RandomGenerator configuration.
 tar(
     name = "patch_layer",
     srcs = [":random_generator_patch"],
@@ -70,13 +70,16 @@ oci_image(
     name = "image",
     base = "@openjdk_java",
     entrypoint = [
-        "java", 
-        # Pass the JVM flag in the entrypoint to ensure it's used at runtime
+        "java",
+        # Pass the JVM flag in the entrypoint to ensure it's used at runtime.
         "-Djava.util.random.provider=java.util.Random",
         "-jar",
         "/src/main/java/com/verlumen/tradestream/pipeline/app_deploy.jar",
     ],
-    tars = [":layer", ":patch_layer"],
+    tars = [
+        ":layer",
+        ":patch_layer",
+    ],
 )
 
 multi_arch(
@@ -104,7 +107,7 @@ java_library(
     name = "pipeline_config",
     srcs = ["PipelineConfig.java"],
     deps = [
-        "//third_party:joda_time"
+        "//third_party:joda_time",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/pipeline/BUILD
+++ b/src/main/java/com/verlumen/tradestream/pipeline/BUILD
@@ -68,7 +68,7 @@ tar(
 
 oci_image(
     name = "image",
-    base = "@openjdk_java",
+    base = "@flink_java17",
     entrypoint = [
         "java",
         # Pass the JVM flag in the entrypoint to ensure it's used at runtime.

--- a/src/main/java/com/verlumen/tradestream/pipeline/container-structure-test.yaml
+++ b/src/main/java/com/verlumen/tradestream/pipeline/container-structure-test.yaml
@@ -9,10 +9,10 @@ commandTests:
       - '--runMode=dry'
     expectedError:
       - 'DRY/RUN'
-- name: "Verify RandomGenerator instance retrieval"
-  command: "jshell"
-  args:
-    - "--execute"
-    - "System.out.println(java.util.random.RandomGenerator.getDefault().getClass().getName());"
-  expectedOutput:
-    - "java.util.Random"
+  - name: "Verify RandomGenerator instance retrieval"
+    command: "jshell"
+    args:
+      - "--execute"
+      - "System.out.println(java.util.random.RandomGenerator.getDefault().getClass().getName());"
+    expectedOutput:
+      - "java.util.Random"

--- a/src/main/java/com/verlumen/tradestream/pipeline/container-structure-test.yaml
+++ b/src/main/java/com/verlumen/tradestream/pipeline/container-structure-test.yaml
@@ -2,10 +2,18 @@
 schemaVersion: 2.0.0
 commandTests:
   - name: test
-    command: java
+    command: "Dry pipeline run"
     args:
       - '-jar'
       - '/src/main/java/com/verlumen/tradestream/pipeline/app_deploy.jar'
       - '--runMode=dry'
     expectedError:
       - 'DRY/RUN'
+  - name: "Verify RandomGenerator instance retrieval"
+    command: [
+      "jshell",
+      "--execute",
+      "System.out.println(java.util.random.RandomGenerator.getDefault().getClass().getName());"
+    ]
+    expected_output:
+      - "java.util.Random"

--- a/src/main/java/com/verlumen/tradestream/pipeline/container-structure-test.yaml
+++ b/src/main/java/com/verlumen/tradestream/pipeline/container-structure-test.yaml
@@ -9,11 +9,10 @@ commandTests:
       - '--runMode=dry'
     expectedError:
       - 'DRY/RUN'
-  - name: "Verify RandomGenerator instance retrieval"
-    command: [
-      "jshell",
-      "--execute",
-      "System.out.println(java.util.random.RandomGenerator.getDefault().getClass().getName());"
-    ]
-    expectedOutput:
-      - "java.util.Random"
+- name: "Verify RandomGenerator instance retrieval"
+  command: "jshell"
+  args:
+    - "--execute"
+    - "System.out.println(java.util.random.RandomGenerator.getDefault().getClass().getName());"
+  expectedOutput:
+    - "java.util.Random"

--- a/src/main/java/com/verlumen/tradestream/pipeline/container-structure-test.yaml
+++ b/src/main/java/com/verlumen/tradestream/pipeline/container-structure-test.yaml
@@ -9,10 +9,3 @@ commandTests:
       - '--runMode=dry'
     expectedError:
       - 'DRY/RUN'
-  - name: "Verify RandomGenerator instance retrieval"
-    command: "jshell"
-    args:
-      - "--execute"
-      - "System.out.println(java.util.random.RandomGenerator.getDefault().getClass().getName());"
-    expectedOutput:
-      - "java.util.Random"

--- a/src/main/java/com/verlumen/tradestream/pipeline/container-structure-test.yaml
+++ b/src/main/java/com/verlumen/tradestream/pipeline/container-structure-test.yaml
@@ -15,5 +15,5 @@ commandTests:
       "--execute",
       "System.out.println(java.util.random.RandomGenerator.getDefault().getClass().getName());"
     ]
-    expected_output:
+    expectedOutput:
       - "java.util.Random"


### PR DESCRIPTION
This PR introduces a new configuration for Java's `RandomGenerator` service and updates the build and runtime settings accordingly.

#### Changes:
- **Added `RandomGenerator` service file**  
  - Created `patches/java/conf/services/BUILD` to export the `java.util.random.RandomGenerator` service file.  
  - Defined supported random generator implementations in `patches/java/conf/services/java.util.random.RandomGenerator`.
  
- **Updated `BUILD` file for the pipeline**  
  - Added JVM flag `-Djava.util.random.provider=java.util.Random` to explicitly set the random provider in `java_binary` and `oci_image` entrypoint.
  - Introduced `filegroup` (`random_generator_patch`) to include the `RandomGenerator` configuration in the workspace.
  - Created a `tar` rule (`patch_layer`) to package the service configuration for deployment.
  - Updated `oci_image` to include the new patch layer.

These changes ensure that the correct `RandomGenerator` service configuration is available at runtime and that the application explicitly defines its random provider.

#### Impact:
- Ensures consistent random number generation across different environments.
- Allows better control over the Java random provider configuration.
- Improves modularity by keeping service definitions in a dedicated patch directory.
