### PR TITLE
Update `rules_oci` Bazel dependency to v2.2.3

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,7 +11,7 @@ bazel_dep(name = "container_structure_test", version = "1.16.0")
 bazel_dep(name = "protobuf", repo_name = "com_google_protobuf", version = "29.1")
 bazel_dep(name = "rules_java", version = "8.5.1")
 bazel_dep(name = "rules_jvm_external", version = "6.5")
-bazel_dep(name = "rules_oci", version = "2.0.1")
+bazel_dep(name = "rules_oci", version = "2.2.3")
 
 # Add Java toolchain configuration
 JAVA_LANGUAGE_LEVEL = "17"


### PR DESCRIPTION
This PR updates the `rules_oci` Bazel dependency from version `2.0.1` to `2.2.3` in `MODULE.bazel`. 

#### Changes:
- Bumped `rules_oci` from `2.0.1` to `2.2.3`.

#### Rationale:
- Ensures compatibility with the latest features and fixes in `rules_oci`.
- Potential improvements in performance, security, or stability.

No other dependencies were modified, and Java toolchain settings remain unchanged.