### PR TITLE
Add Ichimoku Cloud configuration to TrendFollowingParams

### DIFF
--- a/src/main/java/com/verlumen/tradestream/backtesting/trendfollowing/TrendFollowingParams.kt
+++ b/src/main/java/com/verlumen/tradestream/backtesting/trendfollowing/TrendFollowingParams.kt
@@ -4,5 +4,7 @@ import com.verlumen.tradestream.backtesting.ParamConfig
 
 object TrendFollowingParams {
     @JvmField
-    val allConfigs: List<ParamConfig> = emptyList()
+    val allConfigs: List<ParamConfig> = listOf(
+        IchimokuCloudParamConfig.create()
+    )
 }


### PR DESCRIPTION
This update populates `TrendFollowingParams.allConfigs` with a predefined parameter configuration by adding `IchimokuCloudParamConfig.create()`. Previously, the list was empty. This change enables support for the Ichimoku Cloud strategy within the trend-following backtesting module.

No version bump label is required, as this is a patch-level update that does not introduce new public API surface or behavior changes.