### PR TITLE
Add `rules_kotlin` dependency to `MODULE.bazel`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,6 +11,7 @@ bazel_dep(name = "container_structure_test", version = "1.16.0")
 bazel_dep(name = "protobuf", repo_name = "com_google_protobuf", version = "29.1")
 bazel_dep(name = "rules_java", version = "8.5.1")
 bazel_dep(name = "rules_jvm_external", version = "6.5")
+bazel_dep(name = "rules_kotlin", version = "2.1.3")
 bazel_dep(name = "rules_oci", version = "2.0.1")
 
 # Add Java toolchain configuration


### PR DESCRIPTION
This change adds the `rules_kotlin` dependency (version 2.1.3) to `MODULE.bazel`. This enables Kotlin support within the Bazel build system. No other dependencies were modified.

**Changes:**
- Added `rules_kotlin` version 2.1.3 to `MODULE.bazel`.

**Context:**
This update is necessary for projects that require Kotlin support in Bazel builds. The addition does not affect existing dependencies or configurations.