### PR TITLE
(MINOR) Add DryRunTradeSource for Simulated Trade Data in Market Data Pipeline

### DIFF
--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -70,6 +70,12 @@ java_library(
 java_library(
     name = "dry_run_trade_source",
     srcs = ["DryRunTradeSource.java"],
+    deps = [
+        ":trade_source",
+        "//protos:marketdata_java_proto",
+        "//third_party:auto_value",
+        "//third_party:beam_sdks_java_core",
+    ],
 )
 
 java_library(

--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -75,6 +75,7 @@ java_library(
         "//protos:marketdata_java_proto",
         "//third_party:auto_value",
         "//third_party:beam_sdks_java_core",
+        "//third_party:guava",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -68,6 +68,11 @@ java_library(
 )
 
 java_library(
+    name = "dry_run_trade_source",
+    srcs = ["DryRunTradeSource.java"],
+)
+
+java_library(
     name = "exchange_client_trade_source",
     srcs = ["ExchangeClientTradeSource.java"],
     deps = [

--- a/src/main/java/com/verlumen/tradestream/marketdata/DryRunTradeSource.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/DryRunTradeSource.java
@@ -1,12 +1,16 @@
 package com.verlumen.tradestream.marketdata;
 
+import com.google.auto.value.AutoValue;
 import org.apache.beam.sdk.transforms.Create;
 
-final class DryRunTradeSource extends TradeSource {
-  private final ImmutableList<Trade> trades;
+@AutoValue
+abstract class DryRunTradeSource extends TradeSource {
+  abstract ImmutableList<Trade> trades();
 
+  DryRunTradeSource
+  
   @Override
   public PCollection<Trade> expand(PBegin input) {
-   return input.apply(Create.of(trades));
+   return input.apply(Create.of(trades()));
   }
 }

--- a/src/main/java/com/verlumen/tradestream/marketdata/DryRunTradeSource.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/DryRunTradeSource.java
@@ -2,12 +2,17 @@ package com.verlumen.tradestream.marketdata;
 
 import com.google.auto.value.AutoValue;
 import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
 
 @AutoValue
 abstract class DryRunTradeSource extends TradeSource {
-  abstract ImmutableList<Trade> trades();
+  static DryRunTradeSource create(ImmutableList<Trade> trades) {
+    return new AutoValue_DryRunTradeSource(trades);
+  }
 
-  DryRunTradeSource
+  abstract ImmutableList<Trade> trades();
   
   @Override
   public PCollection<Trade> expand(PBegin input) {

--- a/src/main/java/com/verlumen/tradestream/marketdata/DryRunTradeSource.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/DryRunTradeSource.java
@@ -1,6 +1,7 @@
 package com.verlumen.tradestream.marketdata;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PBegin;

--- a/src/main/java/com/verlumen/tradestream/marketdata/DryRunTradeSource.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/DryRunTradeSource.java
@@ -1,8 +1,12 @@
 package com.verlumen.tradestream.marketdata;
 
+import org.apache.beam.sdk.transforms.Create;
+
 final class DryRunTradeSource extends TradeSource {
+  private final ImmutableList<Trade> trades;
+
   @Override
   public PCollection<Trade> expand(PBegin input) {
-    
+   return input.apply(Create.of(trades));
   }
 }

--- a/src/main/java/com/verlumen/tradestream/marketdata/DryRunTradeSource.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/DryRunTradeSource.java
@@ -1,0 +1,8 @@
+package com.verlumen.tradestream.marketdata;
+
+final class DryRunTradeSource extends TradeSource {
+  @Override
+  public PCollection<Trade> expand(PBegin input) {
+    
+  }
+}


### PR DESCRIPTION
#### Summary
- Added a new `DryRunTradeSource` class to simulate trade data for testing and dry-run purposes.
- Defined `DryRunTradeSource` as an `AutoValue` class extending `TradeSource`, applying a list of trades using `Create.of()`.
- Registered the new `dry_run_trade_source` Java library in the `BUILD` file, including necessary dependencies:
  - `:trade_source`
  - `//protos:marketdata_java_proto`
  - `//third_party:auto_value`
  - `//third_party:beam_sdks_java_core`
  - `//third_party:guava`

#### Context
- This change introduces functionality to create and apply simulated trade data, which can be useful for testing pipeline behavior without relying on real market data.
- The new library ensures seamless integration with the existing pipeline infrastructure.

#### Impact
- No breaking changes introduced.
- Adds new functionality, justifying a **minor version bump**.

#### Versioning
- Since this PR introduces a new feature, it requires a **minor version** update.