### PR TITLE
(MINOR) Add `TradeSource` class and corresponding build target

### DIFF
--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -251,3 +251,11 @@ java_library(
         "//third_party:protobuf_java_util",
     ],
 )
+
+java_library(
+    name = "trade_source",
+    srcs = ["TradeSource.java"],
+    deps = [
+        "//third_party:beam_sdks_java_core",
+    ],
+)

--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -256,6 +256,7 @@ java_library(
     name = "trade_source",
     srcs = ["TradeSource.java"],
     deps = [
+        "//protos:marketdata_java_proto",
         "//third_party:beam_sdks_java_core",
     ],
 )

--- a/src/main/java/com/verlumen/tradestream/marketdata/TradeSource.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/TradeSource.java
@@ -1,3 +1,7 @@
 package com.verlumen.tradestream.marketdata;
 
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+
 public abstract class TradeSource extends PTransform<PBegin,PCollection<Trade>> {}

--- a/src/main/java/com/verlumen/tradestream/marketdata/TradeSource.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/TradeSource.java
@@ -1,0 +1,3 @@
+package com.verlumen.tradestream.marketdata;
+
+public abstract class TradeSource extends PTransform<PBegin,PCollection<Trade>> {}


### PR DESCRIPTION
#### Summary of Changes
- **Added `TradeSource.java`**  
  - Introduced an abstract class `TradeSource` that extends `PTransform<PBegin, PCollection<Trade>>`.
  - This class is designed to act as a base class for creating Beam sources for trade data.
- **Updated `BUILD` file**  
  - Added a new `java_library` target named `trade_source`.
  - Included `TradeSource.java` in the `srcs` list.
  - Added the necessary dependencies:
    - `//protos:marketdata_java_proto`
    - `//third_party:beam_sdks_java_core`

#### Context
This change introduces a foundational class for integrating trade data as a Beam source, enabling further extensions and data ingestion capabilities. The new build target ensures that the source can be compiled and utilized effectively in future pipelines.

#### Version Impact
Since this PR introduces a new class and functionality, it qualifies as a **MINOR** version change.