### PR TITLE
Refactor GAConstants and Improve Tournament Selector Configuration  

### DIFF
--- a/src/main/java/com/verlumen/tradestream/backtesting/GAConstants.java
+++ b/src/main/java/com/verlumen/tradestream/backtesting/GAConstants.java
@@ -5,12 +5,11 @@ package com.verlumen.tradestream.backtesting;
  * Extracted to a separate class to avoid duplication and facilitate changes.
  */
 final class GAConstants {
-  private GAConstants() {
-      // Prevent instantiation
-  }
-
+  static final double CROSSOVER_PROBABILITY = 0.35;
   static final int DEFAULT_POPULATION_SIZE = 50;
   static final int DEFAULT_MAX_GENERATIONS = 100;
   static final double MUTATION_PROBABILITY = 0.15;
-  static final double CROSSOVER_PROBABILITY = 0.35;
+  static final int TOURNAMENT_SIZE = 3;
+
+  private GAConstants() {}
 }


### PR DESCRIPTION
- **Refactored `GAConstants`** to include `TOURNAMENT_SIZE` for better configurability.  
- **Reordered constants** to maintain logical grouping and improve readability.  
- **Updated `GAEngineFactoryImpl`** to use `GAConstants.TOURNAMENT_SIZE` instead of a hardcoded value, improving maintainability.  
- **Removed redundant constructor visibility modifier in `GAEngineFactoryImpl`** (package-private is sufficient).  
- **Minor formatting improvements** for better code clarity.  

This change enhances flexibility and code maintainability by centralizing tournament size configuration.