### PR TITLE
Add fallback mechanism for CMC API key from environment variables

### DIFF
--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -39,7 +39,6 @@ import org.joda.time.Instant;
 
 public final class App {
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
-
   private static final String CMC_API_KEY_ENV_VAR = "COINMARKETCAP_API_KEY";
 
   public interface Options extends StreamingOptions {
@@ -190,6 +189,14 @@ public final class App {
     }
   }
 
+  private static String getCmcApiKey(Options options) {
+      if (isNullOrEmpty(options.getCoinMarketCapApiKey())) {
+           return System.getenv().getOrDefault(CMC_API_KEY_ENV_VAR, "INVALID_API_KEY");
+      } 
+
+      return options.getCoinMarketCapApiKey();
+  }
+
   public static void main(String[] args) throws Exception {
     logger.atInfo().log("Application starting with arguments: %s", (Object) args);
 
@@ -213,7 +220,7 @@ public final class App {
     RunMode runMode = RunMode.fromString(options.getRunMode());
     var module = PipelineModule.create(
       options.getBootstrapServers(),
-      options.getCoinMarketCapApiKey(),
+      getCmcApiKey(options),
       options.getExchangeName(),
       runMode,
       options.getSignalTopic(),

--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -1,6 +1,7 @@
 package com.verlumen.tradestream.pipeline;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.Iterables.getLast;
 
 import com.google.common.collect.ImmutableList;
@@ -39,6 +40,7 @@ import org.joda.time.Instant;
 
 public final class App {
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
+
   private static final String CMC_API_KEY_ENV_VAR = "COINMARKETCAP_API_KEY";
 
   public interface Options extends StreamingOptions {


### PR DESCRIPTION
- Introduced a new method `getCmcApiKey(Options options)` to retrieve the CoinMarketCap (CMC) API key.
- The method checks if the API key is provided in the `options` object. If the value is null or empty, it falls back to the `CMC_API_KEY_ENV_VAR` environment variable.
- Updated the `PipelineModule.create()` method in `main()` to use the new `getCmcApiKey` method.
- Added `isNullOrEmpty` import from `com.google.common.base.Strings` to validate API key presence.

### Context
- This change ensures that the application gracefully falls back to an environment variable when the API key is not explicitly provided via options.
- Improves robustness by preventing invalid API key scenarios and provides a default value of `"INVALID_API_KEY"` if neither source is available.
