### PR TITLE
Remove Unused Pipeline Dependency from KafkaTradeSource Constructor

### DIFF
--- a/src/main/java/com/verlumen/tradestream/marketdata/KafkaTradeSource.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/KafkaTradeSource.java
@@ -2,7 +2,6 @@ package com.verlumen.tradestream.marketdata;
 
 import com.google.inject.Inject;
 import com.verlumen.tradestream.kafka.KafkaReadTransform;
-import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
@@ -10,14 +9,11 @@ import org.apache.beam.sdk.values.PCollection;
 final class KafkaTradeSource extends TradeSource {
   private final KafkaReadTransform<String, byte[]> kafkaReadTransform;
   private final ParseTrades parseTrades;
-  private final Pipeline pipeline;
 
   @Inject
   KafkaTradeSource(
-      Pipeline pipeline,
       KafkaReadTransform<String, byte[]> kafkaReadTransform,
       ParseTrades parseTrades) {
-    this.pipeline = pipeline;
     this.kafkaReadTransform = kafkaReadTransform;
     this.parseTrades = parseTrades;
   }


### PR DESCRIPTION
### PR Title
- Removed the unused `Pipeline` parameter from the `KafkaTradeSource` constructor.
- Updated the constructor signature to exclude `Pipeline` and modified the class to reflect this change.
- Cleaned up the unnecessary import of `Pipeline`.

#### Context
This change simplifies the `KafkaTradeSource` constructor by removing a redundant dependency that was not being utilized. This enhances code maintainability and reduces unnecessary coupling.

No functional impact is expected as the `Pipeline` was not being used.