### PR TITLE
(MINOR) Move exchange streaming client components to marketdata package

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -23,21 +23,6 @@ java_binary(
 )
 
 java_library(
-    name = "coinbase_streaming_client",
-    srcs = ["CoinbaseStreamingClient.java"],
-    deps = [
-        ":exchange_streaming_client",
-        "//protos:marketdata_java_proto",
-        "//src/main/java/com/verlumen/tradestream/instruments:currency_pair",
-        "//third_party:flogger",
-        "//third_party:gson",
-        "//third_party:guava",
-        "//third_party:guice",
-        "//third_party:protobuf_java_util",
-    ],
-)
-
-java_library(
     name = "coin_market_cap_config",
     srcs = ["CoinMarketCapConfig.java"],
 )
@@ -77,27 +62,6 @@ java_library(
         ":currency_pair_supply",
         "//src/main/java/com/verlumen/tradestream/http:http_client",
         "//third_party:gson",
-        "//third_party:guava",
-        "//third_party:guice",
-    ],
-)
-
-java_library(
-    name = "exchange_streaming_client",
-    srcs = ["ExchangeStreamingClient.java"],
-    deps = [
-        "//protos:marketdata_java_proto",
-        "//src/main/java/com/verlumen/tradestream/instruments:currency_pair",
-        "//third_party:guava",
-    ],
-)
-
-java_library(
-    name = "exchange_streaming_client_factory",
-    srcs = ["ExchangeStreamingClientFactory.java"],
-    deps = [
-        ":coinbase_streaming_client",
-        ":exchange_streaming_client",
         "//third_party:guava",
         "//third_party:guice",
     ],

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -114,11 +114,8 @@ java_library(
     name = "ingestion_module",
     srcs = ["IngestionModule.java"],
     deps = [
-        ":coin_market_cap_config",
         ":currency_pair_supply",
         ":currency_pair_supply_provider",
-        ":exchange_streaming_client",
-        ":exchange_streaming_client_factory",
         ":ingestion_config",
         ":real_time_data_ingestion",
         ":real_time_data_ingestion_impl",

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -151,10 +151,10 @@ java_library(
     srcs = ["RealTimeDataIngestionImpl.java"],
     deps = [
         ":currency_pair_supply",
-        ":exchange_streaming_client",
         ":real_time_data_ingestion",
         "//protos:marketdata_java_proto",
         "//src/main/java/com/verlumen/tradestream/instruments:currency_pair",
+        "//src/main/java/com/verlumen/tradestream/marketdata:exchange_streaming_client",
         "//src/main/java/com/verlumen/tradestream/marketdata:trade_publisher",
         "//third_party:flogger",
         "//third_party:guava",

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -150,6 +150,7 @@ java_library(
     name = "real_time_data_ingestion_impl",
     srcs = ["RealTimeDataIngestionImpl.java"],
     deps = [
+        ":coin_market_cap_config",
         ":currency_pair_supply",
         ":real_time_data_ingestion",
         "//protos:marketdata_java_proto",

--- a/src/main/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/main/java/com/verlumen/tradestream/ingestion/BUILD
@@ -114,6 +114,7 @@ java_library(
     name = "ingestion_module",
     srcs = ["IngestionModule.java"],
     deps = [
+        ":coin_market_cap_config",
         ":currency_pair_supply",
         ":currency_pair_supply_provider",
         ":ingestion_config",
@@ -150,7 +151,6 @@ java_library(
     name = "real_time_data_ingestion_impl",
     srcs = ["RealTimeDataIngestionImpl.java"],
     deps = [
-        ":coin_market_cap_config",
         ":currency_pair_supply",
         ":real_time_data_ingestion",
         "//protos:marketdata_java_proto",

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionConfig.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionConfig.java
@@ -5,6 +5,7 @@ import com.verlumen.tradestream.execution.RunMode;
 record IngestionConfig(
     String coinMarketCapApiKey,
     int topCryptocurrencyCount,
+    String exchangeName,
     RunMode runMode,
     String kafkaBootstrapServers,
     String tradeTopic) {}

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionConfig.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionConfig.java
@@ -5,7 +5,6 @@ import com.verlumen.tradestream.execution.RunMode;
 record IngestionConfig(
     String coinMarketCapApiKey,
     int topCryptocurrencyCount,
-    String exchangeName,
     RunMode runMode,
     String kafkaBootstrapServers,
     String tradeTopic) {}

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -23,7 +23,7 @@ abstract class IngestionModule extends AbstractModule {
 
     install(HttpModule.create());
     install(KafkaModule.create(ingestionConfig().kafkaBootstrapServers()));
-    install(MarketDataModule.create(ingestionConfig().tradeTopic()));
+    install(MarketDataModule.create(ingestionConfig().exchangeName(), ingestionConfig().tradeTopic()));
   }
 
   @Provides

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -19,7 +19,6 @@ abstract class IngestionModule extends AbstractModule {
   @Override
   protected void configure() {
     bind(CurrencyPairSupply.class).toProvider(CurrencyPairSupplyProvider.class);
-    bind(ExchangeStreamingClient.Factory.class).to(ExchangeStreamingClientFactory.class);
     bind(RealTimeDataIngestion.class).to(RealTimeDataIngestionImpl.class);
 
     install(HttpModule.create());
@@ -31,12 +30,6 @@ abstract class IngestionModule extends AbstractModule {
   CoinMarketCapConfig provideCoinMarketCapConfig() {
     return CoinMarketCapConfig.create(
         ingestionConfig().topCryptocurrencyCount(), ingestionConfig().coinMarketCapApiKey());
-  }
-
-  @Provides
-  ExchangeStreamingClient provideExchangeStreamingClient(
-      ExchangeStreamingClient.Factory exchangeStreamingClientFactory) {
-    return exchangeStreamingClientFactory.create(ingestionConfig().exchangeName());
   }
 
   @Provides

--- a/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImpl.java
@@ -12,6 +12,7 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.verlumen.tradestream.instruments.CurrencyPair;
 import com.verlumen.tradestream.marketdata.Trade;
+import com.verlumen.tradestream.marketdata.ExchangeStreamingClient;
 import com.verlumen.tradestream.marketdata.TradePublisher;
 import java.util.Objects;
 import java.util.concurrent.BlockingQueue;

--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -89,7 +89,6 @@ java_library(
   name = "market_data_module",
   srcs = ["MarketDataModule.java"],
   deps = [
-    ":coin_market_cap_config",
     ":exchange_streaming_client",
     ":exchange_streaming_client_factory",
     ":market_data_config",

--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -89,6 +89,9 @@ java_library(
   name = "market_data_module",
   srcs = ["MarketDataModule.java"],
   deps = [
+    ":coin_market_cap_config",,
+    ":exchange_streaming_client",
+    ":exchange_streaming_client_factory",
     ":market_data_config",
     ":trade_publisher",
     ":trade_publisher_impl",

--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -89,7 +89,7 @@ java_library(
   name = "market_data_module",
   srcs = ["MarketDataModule.java"],
   deps = [
-    ":coin_market_cap_config",,
+    ":coin_market_cap_config",
     ":exchange_streaming_client",
     ":exchange_streaming_client_factory",
     ":market_data_config",

--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -18,6 +18,22 @@ java_library(
     ],
 )
 
+
+java_library(
+    name = "coinbase_streaming_client",
+    srcs = ["CoinbaseStreamingClient.java"],
+    deps = [
+        ":exchange_streaming_client",
+        "//protos:marketdata_java_proto",
+        "//src/main/java/com/verlumen/tradestream/instruments:currency_pair",
+        "//third_party:flogger",
+        "//third_party:gson",
+        "//third_party:guava",
+        "//third_party:guice",
+        "//third_party:protobuf_java_util",
+    ],
+)
+
 java_library(
     name = "default_trade_generator",
     srcs = ["DefaultTradeGenerator.java"],
@@ -28,6 +44,27 @@ java_library(
       "//third_party:joda_time",
       "//third_party:protobuf_java",
       "//third_party:protobuf_java_util",
+    ],
+)
+
+java_library(
+    name = "exchange_streaming_client",
+    srcs = ["ExchangeStreamingClient.java"],
+    deps = [
+        "//protos:marketdata_java_proto",
+        "//src/main/java/com/verlumen/tradestream/instruments:currency_pair",
+        "//third_party:guava",
+    ],
+)
+
+java_library(
+    name = "exchange_streaming_client_factory",
+    srcs = ["ExchangeStreamingClientFactory.java"],
+    deps = [
+        ":coinbase_streaming_client",
+        ":exchange_streaming_client",
+        "//third_party:guava",
+        "//third_party:guice",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/marketdata/CoinbaseStreamingClient.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/CoinbaseStreamingClient.java
@@ -1,4 +1,4 @@
-package com.verlumen.tradestream.ingestion;
+package com.verlumen.tradestream.marketdata;
 
 import static com.google.common.collect.Streams.stream;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -12,8 +12,6 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.inject.Inject;
 import com.verlumen.tradestream.instruments.CurrencyPair;
-import com.verlumen.tradestream.marketdata.Trade;
-
 import java.io.IOException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;

--- a/src/main/java/com/verlumen/tradestream/marketdata/ExchangeStreamingClient.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/ExchangeStreamingClient.java
@@ -1,11 +1,9 @@
-package com.verlumen.tradestream.ingestion;
+package com.verlumen.tradestream.marketdata;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.common.collect.ImmutableList;
 import com.verlumen.tradestream.instruments.CurrencyPair;
-import com.verlumen.tradestream.marketdata.Trade;
-
 import java.util.function.Consumer;
 
 /**

--- a/src/main/java/com/verlumen/tradestream/marketdata/ExchangeStreamingClient.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/ExchangeStreamingClient.java
@@ -11,7 +11,7 @@ import java.util.function.Consumer;
  * This allows different exchanges to provide their own implementations
  * while maintaining a consistent interface for the data ingestion system.
  */
-interface ExchangeStreamingClient {
+public interface ExchangeStreamingClient {
     /**
      * Starts streaming market data for the given currency pairs.
      *

--- a/src/main/java/com/verlumen/tradestream/marketdata/ExchangeStreamingClientFactory.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/ExchangeStreamingClientFactory.java
@@ -1,4 +1,4 @@
-package com.verlumen.tradestream.ingestion;
+package com.verlumen.tradestream.marketdata;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;

--- a/src/main/java/com/verlumen/tradestream/marketdata/MarketDataConfig.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/MarketDataConfig.java
@@ -1,7 +1,7 @@
 package com.verlumen.tradestream.marketdata;
 
-public record MarketDataConfig(String exchangeName) {
-  public static MarketDataConfig create(String exchangeName) {
-    return new MarketDataConfig(exchangeName);
+public record MarketDataConfig(String exchangeName, String tradeTopic) {
+  public static MarketDataConfig create(String exchangeName, String tradeTopic) {
+    return new MarketDataConfig(exchangeName, tradeTopic);
   }
 }

--- a/src/main/java/com/verlumen/tradestream/marketdata/MarketDataConfig.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/MarketDataConfig.java
@@ -1,7 +1,7 @@
 package com.verlumen.tradestream.marketdata;
 
-public record MarketDataConfig(String tradeTopic) {
-  public static MarketDataConfig create(String tradeTopic) {
-    return new MarketDataConfig(tradeTopic);
+public record MarketDataConfig(String exchangeName) {
+  public static MarketDataConfig create(String exchangeName) {
+    return new MarketDataConfig(exchangeName);
   }
 }

--- a/src/main/java/com/verlumen/tradestream/marketdata/MarketDataModule.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/MarketDataModule.java
@@ -7,8 +7,8 @@ import com.google.inject.assistedinject.FactoryModuleBuilder;
 
 @AutoValue
 public abstract class MarketDataModule extends AbstractModule {
-  public static MarketDataModule create(String tradeTopic) {
-    return new AutoValue_MarketDataModule(MarketDataConfig.create(tradeTopic));
+  public static MarketDataModule create(String exchangeName) {
+    return new AutoValue_MarketDataModule(MarketDataConfig.create(exchangeName));
   }
 
   abstract MarketDataConfig config();
@@ -19,10 +19,5 @@ public abstract class MarketDataModule extends AbstractModule {
         new FactoryModuleBuilder()
             .implement(TradePublisher.class, TradePublisherImpl.class)
             .build(TradePublisher.Factory.class));
-  }
-
-  @Provides
-  TradePublisher provideTradePublisher(TradePublisher.Factory tradePublisherFactory) {
-    return tradePublisherFactory.create(config().tradeTopic());
   }
 }

--- a/src/main/java/com/verlumen/tradestream/marketdata/MarketDataModule.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/MarketDataModule.java
@@ -20,4 +20,10 @@ public abstract class MarketDataModule extends AbstractModule {
             .implement(TradePublisher.class, TradePublisherImpl.class)
             .build(TradePublisher.Factory.class));
   }
+
+  @Provides
+  ExchangeStreamingClient provideExchangeStreamingClient(
+      ExchangeStreamingClient.Factory exchangeStreamingClientFactory) {
+    return exchangeStreamingClientFactory.create(ingestionConfig().exchangeName());
+  }
 }

--- a/src/main/java/com/verlumen/tradestream/marketdata/MarketDataModule.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/MarketDataModule.java
@@ -26,4 +26,9 @@ public abstract class MarketDataModule extends AbstractModule {
       ExchangeStreamingClient.Factory exchangeStreamingClientFactory) {
     return exchangeStreamingClientFactory.create(config().exchangeName());
   }
+
+  @Provides
+  TradePublisher provideTradePublisher(TradePublisher.Factory tradePublisherFactory) {
+    return tradePublisherFactory.create(config().tradeTopic());
+  }
 }

--- a/src/main/java/com/verlumen/tradestream/marketdata/MarketDataModule.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/MarketDataModule.java
@@ -15,6 +15,8 @@ public abstract class MarketDataModule extends AbstractModule {
 
   @Override
   protected void configure() {
+    bind(ExchangeStreamingClient.Factory.class).to(ExchangeStreamingClientFactory.class);
+
     install(
         new FactoryModuleBuilder()
             .implement(TradePublisher.class, TradePublisherImpl.class)

--- a/src/main/java/com/verlumen/tradestream/marketdata/MarketDataModule.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/MarketDataModule.java
@@ -7,8 +7,8 @@ import com.google.inject.assistedinject.FactoryModuleBuilder;
 
 @AutoValue
 public abstract class MarketDataModule extends AbstractModule {
-  public static MarketDataModule create(String exchangeName) {
-    return new AutoValue_MarketDataModule(MarketDataConfig.create(exchangeName));
+  public static MarketDataModule create(String exchangeName, String tradeTopic) {
+    return new AutoValue_MarketDataModule(MarketDataConfig.create(exchangeName, tradeTopic));
   }
 
   abstract MarketDataConfig config();

--- a/src/main/java/com/verlumen/tradestream/marketdata/MarketDataModule.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/MarketDataModule.java
@@ -24,6 +24,6 @@ public abstract class MarketDataModule extends AbstractModule {
   @Provides
   ExchangeStreamingClient provideExchangeStreamingClient(
       ExchangeStreamingClient.Factory exchangeStreamingClientFactory) {
-    return exchangeStreamingClientFactory.create(ingestionConfig().exchangeName());
+    return exchangeStreamingClientFactory.create(config().exchangeName());
   }
 }

--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -27,9 +27,9 @@ java_test(
     deps = [
         "//protos:marketdata_java_proto",
         "//src/main/java/com/verlumen/tradestream/ingestion:currency_pair_supply",
-        "//src/main/java/com/verlumen/tradestream/ingestion:exchange_streaming_client",
         "//src/main/java/com/verlumen/tradestream/ingestion:real_time_data_ingestion_impl",
         "//src/main/java/com/verlumen/tradestream/instruments:currency_pair",
+        "//src/main/java/com/verlumen/tradestream/marketdata:exchange_streaming_client",
         "//src/main/java/com/verlumen/tradestream/marketdata:trade_publisher",
         "//third_party:guava",
         "//third_party:guice",

--- a/src/test/java/com/verlumen/tradestream/ingestion/BUILD
+++ b/src/test/java/com/verlumen/tradestream/ingestion/BUILD
@@ -22,24 +22,6 @@ java_test(
 )
 
 java_test(
-    name = "CoinbaseStreamingClientTest",
-    srcs = ["CoinbaseStreamingClientTest.java"],
-    deps = [
-        "//protos:marketdata_java_proto",
-        "//src/main/java/com/verlumen/tradestream/ingestion:coinbase_streaming_client",
-        "//src/main/java/com/verlumen/tradestream/ingestion:exchange_streaming_client",
-        "//src/main/java/com/verlumen/tradestream/instruments:currency_pair",
-        "//third_party:gson",
-        "//third_party:guava",
-        "//third_party:guice",
-        "//third_party:guice_testlib",
-        "//third_party:junit",
-        "//third_party:mockito_core",
-        "//third_party:truth",
-    ],
-)
-
-java_test(
     name = "RealTimeDataIngestionImplTest",
     srcs = ["RealTimeDataIngestionImplTest.java"],
     deps = [

--- a/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/ingestion/RealTimeDataIngestionImplTest.java
@@ -10,6 +10,7 @@ import com.google.inject.Inject;
 import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import com.verlumen.tradestream.instruments.CurrencyPair;
+import com.verlumen.tradestream.marketdata.ExchangeStreamingClient;
 import com.verlumen.tradestream.marketdata.Trade;
 import com.verlumen.tradestream.marketdata.TradePublisher;
 import java.lang.reflect.Field;

--- a/src/test/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/test/java/com/verlumen/tradestream/marketdata/BUILD
@@ -25,9 +25,9 @@ java_test(
     srcs = ["CoinbaseStreamingClientTest.java"],
     deps = [
         "//protos:marketdata_java_proto",
-        "//src/main/java/com/verlumen/tradestream/ingestion:coinbase_streaming_client",
-        "//src/main/java/com/verlumen/tradestream/ingestion:exchange_streaming_client",
         "//src/main/java/com/verlumen/tradestream/instruments:currency_pair",
+        "//src/main/java/com/verlumen/tradestream/marketdata:coinbase_streaming_client",
+        "//src/main/java/com/verlumen/tradestream/marketdata:exchange_streaming_client",
         "//third_party:gson",
         "//third_party:guava",
         "//third_party:guice",

--- a/src/test/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/test/java/com/verlumen/tradestream/marketdata/BUILD
@@ -21,6 +21,24 @@ java_test(
 )
 
 java_test(
+    name = "CoinbaseStreamingClientTest",
+    srcs = ["CoinbaseStreamingClientTest.java"],
+    deps = [
+        "//protos:marketdata_java_proto",
+        "//src/main/java/com/verlumen/tradestream/ingestion:coinbase_streaming_client",
+        "//src/main/java/com/verlumen/tradestream/ingestion:exchange_streaming_client",
+        "//src/main/java/com/verlumen/tradestream/instruments:currency_pair",
+        "//third_party:gson",
+        "//third_party:guava",
+        "//third_party:guice",
+        "//third_party:guice_testlib",
+        "//third_party:junit",
+        "//third_party:mockito_core",
+        "//third_party:truth",
+    ],
+)
+
+java_test(
     name = "DefaultTradeGeneratorTest",
     srcs = ["DefaultTradeGeneratorTest.java"],
     deps = [

--- a/src/test/java/com/verlumen/tradestream/marketdata/CoinbaseStreamingClientTest.java
+++ b/src/test/java/com/verlumen/tradestream/marketdata/CoinbaseStreamingClientTest.java
@@ -1,4 +1,4 @@
-package com.verlumen.tradestream.ingestion;
+package com.verlumen.tradestream.marketdata;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;


### PR DESCRIPTION
This change reorganizes the `ExchangeStreamingClient`, its factory, and related implementations and tests by relocating them from the `ingestion` package to the `marketdata` package. This aligns the code structure with logical module responsibilities and improves separation of concerns between ingestion and market data handling.

### Summary of Changes:
- **Moved Classes:**
  - `ExchangeStreamingClient`, `ExchangeStreamingClientFactory`, `CoinbaseStreamingClient`, and their corresponding tests were moved from `ingestion` to `marketdata`.
- **BUILD File Updates:**
  - Removed associated targets from `ingestion/BUILD` and added them to `marketdata/BUILD`.
  - Updated test dependencies and package paths accordingly.
- **Dependency Injection Adjustments:**
  - Updated `IngestionModule` to rely on `MarketDataModule` for binding `ExchangeStreamingClient`.
  - `MarketDataModule` now accepts both `exchangeName` and `tradeTopic` via `MarketDataConfig`.
  - Moved `ExchangeStreamingClient` provisioning logic from `IngestionModule` to `MarketDataModule`.

This refactor is backward-compatible and introduces no functional changes to runtime behavior, but it qualifies as a **minor version** update due to module boundary shifts and DI restructuring.