### PR TITLE
(MINOR) Add CoinMarketCap API support and exchange name configuration 

### DIFF
--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -44,26 +44,32 @@ public final class App {
     @Description("Comma-separated list of Kafka bootstrap servers.")
     @Default.String("localhost:9092")
     String getBootstrapServers();
-
     void setBootstrapServers(String value);
 
-    @Description("Kafka topic to read trade data from.")
-    @Default.String("trades")
-    String getTradeTopic();
-
-    void setTradeTopic(String value);
+    @Description("Name of the exchange.")
+    @Default.String("coinbase")
+    String getExchangeName();
+    void setExchangeName(String value);
 
     @Description("Kafka topic to publish signal data to.")
     @Default.String("signals")
     String getSignalTopic();
-
     void setSignalTopic(String value);
 
     @Description("Run mode: wet or dry.")
     @Default.String("wet")
     String getRunMode();
-
     void setRunMode(String value);
+
+    @Description("CoinMarketCap API Key (default: value of " + CMC_API_KEY_ENV_VAR + " environment variable)")
+    @Default.String("")
+    String getCoinMarketCapApiKey();
+    void setCoinMarketCapApiKey(String value);
+
+    @Description("Number of top cryptocurrencies to track (default: 10)")
+    @Default.Integer(10)
+    int getCoinMarketCapTopCurrencyCount();
+    void setCoinMarketCapTopCurrencyCount(int value);
   }
 
   private final Duration allowedLateness;

--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -61,6 +61,11 @@ public final class App {
     String getRunMode();
     void setRunMode(String value);
 
+    @Description("Kafka topic to read trade data from.")
+    @Default.String("trades")
+    String getTradeTopic();
+    void setTradeTopic(String value);
+
     @Description("CoinMarketCap API Key (default: value of " + CMC_API_KEY_ENV_VAR + " environment variable)")
     @Default.String("")
     String getCoinMarketCapApiKey();

--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -40,6 +40,8 @@ import org.joda.time.Instant;
 public final class App {
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
+  private static final String CMC_API_KEY_ENV_VAR = "COINMARKETCAP_API_KEY";
+
   public interface Options extends StreamingOptions {
     @Description("Comma-separated list of Kafka bootstrap servers.")
     @Default.String("localhost:9092")


### PR DESCRIPTION
This PR introduces new configuration options and enhancements to the `App` class in the `tradestream` pipeline:  

### Key Changes:
- Added support for CoinMarketCap API by introducing two new options:  
  - `getCoinMarketCapApiKey()`: Retrieves the API key, defaulting to the value from the `COINMARKETCAP_API_KEY` environment variable if not provided.
  - `getCoinMarketCapTopCurrencyCount()`: Specifies the number of top cryptocurrencies to track, with a default value of 10.
- Introduced a new configuration option:  
  - `getExchangeName()`: Defines the exchange name, defaulting to `coinbase`.
- Reordered and grouped `Options` methods for improved readability.

These changes enhance the pipeline by enabling external data integration and providing more flexibility for configuring the trade and signal processing behavior.

No breaking changes have been introduced, and default values ensure backward compatibility.