### PR TITLE
(MINOR) Remove `MarketDataConfig` and refactor `MarketDataModule` to directly use configuration parameters

### DIFF
--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -198,11 +198,6 @@ java_library(
 )
 
 java_library(
-    name = "market_data_config",
-    srcs = ["MarketDataConfig.java"],
-)
-
-java_library(
     name = "market_data_module",
     srcs = ["MarketDataModule.java"],
     deps = [
@@ -212,7 +207,6 @@ java_library(
         ":exchange_client_unbounded_source_impl",
         ":exchange_streaming_client",
         ":exchange_streaming_client_factory",
-        ":market_data_config",
         ":trade_publisher",
         ":trade_publisher_impl",
         "//third_party:auto_value",

--- a/src/main/java/com/verlumen/tradestream/marketdata/MarketDataConfig.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/MarketDataConfig.java
@@ -1,7 +1,0 @@
-package com.verlumen.tradestream.marketdata;
-
-public record MarketDataConfig(String exchangeName, String tradeTopic) {
-  public static MarketDataConfig create(String exchangeName, String tradeTopic) {
-    return new MarketDataConfig(exchangeName, tradeTopic);
-  }
-}

--- a/src/main/java/com/verlumen/tradestream/marketdata/MarketDataModule.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/MarketDataModule.java
@@ -8,10 +8,11 @@ import com.google.inject.assistedinject.FactoryModuleBuilder;
 @AutoValue
 public abstract class MarketDataModule extends AbstractModule {
   public static MarketDataModule create(String exchangeName, String tradeTopic) {
-    return new AutoValue_MarketDataModule(MarketDataConfig.create(exchangeName, tradeTopic));
+    return new AutoValue_MarketDataModule(exchangeName, tradeTopic);
   }
 
-  abstract MarketDataConfig config();
+  abstract String exchangeName();
+  abstract String tradeTopic();
 
   @Override
   protected void configure() {
@@ -30,11 +31,11 @@ public abstract class MarketDataModule extends AbstractModule {
   @Provides
   ExchangeStreamingClient provideExchangeStreamingClient(
       ExchangeStreamingClient.Factory exchangeStreamingClientFactory) {
-    return exchangeStreamingClientFactory.create(config().exchangeName());
+    return exchangeStreamingClientFactory.create(exchangeName());
   }
 
   @Provides
   TradePublisher provideTradePublisher(TradePublisher.Factory tradePublisherFactory) {
-    return tradePublisherFactory.create(config().tradeTopic());
+    return tradePublisherFactory.create(tradeTopic());
   }
 }


### PR DESCRIPTION
#### Summary
- Removed `MarketDataConfig.java` and its associated `market_data_config` target from the build.
- Refactored `MarketDataModule` to eliminate the use of `MarketDataConfig` and replaced it with direct usage of `exchangeName` and `tradeTopic` parameters.
- Updated provider methods in `MarketDataModule` to use `exchangeName` and `tradeTopic` directly.

#### Context
- `MarketDataConfig` was an unnecessary abstraction, as the configuration values can be passed directly to `MarketDataModule`. This change simplifies the module's structure and improves maintainability.
- The `BUILD` file was updated to remove the `market_data_config` target and its dependencies.

#### Impact
- This change is backward-compatible and does not affect external APIs.
- The module now directly references the configuration parameters, which improves readability and reduces unnecessary indirection.

✅ Refactor improves clarity  
✅ No breaking changes  
✅ Simplifies configuration management