### PR TITLE
Add support for isolated strategy optimization via per-strategy splitting and processing (MINOR)

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -61,6 +61,7 @@ java_library(
     deps = [
         ":strategy_processing_request",
         "//protos:marketdata_java_proto",
+        "//protos:strategies_java_proto",
         "//third_party:beam_sdks_java_core",
         "//third_party:guava",
         "//third_party:guice",

--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -45,6 +45,7 @@ java_library(
     srcs = ["OptimizeStrategiesIsolated.java"],
     deps = [
         ":optimize_each_strategy_do_fn",
+        ":strategy_processing_request",
         ":strategy_state",
         "//protos:marketdata_java_proto",
         "//third_party:beam_sdks_java_core",

--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -45,6 +45,7 @@ java_library(
     srcs = ["OptimizeStrategiesIsolated.java"],
     deps = [
         ":optimize_each_strategy_do_fn",
+        ":split_by_strategy_type",
         ":strategy_processing_request",
         ":strategy_state",
         "//protos:marketdata_java_proto",

--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -4,6 +4,24 @@ load("@rules_java//java:defs.bzl", "java_library")
 package(default_visibility = ["//visibility:public"])
 
 java_library(
+    name = "optimize_each_strategy_do_fn",
+    srcs = ["OptimizeEachStrategyDoFn.java"],
+    deps = [
+        ":strategy_state",
+        "//protos:backtesting_java_proto",
+        "//protos:marketdata_java_proto",
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/backtesting:genetic_algorithm_orchestrator",
+        "//src/main/java/com/verlumen/tradestream/ta4j:bar_series_factory",
+        "//third_party:beam_sdks_java_core",
+        "//third_party:flogger",
+        "//third_party:guava",
+        "//third_party:guice",
+        "//third_party:ta4j_core",
+    ],
+)
+
+java_library(
     name = "optimize_strategies",
     srcs = ["OptimizeStrategies.java"],
     deps = [

--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -7,6 +7,7 @@ java_library(
     name = "optimize_each_strategy_do_fn",
     srcs = ["OptimizeEachStrategyDoFn.java"],
     deps = [
+        ":strategy_processing_request",
         ":strategy_state",
         "//protos:backtesting_java_proto",
         "//protos:marketdata_java_proto",

--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -22,6 +22,19 @@ java_library(
 )
 
 java_library(
+    name = "optimize_strategies_isolated",
+    srcs = ["OptimizeStrategiesIsolated.java"],
+    deps = [
+        ":optimize_each_strategy_do_fn",
+        ":strategy_state",
+        "//protos:marketdata_java_proto",
+        "//third_party:beam_sdks_java_core",
+        "//third_party:guava",
+        "//third_party:guice",
+    ],
+)
+
+java_library(
     name = "strategies_module",
     srcs = ["StrategiesModule.java"],
     deps = [

--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -56,7 +56,7 @@ java_library(
 
 java_library(
     name = "split_by_strategy_type",
-    srcs = ["SplitByStrategyType .java"],
+    srcs = ["SplitByStrategyType.java"],
     deps = [
         ":strategy_processing_request",
         "//protos:marketdata_java_proto",

--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -140,6 +140,15 @@ java_library(
     ],
 )
 
+kt_jvm_library(
+    name = "strategy_processing_request",
+    srcs = ["StrategyProcessingRequest.kt"],
+    deps = [
+        "//protos:marketdata_java_proto",
+        "//protos:strategies_java_proto",
+    ],
+)
+
 java_library(
     name = "strategy_record",
     srcs = ["StrategyRecord.java"],

--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -55,6 +55,18 @@ java_library(
 )
 
 java_library(
+    name = "split_by_strategy_type",
+    srcs = ["SplitByStrategyType .java"],
+    deps = [
+        ":strategy_processing_request",
+        "//protos:marketdata_java_proto",
+        "//third_party:beam_sdks_java_core",
+        "//third_party:guava",
+        "//third_party:guice",
+    ],
+)
+
+java_library(
     name = "strategies_module",
     srcs = ["StrategiesModule.java"],
     deps = [

--- a/src/main/java/com/verlumen/tradestream/strategies/OptimizeEachStrategyDoFn.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/OptimizeEachStrategyDoFn.java
@@ -44,7 +44,7 @@ public class OptimizeEachStrategyDoFn
     String key = element.getKey();
     StrategyProcessingRequest request = element.getValue();
     StrategyType strategyType = request.getStrategyType();
-    ImmutableList<Candle> candles = request.getCandles();
+    ImmutableList<Candle> candles = ImmutableList.copyOf(request.getCandles());
 
     if (candles == null || candles.isEmpty()) {
       // Optionally log a warning here.

--- a/src/main/java/com/verlumen/tradestream/strategies/OptimizeEachStrategyDoFn.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/OptimizeEachStrategyDoFn.java
@@ -1,0 +1,78 @@
+package com.verlumen.tradestream.strategies;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import com.verlumen.tradestream.backtesting.BestStrategyResponse;
+import com.verlumen.tradestream.backtesting.GAOptimizationRequest;
+import com.verlumen.tradestream.backtesting.GeneticAlgorithmOrchestrator;
+import com.verlumen.tradestream.marketdata.Candle;
+import com.verlumen.tradestream.ta4j.BarSeriesFactory;
+import org.apache.beam.sdk.state.StateSpec;
+import org.apache.beam.sdk.state.StateSpecs;
+import org.apache.beam.sdk.state.ValueState;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.DoFn.StateId;
+import org.apache.beam.sdk.values.KV;
+import org.ta4j.core.BarSeries;
+
+/**
+ * DoFn that processes each strategy type in isolation while maintaining shared state.
+ */
+public class OptimizeEachStrategyDoFn 
+    extends DoFn<KV<String, StrategyProcessingRequest>, KV<String, StrategyState>> {
+
+  private final BarSeriesFactory barSeriesFactory;
+  private final GeneticAlgorithmOrchestrator geneticAlgorithmOrchestrator;
+  private final StrategyState.Factory stateFactory;
+
+  @StateId("strategyState")
+  private final StateSpec<ValueState<StrategyState>> stateSpec = StateSpecs.value();
+
+  @Inject
+  public OptimizeEachStrategyDoFn(BarSeriesFactory barSeriesFactory,
+                                  GeneticAlgorithmOrchestrator geneticAlgorithmOrchestrator,
+                                  StrategyState.Factory stateFactory) {
+    this.barSeriesFactory = barSeriesFactory;
+    this.geneticAlgorithmOrchestrator = geneticAlgorithmOrchestrator;
+    this.stateFactory = stateFactory;
+  }
+
+  @ProcessElement
+  public void processElement(ProcessContext context,
+                             @StateId("strategyState") ValueState<StrategyState> sharedState) {
+    KV<String, StrategyProcessingRequest> element = context.element();
+    String key = element.getKey();
+    StrategyProcessingRequest request = element.getValue();
+    StrategyType strategyType = request.getStrategyType();
+    ImmutableList<Candle> candles = request.getCandles();
+
+    if (candles == null || candles.isEmpty()) {
+      // Optionally log a warning here.
+      return;
+    }
+
+    // Read or initialize the shared state.
+    StrategyState state = sharedState.read();
+    if (state == null) {
+      state = stateFactory.create();
+    }
+
+    BarSeries barSeries = barSeriesFactory.createBarSeries(candles);
+
+    GAOptimizationRequest optimizationRequest = GAOptimizationRequest.newBuilder()
+        .setStrategyType(strategyType)
+        .addAllCandles(candles)
+        .build();
+
+    try {
+      BestStrategyResponse response = geneticAlgorithmOrchestrator.runOptimization(optimizationRequest);
+      state.updateRecord(strategyType, response.getBestStrategyParameters(), response.getBestScore());
+    } catch (Exception e) {
+      // Handle or log the exception for this strategy type.
+    }
+
+    StrategyState updatedState = state.selectBestStrategy(barSeries);
+    sharedState.write(updatedState);
+    context.output(KV.of(key, updatedState));
+  }
+}

--- a/src/main/java/com/verlumen/tradestream/strategies/OptimizeStrategiesIsolated.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/OptimizeStrategiesIsolated.java
@@ -31,7 +31,6 @@ final class OptimizeStrategiesIsolated
     PCollection<KV<String, StrategyProcessingRequest>> split = input.apply(ParDo.of(optimizeEachStrategyDoFn));
 
     // Process each strategy type record.
-    return split.apply("OptimizeEachStrategy", ParDo.of(optimizeEachStrategyDoFn))
-    ));
+    return split.apply("OptimizeEachStrategy", ParDo.of(optimizeEachStrategyDoFn));
   }
 }

--- a/src/main/java/com/verlumen/tradestream/strategies/OptimizeStrategiesIsolated.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/OptimizeStrategiesIsolated.java
@@ -19,8 +19,8 @@ final class OptimizeStrategiesIsolated
   private final SplitByStrategyType splitByStrategyType;
 
   @Inject
-  public OptimizeStrategiesIsolated(OptimizeEachStrategyDoFn optimizeEachStrategyDoFn,
-                                    SplitByStrategyType splitByStrategyType) {
+  OptimizeStrategiesIsolated(OptimizeEachStrategyDoFn optimizeEachStrategyDoFn,
+                             SplitByStrategyType splitByStrategyType) {
     this.optimizeEachStrategyDoFn = optimizeEachStrategyDoFn;
     this.splitByStrategyType = splitByStrategyType;
   }

--- a/src/main/java/com/verlumen/tradestream/strategies/OptimizeStrategiesIsolated.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/OptimizeStrategiesIsolated.java
@@ -28,7 +28,8 @@ final class OptimizeStrategiesIsolated
   @Override
   public PCollection<KV<String, StrategyState>> expand(PCollection<KV<String, ImmutableList<Candle>>> input) {
     // Split input so that each strategy type is processed individually.
-    PCollection<KV<String, StrategyProcessingRequest>> split = input.apply(ParDo.of(optimizeEachStrategyDoFn));
+    PCollection<KV<String, StrategyProcessingRequest>> split =
+        input.apply("SplitByStrategyType", splitByStrategyType);
 
     // Process each strategy type record.
     return split.apply("OptimizeEachStrategy", ParDo.of(optimizeEachStrategyDoFn));

--- a/src/main/java/com/verlumen/tradestream/strategies/OptimizeStrategiesIsolated.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/OptimizeStrategiesIsolated.java
@@ -1,0 +1,41 @@
+package com.verlumen.tradestream.strategies;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import com.verlumen.tradestream.marketdata.Candle;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+
+/**
+ * A composite PTransform that first splits the input per strategy type and then processes
+ * each strategy type in isolation while sharing the state.
+ */
+public class OptimizeStrategiesIsolated 
+    extends PTransform<PCollection<KV<String, ImmutableList<Candle>>>, PCollection<KV<String, StrategyState>>> {
+
+  private final BarSeriesFactory barSeriesFactory;
+  private final GeneticAlgorithmOrchestrator geneticAlgorithmOrchestrator;
+  private final StrategyState.Factory stateFactory;
+
+  @Inject
+  public OptimizeStrategiesIsolated(BarSeriesFactory barSeriesFactory,
+                                    GeneticAlgorithmOrchestrator geneticAlgorithmOrchestrator,
+                                    StrategyState.Factory stateFactory) {
+    this.barSeriesFactory = barSeriesFactory;
+    this.geneticAlgorithmOrchestrator = geneticAlgorithmOrchestrator;
+    this.stateFactory = stateFactory;
+  }
+
+  @Override
+  public PCollection<KV<String, StrategyState>> expand(PCollection<KV<String, ImmutableList<Candle>>> input) {
+    // Split input so that each strategy type is processed individually.
+    PCollection<KV<String, StrategyProcessingRequest>> split = input.apply(new SplitByStrategyType());
+
+    // Process each strategy type record.
+    return split.apply("OptimizeEachStrategy", ParDo.of(
+        new OptimizeEachStrategyDoFn(barSeriesFactory, geneticAlgorithmOrchestrator, stateFactory)
+    ));
+  }
+}

--- a/src/main/java/com/verlumen/tradestream/strategies/OptimizeStrategiesIsolated.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/OptimizeStrategiesIsolated.java
@@ -12,7 +12,7 @@ import org.apache.beam.sdk.values.PCollection;
  * A composite PTransform that first splits the input per strategy type and then processes
  * each strategy type in isolation while sharing the state.
  */
-public class OptimizeStrategiesIsolated 
+final class OptimizeStrategiesIsolated 
     extends PTransform<PCollection<KV<String, ImmutableList<Candle>>>, PCollection<KV<String, StrategyState>>> {
 
   private final BarSeriesFactory barSeriesFactory;

--- a/src/main/java/com/verlumen/tradestream/strategies/SplitByStrategyType.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/SplitByStrategyType.java
@@ -1,0 +1,41 @@
+package com.verlumen.tradestream.strategies;
+
+import com.google.common.collect.ImmutableList;
+import com.verlumen.tradestream.marketdata.Candle;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+
+/**
+ * A PTransform that splits the input KV<String, ImmutableList<Candle>> into one record
+ * per strategy type.
+ */
+class SplitByStrategyType 
+    extends PTransform<PCollection<KV<String, ImmutableList<Candle>>>,
+                       PCollection<KV<String, StrategyProcessingRequest>>> {
+
+  @Override
+  public PCollection<KV<String, StrategyProcessingRequest>> expand(
+      PCollection<KV<String, ImmutableList<Candle>>> input) {
+    return input.apply("SplitPerStrategyType", ParDo.of(new SplitByStrategyTypeFn()));
+  }
+  
+  private static class SplitByStrategyTypeFn 
+      extends DoFn<KV<String, ImmutableList<Candle>>, KV<String, StrategyProcessingRequest>> {
+
+    @ProcessElement
+    public void processElement(
+            @Element KV<String, ImmutableList<Candle>> element,
+            OutputReceiver<KV<String, StrategyProcessingRequest>> out) {
+      String key = element.getKey();
+      ImmutableList<Candle> candles = element.getValue();
+
+      for (StrategyType strategyType : StrategyType.values()) {
+        StrategyProcessingRequest request = new StrategyProcessingRequest(strategyType, candles);
+        out.output(KV.of(key, request));
+      }
+    }
+  }
+}

--- a/src/main/java/com/verlumen/tradestream/strategies/SplitByStrategyType.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/SplitByStrategyType.java
@@ -1,6 +1,7 @@
 package com.verlumen.tradestream.strategies;
 
 import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
 import com.verlumen.tradestream.marketdata.Candle;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -12,18 +13,27 @@ import org.apache.beam.sdk.values.PCollection;
  * A PTransform that splits the input KV<String, ImmutableList<Candle>> into one record
  * per strategy type.
  */
-class SplitByStrategyType 
+final class SplitByStrategyType 
     extends PTransform<PCollection<KV<String, ImmutableList<Candle>>>,
                        PCollection<KV<String, StrategyProcessingRequest>>> {
+
+  private final SplitByStrategyTypeFn splitByStrategyTypeFn;
+
+  @Inject
+  SplitByStrategyType(SplitByStrategyTypeFn splitByStrategyTypeFn) {
+      this.splitByStrategyTypeFn = splitByStrategyTypeFn;
+  }
 
   @Override
   public PCollection<KV<String, StrategyProcessingRequest>> expand(
       PCollection<KV<String, ImmutableList<Candle>>> input) {
-    return input.apply("SplitPerStrategyType", ParDo.of(new SplitByStrategyTypeFn()));
+    return input.apply("SplitPerStrategyType", ParDo.of(splitByStrategyTypeFn));
   }
   
   private static class SplitByStrategyTypeFn 
       extends DoFn<KV<String, ImmutableList<Candle>>, KV<String, StrategyProcessingRequest>> {
+    @Inject
+    SplitByStrategyTypeFn() {}
 
     @ProcessElement
     public void processElement(

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyProcessingRequest.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyProcessingRequest.kt
@@ -1,0 +1,8 @@
+package com.verlumen.tradestream.strategies;
+
+import com.verlumen.tradestream.marketdata.Candle;
+
+/**
+ * Helper class representing a request to process a single strategy type.
+ */
+data class StrategyProcessingRequest(val strategyType: StrategyType, val candles: List<Candle>)


### PR DESCRIPTION
This PR introduces a new pipeline mode for optimizing strategies in isolation, enabling finer control and modular processing of each strategy type. Key additions include:

- **New pipeline components:**
  - `OptimizeEachStrategyDoFn`: A stateful Beam `DoFn` that processes individual `StrategyProcessingRequest` records, optimizes a single strategy type, and updates shared `StrategyState`.
  - `SplitByStrategyType`: A transform that splits incoming candle lists into separate processing requests per `StrategyType`.
  - `OptimizeStrategiesIsolated`: A composite transform that uses the above components to run isolated optimization pipelines.

- **Supporting classes and changes:**
  - Added `StrategyProcessingRequest.kt` as a Kotlin data class to carry strategy type and associated candle data.
  - Updated the Bazel `BUILD` file to include new Java/Kotlin targets for these components.
  - Adjusted visibility and constructor modifiers in `OptimizeStrategies` and `OptimizeStrategiesDoFn` to enable composition and dependency injection.

### Rationale
This isolation strategy enables:
- More granular control over how each `StrategyType` is optimized.
- Better utilization of parallelism in Beam by separating strategy-specific logic.
- Simplified and more testable components.

### Versioning
This change introduces **new functionality** and is therefore marked as a **(MINOR)** version update.