### PR TITLE
Refactor: Consolidate Timing Configuration into `TimingConfig` Class

### DIFF
--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -79,12 +79,10 @@ public final class App {
     void setCoinMarketCapTopCurrencyCount(int value);
   }
 
-  private final Duration allowedLateness;
-  private final Duration allowedTimestampSkew;
-  private final Duration windowDuration;
   private final KafkaReadTransform<String, byte[]> kafkaReadTransform;
   private final ParseTrades parseTrades;
   private final StrategyEnginePipeline strategyEnginePipeline;
+  private final TimingConfig timingConfig;
 
   @Inject
   App(
@@ -92,15 +90,10 @@ public final class App {
       ParseTrades parseTrades,
       StrategyEnginePipeline strategyEnginePipeline,
       TimingConfig timingConfig) {
-    this.allowedLateness = timingConfig.allowedLateness();
-    this.allowedTimestampSkew = timingConfig.allowedTimestampSkew();
-    this.windowDuration = timingConfig.windowDuration();
     this.kafkaReadTransform = kafkaReadTransform;
     this.parseTrades = parseTrades;
     this.strategyEnginePipeline = strategyEnginePipeline;
-    logger.atInfo().log(
-        "Initialized App with allowedLateness=%s, windowDuration=%s, allowedTimestampSkew=%s",
-        allowedLateness, windowDuration, allowedTimestampSkew);
+    this.timingConfig = timingConfig;
   }
 
   /** Build the Beam pipeline, integrating all components. */
@@ -124,7 +117,7 @@ public final class App {
                       logger.atFinest().log("Assigned timestamp %s for trade: %s", timestamp, trade);
                       return timestamp;
                     })
-                .withAllowedTimestampSkew(allowedTimestampSkew));
+                .withAllowedTimestampSkew(timingConfig.allowedTimestampSkew()));
 
     // 4. Convert trades into KV pairs keyed by currency pair.
     PCollection<KV<String, Trade>> tradePairs =
@@ -143,7 +136,7 @@ public final class App {
         tradePairs.apply(
             "ApplyWindows",
             Window.<KV<String, Trade>>into(FixedWindows.of(windowDuration))
-                .withAllowedLateness(allowedLateness)
+                .withAllowedLateness(timingConfig.allowedLateness())
                 .triggering(DefaultTrigger.of())
                 .discardingFiredPanes());
 
@@ -155,7 +148,7 @@ public final class App {
         windowedTradePairs.apply(
             "CreateBaseCandles",
             new CandleStreamWithDefaults(
-                windowDuration, // Use the same 1-minute window for candle aggregation.
+                timingConfig.windowDuration(), // Use the same 1-minute window for candle aggregation.
                 Duration.standardSeconds(30), // Slide duration for the candle aggregator.
                 5, // Buffer size for base candle consolidation.
                 Arrays.asList("BTC/USD", "ETH/USD"),

--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -135,7 +135,7 @@ public final class App {
     PCollection<KV<String, Trade>> windowedTradePairs =
         tradePairs.apply(
             "ApplyWindows",
-            Window.<KV<String, Trade>>into(FixedWindows.of(windowDuration))
+            Window.<KV<String, Trade>>into(FixedWindows.of(timingConfig.windowDuration()))
                 .withAllowedLateness(timingConfig.allowedLateness())
                 .triggering(DefaultTrigger.of())
                 .discardingFiredPanes());


### PR DESCRIPTION
#### Summary
This PR refactors the `App` class to consolidate the timing-related configuration (`allowedLateness`, `allowedTimestampSkew`, and `windowDuration`) into a single `TimingConfig` class. 

#### Key Changes
- Removed individual `Duration` fields (`allowedLateness`, `allowedTimestampSkew`, and `windowDuration`) from `App.java`.
- Introduced a new `timingConfig` field, injected via the constructor.
- Updated references to timing configurations in the `buildPipeline` method to use `timingConfig` directly.
- Simplified logging and configuration by encapsulating all timing-related logic in `TimingConfig`.

#### Context
This refactor improves maintainability and reduces redundancy by centralizing timing configuration in `TimingConfig`. This change will make it easier to modify timing settings in the future.

No functionality changes were introduced, ensuring that pipeline behavior remains consistent.