### PR TITLE
Increase Bazel test output limit in GitHub Actions workflow  

### DIFF
--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -19,4 +19,8 @@ jobs:
         disk-cache: ${{ github.workflow }}
         # Share repository cache between workflows.
         repository-cache: true
-    - run: bazel test //... --test_output=all  --verbose_failures
+    - run: |
+        bazel test //... \
+          --experimental_ui_max_stdouterr_bytes=2097152 \
+          --test_output=all \
+          --verbose_failures


### PR DESCRIPTION
This update modifies the Bazel test step in the `.github/workflows/bazel-test.yaml` file by adding the `--experimental_ui_max_stdouterr_bytes=2097152` flag. This increases the maximum size of standard output and error logs captured by Bazel to 2MB, helping to retain more detailed logs for debugging test failures.  

Other existing test flags (`--test_output=all` and `--verbose_failures`) remain unchanged to ensure verbose output and better failure diagnostics. This change is intended to improve visibility into test failures within CI.