### PR TITLE
(MINOR) Add run mode configuration to MarketDataModule and IngestionModule

### DIFF
--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -22,7 +22,7 @@ abstract class IngestionModule extends AbstractModule {
 
     install(HttpModule.create());
     install(KafkaModule.create(ingestionConfig().kafkaBootstrapServers()));
-    install(MarketDataModule.create(ingestionConfig().exchangeName(), ingestionConfig().tradeTopic()), ingestionConfig().runMode());
+    install(MarketDataModule.create(ingestionConfig().exchangeName(), ingestionConfig().tradeTopic(), ingestionConfig().runMode());
   }
 
   @Provides

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -22,7 +22,7 @@ abstract class IngestionModule extends AbstractModule {
 
     install(HttpModule.create());
     install(KafkaModule.create(ingestionConfig().kafkaBootstrapServers()));
-    install(marketDataModule();
+    install(marketDataModule());
   }
 
   MarketDataModule marketDataModule() {

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -22,7 +22,7 @@ abstract class IngestionModule extends AbstractModule {
 
     install(HttpModule.create());
     install(KafkaModule.create(ingestionConfig().kafkaBootstrapServers()));
-    install(MarketDataModule.create(ingestionConfig().exchangeName(), ingestionConfig().tradeTopic()));
+    install(MarketDataModule.create(ingestionConfig().exchangeName(), ingestionConfig().tradeTopic()), ingestionConfig().runMode());
   }
 
   @Provides

--- a/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
+++ b/src/main/java/com/verlumen/tradestream/ingestion/IngestionModule.java
@@ -22,7 +22,14 @@ abstract class IngestionModule extends AbstractModule {
 
     install(HttpModule.create());
     install(KafkaModule.create(ingestionConfig().kafkaBootstrapServers()));
-    install(MarketDataModule.create(ingestionConfig().exchangeName(), ingestionConfig().tradeTopic(), ingestionConfig().runMode());
+    install(marketDataModule();
+  }
+
+  MarketDataModule marketDataModule() {
+    return MarketDataModule.create(
+      ingestionConfig().exchangeName(),
+      ingestionConfig().tradeTopic(),
+      ingestionConfig().runMode());
   }
 
   @Provides

--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -203,6 +203,7 @@ java_library(
         ":market_data_config",
         ":trade_publisher",
         ":trade_publisher_impl",
+        "//src/main/java/com/verlumen/tradestream/execution:RunMode",
         "//third_party:auto_value",
         "//third_party:guice",
         "//third_party:guice_assistedinject",

--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -203,7 +203,7 @@ java_library(
         ":market_data_config",
         ":trade_publisher",
         ":trade_publisher_impl",
-        "//src/main/java/com/verlumen/tradestream/execution:RunMode",
+        "//src/main/java/com/verlumen/tradestream/execution:run_mode",
         "//third_party:auto_value",
         "//third_party:guice",
         "//third_party:guice_assistedinject",

--- a/src/main/java/com/verlumen/tradestream/marketdata/MarketDataModule.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/MarketDataModule.java
@@ -9,10 +9,11 @@ import com.verlumen.tradestream.execution.RunMode;
 @AutoValue
 public abstract class MarketDataModule extends AbstractModule {
   public static MarketDataModule create(String exchangeName, String tradeTopic, RunMode runMode) {
-    return new AutoValue_MarketDataModule(MarketDataConfig.create(exchangeName, tradeTopic, runMode));
+    return new AutoValue_MarketDataModule(MarketDataConfig.create(exchangeName, tradeTopic), runMode);
   }
 
   abstract MarketDataConfig config();
+  abstract RunMode runMode();
 
   @Override
   protected void configure() {

--- a/src/main/java/com/verlumen/tradestream/marketdata/MarketDataModule.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/MarketDataModule.java
@@ -4,11 +4,12 @@ import com.google.auto.value.AutoValue;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
+import com.verlumen.tradestream.execution.RunMode;
 
 @AutoValue
 public abstract class MarketDataModule extends AbstractModule {
-  public static MarketDataModule create(String exchangeName, String tradeTopic) {
-    return new AutoValue_MarketDataModule(MarketDataConfig.create(exchangeName, tradeTopic));
+  public static MarketDataModule create(String exchangeName, String tradeTopic, RunMode runMode) {
+    return new AutoValue_MarketDataModule(MarketDataConfig.create(exchangeName, tradeTopic, runMode));
   }
 
   abstract MarketDataConfig config();


### PR DESCRIPTION
#### Summary
- **MarketDataModule**:  
  - Updated the `create()` method to include a new `RunMode` parameter.
  - Added `runMode()` as an abstract method to support the new parameter.
- **IngestionModule**:  
  - Refactored the `MarketDataModule.create()` call by extracting it into a separate method `marketDataModule()`.
  - Passed `RunMode` from `ingestionConfig()` to the newly modified `MarketDataModule.create()` method.
- **BUILD File**:  
  - Updated the `BUILD` file to include a new dependency on `//src/main/java/com/verlumen/tradestream/execution:run_mode`.

#### Reason for Change
This change introduces support for `RunMode` to control different execution modes in `MarketDataModule`, enhancing configuration flexibility during ingestion.

#### Impact
- No breaking changes; the refactored module injection and additional `RunMode` parameter ensure compatibility with existing functionality.
- Enables more dynamic configuration and execution control.

#### Notes
- Ensure that downstream modules consuming `MarketDataModule` are updated if they rely on its instantiation.
- Tests covering `RunMode` variations should be validated to confirm expected behavior.