### PR TITLE
Add custom random generator setting for JobManager and TaskManager in Tradestream  

### DIFF
--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -48,6 +48,8 @@ pipeline:
     pullPolicy: IfNotPresent
   version: v1_18
   configuration:
+    env.java.opts.jobmanager: "-Dio.jenetics.util.defaultRandomGenerator=Random"
+    env.java.opts.taskmanager: "-Dio.jenetics.util.defaultRandomGenerator=Random"
     taskmanager.numberOfTaskSlots: "1"
   serviceAccount: flink
   jobManager:


### PR DESCRIPTION
This update modifies `values.yaml` in the `tradestream` Helm chart to include custom Java options for both the JobManager and TaskManager. Specifically, it sets the default random generator for Jenetics to `Random`, ensuring deterministic behavior in Flink-based workloads.  

#### Changes:  
- Added `env.java.opts.jobmanager` with `-Dio.jenetics.util.defaultRandomGenerator=Random`  
- Added `env.java.opts.taskmanager` with `-Dio.jenetics.util.defaultRandomGenerator=Random`  

These changes help control randomness in genetic algorithm operations, improving reproducibility and debugging.