### PR TITLE
(MINOR) Add CoinMarketCap API key as environment variable in Flink container  

### DIFF
--- a/charts/tradestream/templates/pipeline.yaml
+++ b/charts/tradestream/templates/pipeline.yaml
@@ -42,6 +42,12 @@ spec:
           emptyDir: {}
       containers:
         - name: flink-main-container
+          env:
+            - name: COINMARKETCAP_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: coinmarketcap
+                  key: apiKey
           volumeMounts:
             - name: flink-writable-volume
               mountPath: /opt/flink/writable-tmp


### PR DESCRIPTION
- Updated `charts/tradestream/templates/pipeline.yaml` to inject the `COINMARKETCAP_API_KEY` as an environment variable in the `flink-main-container`.  
- The API key is retrieved from the `coinmarketcap` secret under the `apiKey` key.  

#### Context  
- This change introduces a new environment variable required for accessing the CoinMarketCap API.  
- Ensures that the Flink container has the necessary credentials to communicate with the API for relevant data operations.  

#### Notes  
- Marked as a **minor** version update since it introduces new functionality without breaking existing behavior.