### PR TITLE
(MINOR) Add `ExchangeClientTradeSource` to read trades from exchange using unbounded source

### DIFF
--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -72,6 +72,10 @@ java_library(
     srcs = ["ExchangeClientTradeSource.java"],
     deps = [
         ":exchange_client_unbounded_source",
+        ":trade_source",
+        "//src/main/java/com/verlumen/tradestream/kafka:kafka_read_transform",
+        "//src/main/java/com/verlumen/tradestream/marketdata:parse_trades",
+        "//third_party:beam_sdks_java_core",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -77,6 +77,7 @@ java_library(
         "//src/main/java/com/verlumen/tradestream/kafka:kafka_read_transform",
         "//src/main/java/com/verlumen/tradestream/marketdata:parse_trades",
         "//third_party:beam_sdks_java_core",
+        "//third_party:guice",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -73,6 +73,7 @@ java_library(
     deps = [
         ":exchange_client_unbounded_source",
         ":trade_source",
+        "//protos:marketdata_java_proto",
         "//src/main/java/com/verlumen/tradestream/kafka:kafka_read_transform",
         "//src/main/java/com/verlumen/tradestream/marketdata:parse_trades",
         "//third_party:beam_sdks_java_core",

--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -67,6 +67,14 @@ java_library(
     ],
 )
 
+java_library(
+    name = "exchange_client_trade_source",
+    srcs = ["ExchangeClientTradeSource.java"],
+    deps = [
+        ":exchange_client_unbounded_source",
+    ],
+)
+
 kt_jvm_library(
     name = "exchange_client_unbounded_reader",
     srcs = ["ExchangeClientUnboundedReader.kt"],

--- a/src/main/java/com/verlumen/tradestream/marketdata/ExchangeClientTradeSource.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/ExchangeClientTradeSource.java
@@ -1,5 +1,9 @@
 package com.verlumen.tradestream.marketdata;
 
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+
 final class ExchangeClientTradeSource extends TradeSource {
   private final ExchangeClientUnboundedSource source;
 
@@ -10,9 +14,8 @@ final class ExchangeClientTradeSource extends TradeSource {
 
   @Override
   public PCollection<Trade> expand(PBegin input) {
-    // 1. Read from Kafka.
-    PCollection<byte[]> kafkaData = input.apply("ReadFromKafka", kafkaReadTransform);
-    // 2. Parse the byte stream into Trade objects.
-    return kafkaData.apply("ParseTrades", parseTrades);
+    // Read from the exchange using the Unbounded Source.
+    // The source directly produces Trade objects.
+    return input.apply("ReadFromExchange", Read.from(source));
   }
 }

--- a/src/main/java/com/verlumen/tradestream/marketdata/ExchangeClientTradeSource.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/ExchangeClientTradeSource.java
@@ -1,0 +1,18 @@
+package com.verlumen.tradestream.marketdata;
+
+final class ExchangeClientTradeSource extends TradeSource {
+  private final ExchangeClientUnboundedSource source;
+
+  @Inject
+  ExchangeClientTradeSource(ExchangeClientUnboundedSource source) {
+    this.source = source;
+  }
+
+  @Override
+  public PCollection<Trade> expand(PBegin input) {
+    // 1. Read from Kafka.
+    PCollection<byte[]> kafkaData = input.apply("ReadFromKafka", kafkaReadTransform);
+    // 2. Parse the byte stream into Trade objects.
+    return kafkaData.apply("ParseTrades", parseTrades);
+  }
+}

--- a/src/main/java/com/verlumen/tradestream/marketdata/ExchangeClientTradeSource.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/ExchangeClientTradeSource.java
@@ -1,5 +1,7 @@
 package com.verlumen.tradestream.marketdata;
 
+import com.google.inject.Inject;
+import org.apache.beam.sdk.io.Read;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;


### PR DESCRIPTION
- Added a new Java class `ExchangeClientTradeSource` in `src/main/java/com/verlumen/tradestream/marketdata/`.
    - Extends `TradeSource` and uses `ExchangeClientUnboundedSource` to read trade data.
    - Applies `Read.from(source)` to read trades directly from the exchange.
- Updated `BUILD` file to include a new `java_library` target named `exchange_client_trade_source`.
    - Added dependencies for Guice, Beam SDK, trade parsing, and Kafka transform.

#### Context
This change introduces a new trade source to support reading trade data from an exchange using an unbounded source. The addition allows for seamless integration of exchange data into the pipeline.

#### Dependencies
- Added dependencies to `BUILD` file:
    - `exchange_client_unbounded_source`
    - `trade_source`
    - `protos:marketdata_java_proto`
    - `kafka_read_transform`
    - Beam SDK and Guice libraries

#### Impact
This introduces new functionality to enable exchange trade reading and does not modify existing logic, making this a backward-compatible feature addition.