### PR TITLE
(MINOR) Add caching mechanism for currency pair supplier with 1-day expiration

### DIFF
--- a/src/main/java/com/verlumen/tradestream/instruments/BUILD
+++ b/src/main/java/com/verlumen/tradestream/instruments/BUILD
@@ -74,6 +74,7 @@ java_library(
     srcs = ["InstrumentsModule.java"],
     deps = [
         ":coin_market_cap_config",
+        ":currency_pair",
         ":currency_pair_supply",
         ":currency_pair_supply_provider",
         "//third_party:auto_value",

--- a/src/main/java/com/verlumen/tradestream/instruments/InstrumentsModule.java
+++ b/src/main/java/com/verlumen/tradestream/instruments/InstrumentsModule.java
@@ -8,6 +8,7 @@ import com.google.inject.Singleton;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
@@ -17,7 +18,7 @@ public abstract class InstrumentsModule extends AbstractModule {
     return new AutoValue_InstrumentsModule(coinMarketCapApiKey, topCryptocurrencyCount);
   }
 
-  private static final long ONE = 1L;
+  private static final Duration INSTRUMENT_REFRESH_INTERVAL = Duration.ofDays(1);
 
   abstract String coinMarketCapApiKey();
   abstract int topCryptocurrencyCount();
@@ -32,6 +33,7 @@ public abstract class InstrumentsModule extends AbstractModule {
   @Singleton
   Supplier<ImmutableList<CurrencyPair>> provideCurrencyPairSupplier(
     CurrencyPairSupplyProvider provider) {
-    return Suppliers.memoizeWithExpiration(provider.get(), ONE, TimeUnit.DAYS);
+    return Suppliers.memoizeWithExpiration(
+      provider.get(), INSTRUMENT_REFRESH_INTERVAL.toMillis(), TimeUnit.MILLISECONDS);
   }
 }

--- a/src/main/java/com/verlumen/tradestream/instruments/InstrumentsModule.java
+++ b/src/main/java/com/verlumen/tradestream/instruments/InstrumentsModule.java
@@ -4,6 +4,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.base.Suppliers;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
+import com.google.inject.Singleton;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
@@ -28,6 +29,7 @@ public abstract class InstrumentsModule extends AbstractModule {
   }
 
   @Provides
+  @Singleton
   Supplier<ImmutableList<CurrencyPair>> provideCurrencyPairSupplier(
     CurrencyPairSupplyProvider provider) {
     return Suppliers.memoizeWithExpiration(provider.get(), ONE, TimeUnit.DAYS);

--- a/src/main/java/com/verlumen/tradestream/instruments/InstrumentsModule.java
+++ b/src/main/java/com/verlumen/tradestream/instruments/InstrumentsModule.java
@@ -4,12 +4,14 @@ import com.google.auto.value.AutoValue;
 import com.google.common.base.Suppliers;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
+import java.util.concurrent.TimeUnit;
 
 @AutoValue
 public abstract class InstrumentsModule extends AbstractModule {
   public static InstrumentsModule create(String coinMarketCapApiKey, int topCryptocurrencyCount) {
     return new AutoValue_InstrumentsModule(coinMarketCapApiKey, topCryptocurrencyCount);
   }
+
   private static final long ONE = 1L;
 
   abstract String coinMarketCapApiKey();
@@ -28,6 +30,6 @@ public abstract class InstrumentsModule extends AbstractModule {
 
   @Provides
   Supplier<CurrencyPair> provideCurrencyPairSupply(CurrencyPairSupplyProvider provider) {
-    return Suppliers.memoizeWithExpiration(provider.get(), ONE, TimeUnit.Minutes);
+    return Suppliers.memoizeWithExpiration(provider.get(), ONE, TimeUnit.DAYS);
   }
 }

--- a/src/main/java/com/verlumen/tradestream/instruments/InstrumentsModule.java
+++ b/src/main/java/com/verlumen/tradestream/instruments/InstrumentsModule.java
@@ -33,7 +33,10 @@ public abstract class InstrumentsModule extends AbstractModule {
   @Singleton
   Supplier<ImmutableList<CurrencyPair>> provideCurrencyPairSupplier(
     CurrencyPairSupplyProvider provider) {
+    Supplier<ImmutableList<CurrencyPair>> baseSupplier = provider.get();
     return Suppliers.memoizeWithExpiration(
-      provider.get(), INSTRUMENT_REFRESH_INTERVAL.toMillis(), TimeUnit.MILLISECONDS);
+      Suppliers.ofInstance(baseSupplier.get()),
+      INSTRUMENT_REFRESH_INTERVAL.toMillis(),
+      TimeUnit.MILLISECONDS);
   }
 }

--- a/src/main/java/com/verlumen/tradestream/instruments/InstrumentsModule.java
+++ b/src/main/java/com/verlumen/tradestream/instruments/InstrumentsModule.java
@@ -1,6 +1,7 @@
 package com.verlumen.tradestream.instruments;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Suppliers;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 
@@ -9,6 +10,7 @@ public abstract class InstrumentsModule extends AbstractModule {
   public static InstrumentsModule create(String coinMarketCapApiKey, int topCryptocurrencyCount) {
     return new AutoValue_InstrumentsModule(coinMarketCapApiKey, topCryptocurrencyCount);
   }
+  private static final long ONE = 1L;
 
   abstract String coinMarketCapApiKey();
   abstract int topCryptocurrencyCount();
@@ -22,5 +24,10 @@ public abstract class InstrumentsModule extends AbstractModule {
   CoinMarketCapConfig provideCoinMarketCapConfig() {
     return CoinMarketCapConfig.create(
         topCryptocurrencyCount(), coinMarketCapApiKey());
+  }
+
+  @Provides
+  Supplier<CurrencyPair> provideCurrencyPairSupply(CurrencyPairSupplyProvider provider) {
+    return Suppliers.memoizeWithExpiration(provider.get(), ONE, TimeUnit.Minutes);
   }
 }


### PR DESCRIPTION
#### Summary
- Added a caching mechanism for the `CurrencyPair` supplier using `Suppliers.memoizeWithExpiration`, with a 1-day expiration interval.
- Introduced a constant `INSTRUMENT_REFRESH_INTERVAL` set to `Duration.ofDays(1)`.
- Updated `provideCurrencyPairSupplier` to use the memoized supplier to reduce redundant calls and improve performance.
- Marked the supplier provider with `@Singleton` to ensure a single instance is used.

#### Context
- This change optimizes performance by caching the result of `CurrencyPairSupplyProvider` for 24 hours, reducing unnecessary calls to external APIs or data sources.
- No breaking changes introduced; the behavior of the module remains consistent aside from the improved efficiency.

#### Versioning
- Marked as (MINOR) because the update introduces new functionality (caching) without modifying existing APIs.