### PR TITLE
Refactor Timing Configuration by Extracting `TimingConfig` from `PipelineConfig` (MINOR)

### DIFF
--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -78,10 +78,10 @@ public final class App {
       KafkaReadTransform<String, byte[]> kafkaReadTransform,
       ParseTrades parseTrades,
       StrategyEnginePipeline strategyEnginePipeline,
-      PipelineConfig config) {
-    this.allowedLateness = config.allowedLateness();
-    this.allowedTimestampSkew = config.allowedTimestampSkew();
-    this.windowDuration = config.windowDuration();
+      TimingConfig timingConfig) {
+    this.allowedLateness = timingConfig.allowedLateness();
+    this.allowedTimestampSkew = timingConfig.allowedTimestampSkew();
+    this.windowDuration = timingConfig.windowDuration();
     this.kafkaReadTransform = kafkaReadTransform;
     this.parseTrades = parseTrades;
     this.strategyEnginePipeline = strategyEnginePipeline;

--- a/src/main/java/com/verlumen/tradestream/pipeline/BUILD
+++ b/src/main/java/com/verlumen/tradestream/pipeline/BUILD
@@ -91,7 +91,6 @@ java_library(
     srcs = ["PipelineConfig.java"],
     deps = [
         "//src/main/java/com/verlumen/tradestream/execution:run_mode",
-        "//third_party:joda_time",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/pipeline/BUILD
+++ b/src/main/java/com/verlumen/tradestream/pipeline/BUILD
@@ -16,6 +16,7 @@ java_binary(
     deps = [
         ":pipeline_config",
         ":pipeline_module",
+        ":timing_config",
         "//protos:marketdata_java_proto",
         "//src/main/java/com/verlumen/tradestream/kafka:kafka_read_transform",
         "//src/main/java/com/verlumen/tradestream/marketdata:candle_stream_with_defaults",

--- a/src/main/java/com/verlumen/tradestream/pipeline/BUILD
+++ b/src/main/java/com/verlumen/tradestream/pipeline/BUILD
@@ -99,6 +99,7 @@ java_library(
     srcs = ["PipelineModule.java"],
     deps = [
         ":pipeline_config",
+        ":timing_config",
         "//protos:marketdata_java_proto",
         "//src/main/java/com/verlumen/tradestream/backtesting:backtesting_module",
         "//src/main/java/com/verlumen/tradestream/execution:run_mode",

--- a/src/main/java/com/verlumen/tradestream/pipeline/BUILD
+++ b/src/main/java/com/verlumen/tradestream/pipeline/BUILD
@@ -112,7 +112,6 @@ java_library(
         "//src/main/java/com/verlumen/tradestream/ta4j:ta4j_module",
         "//third_party:auto_value",
         "//third_party:guice",
-        "//third_party:joda_time",
         "//third_party:kafka_clients",
         "//third_party:protobuf_java_util",
     ],

--- a/src/main/java/com/verlumen/tradestream/pipeline/BUILD
+++ b/src/main/java/com/verlumen/tradestream/pipeline/BUILD
@@ -122,3 +122,11 @@ oci_push(
     remote_tags = ["latest"],
     repository = "tradestreamhq/tradestream-data-pipeline",
 )
+
+java_library(
+    name = "timing_config",
+    srcs = ["TimingConfig.java"],
+    deps = [
+        "//third_party:joda_time",
+    ],
+)

--- a/src/main/java/com/verlumen/tradestream/pipeline/BUILD
+++ b/src/main/java/com/verlumen/tradestream/pipeline/BUILD
@@ -113,6 +113,7 @@ java_library(
         "//third_party:auto_value",
         "//third_party:guice",
         "//third_party:joda_time",
+        "//third_party:kafka_clients",
         "//third_party:protobuf_java_util",
     ],
 )

--- a/src/main/java/com/verlumen/tradestream/pipeline/BUILD
+++ b/src/main/java/com/verlumen/tradestream/pipeline/BUILD
@@ -111,7 +111,7 @@ java_library(
         "//src/main/java/com/verlumen/tradestream/ta4j:ta4j_module",
         "//third_party:auto_value",
         "//third_party:guice",
-        "//third_party:kafka_clients",
+        "//third_party:joda_time",
         "//third_party:protobuf_java_util",
     ],
 )

--- a/src/main/java/com/verlumen/tradestream/pipeline/PipelineConfig.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/PipelineConfig.java
@@ -1,17 +1,12 @@
 package com.verlumen.tradestream.pipeline;
 
 import com.verlumen.tradestream.execution.RunMode;
-import org.joda.time.Duration;
 
 record PipelineConfig(
     String bootstrapServers,
     String tradeTopic,
     String signalTopic,
     RunMode runMode) {
-  private static final Duration FIVE_SECONDS = Duration.standardSeconds(5);
-  private static final Duration ONE_MINUTE = Duration.standardMinutes(1);
-  private static final Duration THIRTY_MINUTES = Duration.standardMinutes(30);
-
   static PipelineConfig create(
       String bootstrapServers,
       String tradeTopic,

--- a/src/main/java/com/verlumen/tradestream/pipeline/PipelineConfig.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/PipelineConfig.java
@@ -7,10 +7,7 @@ record PipelineConfig(
     String bootstrapServers,
     String tradeTopic,
     String signalTopic,
-    RunMode runMode,
-    Duration allowedLateness,
-    Duration windowDuration,
-    Duration allowedTimestampSkew) {
+    RunMode runMode) {
   private static final Duration FIVE_SECONDS = Duration.standardSeconds(5);
   private static final Duration ONE_MINUTE = Duration.standardMinutes(1);
   private static final Duration THIRTY_MINUTES = Duration.standardMinutes(30);
@@ -24,9 +21,6 @@ record PipelineConfig(
         bootstrapServers,
         tradeTopic,
         signalTopic,
-        RunMode.fromString(runMode),
-        FIVE_SECONDS,
-        ONE_MINUTE,
-        THIRTY_MINUTES);
+        RunMode.fromString(runMode));
   }
 }

--- a/src/main/java/com/verlumen/tradestream/pipeline/PipelineModule.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/PipelineModule.java
@@ -14,6 +14,9 @@ import com.verlumen.tradestream.marketdata.Trade;
 import com.verlumen.tradestream.signals.SignalsModule;
 import com.verlumen.tradestream.strategies.StrategiesModule;
 import com.verlumen.tradestream.ta4j.Ta4jModule;
+import java.nio.charset.StandardCharsets;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
 import org.joda.time.Duration;
 
 @AutoValue

--- a/src/main/java/com/verlumen/tradestream/pipeline/PipelineModule.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/PipelineModule.java
@@ -14,9 +14,7 @@ import com.verlumen.tradestream.marketdata.Trade;
 import com.verlumen.tradestream.signals.SignalsModule;
 import com.verlumen.tradestream.strategies.StrategiesModule;
 import com.verlumen.tradestream.ta4j.Ta4jModule;
-import java.nio.charset.StandardCharsets;
-import org.apache.kafka.common.serialization.ByteArrayDeserializer;
-import org.apache.kafka.common.serialization.StringDeserializer;
+import org.joda.time.Duration;
 
 @AutoValue
 abstract class PipelineModule extends AbstractModule {
@@ -34,7 +32,8 @@ abstract class PipelineModule extends AbstractModule {
     Duration allowedLateness,
     Duration allowedTimestampSkew,
     Duration windowDuration) {
-    return new AutoValue_PipelineModule(config);
+    return new AutoValue_PipelineModule(
+      config, allowedLateness, allowedTimestampSkew, windowDuration);
   }
 
   abstract PipelineConfig config();

--- a/src/main/java/com/verlumen/tradestream/pipeline/PipelineModule.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/PipelineModule.java
@@ -73,4 +73,9 @@ abstract class PipelineModule extends AbstractModule {
   PipelineConfig providePipelineConfig() {
     return config();
   }
+
+  @Provides
+  TimingConfig provideTimingConfig() {
+    return TimingConfig.create();
+  }
 }

--- a/src/main/java/com/verlumen/tradestream/pipeline/PipelineModule.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/PipelineModule.java
@@ -30,19 +30,11 @@ abstract class PipelineModule extends AbstractModule {
       .setVolume(0.1)
       .build();
 
-  static PipelineModule create(
-    PipelineConfig config,
-    Duration allowedLateness,
-    Duration allowedTimestampSkew,
-    Duration windowDuration) {
-    return new AutoValue_PipelineModule(
-      config, allowedLateness, allowedTimestampSkew, windowDuration);
+  static PipelineModule create(PipelineConfig config) {
+    return new AutoValue_PipelineModule(config);
   }
 
   abstract PipelineConfig config();
-  abstract Duration allowedLateness();
-  abstract Duration allowedTimestampSkew();
-  abstract Duration windowDuration();
 
   @Override
   protected void configure() {

--- a/src/main/java/com/verlumen/tradestream/pipeline/PipelineModule.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/PipelineModule.java
@@ -17,7 +17,6 @@ import com.verlumen.tradestream.ta4j.Ta4jModule;
 import java.nio.charset.StandardCharsets;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
-import org.joda.time.Duration;
 
 @AutoValue
 abstract class PipelineModule extends AbstractModule {

--- a/src/main/java/com/verlumen/tradestream/pipeline/PipelineModule.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/PipelineModule.java
@@ -29,11 +29,18 @@ abstract class PipelineModule extends AbstractModule {
       .setVolume(0.1)
       .build();
 
-  static PipelineModule create(PipelineConfig config) {
+  static PipelineModule create(
+    PipelineConfig config,
+    Duration allowedLateness,
+    Duration allowedTimestampSkew,
+    Duration windowDuration) {
     return new AutoValue_PipelineModule(config);
   }
 
   abstract PipelineConfig config();
+  abstract Duration allowedLateness();
+  abstract Duration allowedTimestampSkew();
+  abstract Duration windowDuration();
 
   @Override
   protected void configure() {

--- a/src/main/java/com/verlumen/tradestream/pipeline/TimingConfig.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/TimingConfig.java
@@ -1,0 +1,20 @@
+package com.verlumen.tradestream.pipeline;
+
+import com.verlumen.tradestream.execution.RunMode;
+import org.joda.time.Duration;
+
+record TimingConfig(
+    Duration allowedLateness,
+    Duration windowDuration,
+    Duration allowedTimestampSkew) {
+  private static final Duration FIVE_SECONDS = Duration.standardSeconds(5);
+  private static final Duration ONE_MINUTE = Duration.standardMinutes(1);
+  private static final Duration THIRTY_MINUTES = Duration.standardMinutes(30);
+
+  static PipelineConfig create() {
+    return new TimingConfig(
+        FIVE_SECONDS,
+        ONE_MINUTE,
+        THIRTY_MINUTES);
+  }
+}

--- a/src/main/java/com/verlumen/tradestream/pipeline/TimingConfig.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/TimingConfig.java
@@ -1,6 +1,5 @@
 package com.verlumen.tradestream.pipeline;
 
-import com.verlumen.tradestream.execution.RunMode;
 import org.joda.time.Duration;
 
 record TimingConfig(

--- a/src/main/java/com/verlumen/tradestream/pipeline/TimingConfig.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/TimingConfig.java
@@ -10,7 +10,7 @@ record TimingConfig(
   private static final Duration ONE_MINUTE = Duration.standardMinutes(1);
   private static final Duration THIRTY_MINUTES = Duration.standardMinutes(30);
 
-  static PipelineConfig create() {
+  static TimingConfig create() {
     return new TimingConfig(
         FIVE_SECONDS,
         ONE_MINUTE,


### PR DESCRIPTION
#### Summary
- **Refactored Timing Logic:** Moved timing-related fields (`allowedLateness`, `windowDuration`, and `allowedTimestampSkew`) from `PipelineConfig` to a new `TimingConfig` class.
- **Updated Constructor:** Updated `App` to accept `TimingConfig` instead of `PipelineConfig` for timing parameters.
- **Created New `TimingConfig` Class:**
  - Introduced `TimingConfig` with default values (`FIVE_SECONDS`, `ONE_MINUTE`, `THIRTY_MINUTES`).
  - Added `create()` method to instantiate `TimingConfig` with these defaults.
- **Updated Dependency Configurations:**
  - Added `timing_config` as a new `java_library` in `BUILD` file.
  - Updated `PipelineModule` to provide `TimingConfig` via Dagger.
  - Removed `joda_time` dependency from `pipeline_config` since it's now included in `timing_config`.

#### Code Changes
- **App.java:** Updated constructor to use `TimingConfig` instead of `PipelineConfig` for timing-related fields.
- **PipelineConfig.java:** Removed timing-related fields and factory logic.
- **PipelineModule.java:** Added provider method for `TimingConfig`.
- **BUILD File:**
  - Added new `timing_config` library.
  - Updated dependencies for `pipeline_module` and `pipeline_config`.
  - Removed `joda_time` from `pipeline_config`.

#### Impact
- This change improves modularity by decoupling timing logic from `PipelineConfig`, making it easier to manage and extend.
- No impact on existing functionality. Configuration values remain the same.

#### Versioning
- **(MINOR)**: Introduces new functionality by adding a separate configuration class without breaking changes.