### PR TITLE
Add Protobuf Support and Introduce Dry Run Trade in MarketDataModule

### DIFF
--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -209,9 +209,11 @@ java_library(
         ":exchange_streaming_client_factory",
         ":trade_publisher",
         ":trade_publisher_impl",
+        "//protos:marketdata_java_proto",
         "//third_party:auto_value",
         "//third_party:guice",
         "//third_party:guice_assistedinject",
+        "//third_party:protobuf_java_util",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/marketdata/MarketDataModule.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/MarketDataModule.java
@@ -11,6 +11,15 @@ public abstract class MarketDataModule extends AbstractModule {
     return new AutoValue_MarketDataModule(MarketDataConfig.create(exchangeName, tradeTopic));
   }
 
+  private static final Trade DRY_RUN_TRADE = Trade.newBuilder()
+      .setExchange("FakeExhange")
+      .setCurrencyPair("DRY/RUN")
+      .setTradeId("trade-123")
+      .setTimestamp(fromMillis(1234567))
+      .setPrice(50000.0)
+      .setVolume(0.1)
+      .build();
+
   abstract MarketDataConfig config();
 
   @Override

--- a/src/main/java/com/verlumen/tradestream/marketdata/MarketDataModule.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/MarketDataModule.java
@@ -1,5 +1,7 @@
 package com.verlumen.tradestream.marketdata;
 
+import static com.google.protobuf.util.Timestamps.fromMillis;
+
 import com.google.auto.value.AutoValue;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;


### PR DESCRIPTION
#### Summary
- **Protobuf Integration:**
  - Updated `BUILD` file to include new dependencies:
    - `//protos:marketdata_java_proto`
    - `//third_party:protobuf_java_util`
- **MarketDataModule Enhancements:**
  - Imported `Timestamps.fromMillis` from `com.google.protobuf.util`.
  - Added a `DRY_RUN_TRADE` constant to simulate a dry run trade for testing and validation purposes.
  - `DRY_RUN_TRADE` includes mock trade data with a preset timestamp, price, and volume.
  
#### Context
- These changes introduce Protobuf support to enable serialization and deserialization of market data.
- The addition of `DRY_RUN_TRADE` provides a default trade for testing and validation, helping ensure the correctness of downstream processing.

#### Impact
- Minimal risk; backward compatible with existing functionality.
- New Protobuf dependencies are required for compilation.

#### Notes
- No breaking changes.
- Ready for review and integration.