### PR TITLE
(MINOR) Add ADX Stochastic Strategy Support

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyConstants.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyConstants.kt
@@ -4,6 +4,7 @@ object StrategyConstants {
     @JvmField
     val supportedStrategyTypes: Set<StrategyType> = setOf(
         StrategyType.SMA_RSI,
-        StrategyType.EMA_MACD
+        StrategyType.EMA_MACD,
+        StrategyType.ADX_STOCHASTIC
     );
 }

--- a/src/test/java/com/verlumen/tradestream/strategies/OptimizeStrategiesTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/OptimizeStrategiesTest.java
@@ -144,7 +144,7 @@ public class OptimizeStrategiesTest {
     GAOptimizationRequest actualRequest = mockOrchestrator.getLastRequest();
     assertThat(actualRequest.getCandlesList()).containsExactlyElementsIn(candles).inOrder();
     assertThat(actualRequest.getStrategyType())
-        .isEqualTo(StrategyType.EMA_MACD);
+        .isEqualTo(StrategyType.ADX_STOCHASTIC);
   }
 
   @Test
@@ -187,7 +187,7 @@ public class OptimizeStrategiesTest {
 
     assertThat(mockOrchestrator.wasRunOptimizationCalled()).isTrue();
     assertThat(mockOrchestrator.getLastRequest().getStrategyType())
-        .isEqualTo(StrategyType.EMA_MACD);
+        .isEqualTo(StrategyType.ADX_STOCHASTIC);
   }
 
   // Fake implementation of StrategyState.Factory.


### PR DESCRIPTION
- **Added** `StrategyType.ADX_STOCHASTIC` to `supportedStrategyTypes` in `StrategyConstants.kt`, enabling support for the ADX Stochastic strategy.
- **Updated** unit tests in `OptimizeStrategiesTest.java`:
  - Modified assertions in `expand_nonEmptyCandleList_callsOrchestratorAndOutputsState` and `expand_multipleStrategies_callsOrchestratorForEachStrategy` to verify that `StrategyType.ADX_STOCHASTIC` is being used correctly.
  
#### Context
- This change introduces a new strategy type to the system, expanding available trading strategies. The corresponding tests ensure that the orchestrator is properly handling the new strategy.

#### Versioning
- Marked as a **minor** version update due to the addition of new functionality.