### PR TITLE
Migrate `CoinMarketCapConfig` to Java record, remove AutoValue dependency

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -40,9 +40,6 @@ java_library(
 java_library(
     name = "coin_market_cap_config",
     srcs = ["CoinMarketCapConfig.java"],
-    deps = [
-        "//third_party:auto_value",
-    ],
 )
 
 container_structure_test(

--- a/src/main/java/com/verlumen/tradestream/ingestion/CoinMarketCapConfig.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/CoinMarketCapConfig.java
@@ -1,14 +1,7 @@
 package com.verlumen.tradestream.ingestion;
 
-import com.google.auto.value.AutoValue;
-
-@AutoValue
-abstract class CoinMarketCapConfig {
+record CoinMarketCapConfig(int topN, String apiKey) {
   static CoinMarketCapConfig create(int topN, String apiKey) {
-      return new AutoValue_CoinMarketCapConfig(topN, apiKey);
+      return new CoinMarketCapConfig(topN, apiKey);
   }
-
-  abstract int topN();
-
-  abstract String apiKey();
 }


### PR DESCRIPTION
This change refactors `CoinMarketCapConfig` to use a Java record instead of an AutoValue class. As a result, the AutoValue dependency is removed from the corresponding Bazel `BUILD` target.

### Summary of Changes:
- Replaced `@AutoValue`-based implementation of `CoinMarketCapConfig` with a Java record.
- Updated the `create()` method to construct a new record instance.
- Removed the `//third_party:auto_value` dependency from the `coin_market_cap_config` target in the Bazel `BUILD` file.

This update simplifies the code by leveraging Java's native record feature for immutable data structures and reduces the need for external dependencies.