### PR TITLE
Update container-structure-test.yaml to improve test naming  

### DIFF
--- a/src/main/java/com/verlumen/tradestream/pipeline/container-structure-test.yaml
+++ b/src/main/java/com/verlumen/tradestream/pipeline/container-structure-test.yaml
@@ -1,7 +1,7 @@
 # See https://github.com/GoogleContainerTools/container-structure-test#command-tests
 schemaVersion: 2.0.0
 commandTests:
-  - name: test
+  - name: "Dry pipeline run"
     command: java
     args:
       - '-jar'


### PR DESCRIPTION
This PR updates `container-structure-test.yaml` by renaming the command test from `test` to `"Dry pipeline run"`. This improves clarity by providing a more descriptive name for the test, making it easier to understand its purpose. No functional changes were made.