### PR TITLE
Add Serializable to CurrencyPairSupply interface (MINOR)

### DIFF
--- a/src/main/java/com/verlumen/tradestream/instruments/CurrencyPairSupply.java
+++ b/src/main/java/com/verlumen/tradestream/instruments/CurrencyPairSupply.java
@@ -1,9 +1,10 @@
 package com.verlumen.tradestream.instruments;
 
 import com.google.common.collect.ImmutableList;
+import java.io.Serializable;
 import java.util.function.Supplier;
 
-public interface CurrencyPairSupply extends Supplier<ImmutableList<CurrencyPair>> {
+public interface CurrencyPairSupply extends Serializable, Supplier<ImmutableList<CurrencyPair>> {
   default ImmutableList<CurrencyPair> currencyPairs() {
     return get();
   }


### PR DESCRIPTION
#### Summary
- Updated `CurrencyPairSupply` interface to extend `Serializable` in addition to `Supplier<ImmutableList<CurrencyPair>>`.
- Ensures that implementations of `CurrencyPairSupply` can be serialized, improving compatibility with distributed systems and caching mechanisms.

#### Context
- This change is beneficial when instances of `CurrencyPairSupply` need to be transmitted or stored in a serialized form.
- No breaking changes expected, as this addition only enhances the interface's functionality.