### PR TITLE
Refactor trade source initialization with switch statement for run modes

### DIFF
--- a/src/main/java/com/verlumen/tradestream/marketdata/MarketDataModule.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/MarketDataModule.java
@@ -52,10 +52,10 @@ public abstract class MarketDataModule extends AbstractModule {
   @Provides
   @Singleton
   TradeSource provideTradeSource(Provider<ExchangeClientTradeSource> exchangeClientTradeSource) {
-    if (runMode().equals(RunMode.DRY)) {
-      return DryRunTradeSource.create(ImmutableList.of(DRY_RUN_TRADE));
+    switch (runMode()) {
+      case DRY: return DryRunTradeSource.create(ImmutableList.of(DRY_RUN_TRADE));
+      case WET: return exchangeClientTradeSource.get();
+      default: throw new UnsupportedOperationException();
     }
-
-    return exchangeClientTradeSource.get();
   }
 }


### PR DESCRIPTION
]#### Summary
- Refactored `provideTradeSource` method in `MarketDataModule.java` to use a `switch` statement for handling `RunMode` values.
- Replaced the previous `if` condition that checked for `RunMode.DRY` with a `switch` block that:
  - Returns `DryRunTradeSource` for `DRY` mode.
  - Returns `exchangeClientTradeSource` for `WET` mode.
  - Throws an `UnsupportedOperationException` for any unsupported mode.
  
#### Context
- This change improves code readability and maintainability by making the run mode handling more explicit and robust.
- No changes to functionality, only structural improvements.