### PR TITLE
Refactor `CurrencyPairSupply` to Use `Supplier` Interface and Simplify Dependency Injection

### DIFF
--- a/src/main/java/com/verlumen/tradestream/instruments/BUILD
+++ b/src/main/java/com/verlumen/tradestream/instruments/BUILD
@@ -78,6 +78,7 @@ java_library(
         ":currency_pair_supply",
         ":currency_pair_supply_provider",
         "//third_party:auto_value",
+        "//third_party:guava",
         "//third_party:guice",
     ],
 )

--- a/src/main/java/com/verlumen/tradestream/instruments/BUILD
+++ b/src/main/java/com/verlumen/tradestream/instruments/BUILD
@@ -74,6 +74,7 @@ java_library(
     srcs = ["InstrumentsModule.java"],
     deps = [
         ":coin_market_cap_config",
+        ":currency_pair",
         ":currency_pair_supply",
         ":currency_pair_supply_provider",
         "//third_party:auto_value",

--- a/src/main/java/com/verlumen/tradestream/instruments/CurrencyPairSupply.java
+++ b/src/main/java/com/verlumen/tradestream/instruments/CurrencyPairSupply.java
@@ -3,8 +3,4 @@ package com.verlumen.tradestream.instruments;
 import com.google.common.collect.ImmutableList;
 import java.util.function.Supplier;
 
-interface CurrencyPairSupply extends Supplier<ImmutableList<CurrencyPair>> {
-  default ImmutableList<CurrencyPair> currencyPairs() {
-    return get();
-  }
-}
+interface CurrencyPairSupply extends Supplier<ImmutableList<CurrencyPair>> {}

--- a/src/main/java/com/verlumen/tradestream/instruments/CurrencyPairSupply.java
+++ b/src/main/java/com/verlumen/tradestream/instruments/CurrencyPairSupply.java
@@ -3,7 +3,7 @@ package com.verlumen.tradestream.instruments;
 import com.google.common.collect.ImmutableList;
 import java.util.function.Supplier;
 
-public interface CurrencyPairSupply extends Supplier<ImmutableList<CurrencyPair>> {
+interface CurrencyPairSupply extends Supplier<ImmutableList<CurrencyPair>> {
   default ImmutableList<CurrencyPair> currencyPairs() {
     return get();
   }

--- a/src/main/java/com/verlumen/tradestream/instruments/InstrumentsModule.java
+++ b/src/main/java/com/verlumen/tradestream/instruments/InstrumentsModule.java
@@ -14,11 +14,6 @@ public abstract class InstrumentsModule extends AbstractModule {
   abstract String coinMarketCapApiKey();
   abstract int topCryptocurrencyCount();
 
-  @Override
-  protected void configure() {
-    bind(CurrencyPairSupply.class).toProvider(CurrencyPairSupplyProvider.class);
-  }
-
   @Provides
   CoinMarketCapConfig provideCoinMarketCapConfig() {
     return CoinMarketCapConfig.create(

--- a/src/main/java/com/verlumen/tradestream/instruments/InstrumentsModule.java
+++ b/src/main/java/com/verlumen/tradestream/instruments/InstrumentsModule.java
@@ -3,6 +3,7 @@ package com.verlumen.tradestream.instruments;
 import com.google.auto.value.AutoValue;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
+import java.util.function.Supplier;
 
 @AutoValue
 public abstract class InstrumentsModule extends AbstractModule {
@@ -22,5 +23,11 @@ public abstract class InstrumentsModule extends AbstractModule {
   CoinMarketCapConfig provideCoinMarketCapConfig() {
     return CoinMarketCapConfig.create(
         topCryptocurrencyCount(), coinMarketCapApiKey());
+  }
+
+  @Provides
+  Supplier<ImmutableList<CurrencyPair>> provideCurrencyPairSupplier(
+    CurrencyPairSupplyProvider provider) {
+    return provider.get();
   }
 }

--- a/src/main/java/com/verlumen/tradestream/instruments/InstrumentsModule.java
+++ b/src/main/java/com/verlumen/tradestream/instruments/InstrumentsModule.java
@@ -1,6 +1,7 @@
 package com.verlumen.tradestream.instruments;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import java.util.function.Supplier;

--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -79,7 +79,6 @@ kt_jvm_library(
         ":trade_checkpoint_mark",
         "//protos:marketdata_java_proto",
         "//src/main/java/com/verlumen/tradestream/instruments:currency_pair",
-        "//src/main/java/com/verlumen/tradestream/instruments:currency_pair_supply",
         "//src/main/java/com/verlumen/tradestream/marketdata:exchange_streaming_client",
         "//third_party:beam_sdks_java_core",
         "//third_party:flogger",

--- a/src/main/java/com/verlumen/tradestream/marketdata/ExchangeClientUnboundedReader.kt
+++ b/src/main/java/com/verlumen/tradestream/marketdata/ExchangeClientUnboundedReader.kt
@@ -7,20 +7,20 @@ import com.google.common.flogger.FluentLogger
 import com.google.inject.Inject
 import com.google.protobuf.util.Timestamps
 import com.verlumen.tradestream.instruments.CurrencyPair
-import com.verlumen.tradestream.instruments.CurrencyPairSupply
 import org.apache.beam.sdk.io.UnboundedSource
 import org.joda.time.Duration
 import org.joda.time.Instant
 import java.io.IOException
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.LinkedBlockingQueue
+import java.util.function.Supplier;
 
 /**
  * An unbounded reader that streams trade data from an exchange.
  */
 class ExchangeClientUnboundedReader(
     private val exchangeClient: ExchangeStreamingClient,
-    private val currencyPairSupply: CurrencyPairSupply,
+    private val currencyPairSupply: Supplier<ImmutableList<CurrencyPair>>,
     private val source: ExchangeClientUnboundedSource,
     private var currentCheckpointMark: TradeCheckpointMark
 ) : UnboundedSource.UnboundedReader<Trade>() {

--- a/src/main/java/com/verlumen/tradestream/marketdata/ExchangeClientUnboundedReader.kt
+++ b/src/main/java/com/verlumen/tradestream/marketdata/ExchangeClientUnboundedReader.kt
@@ -39,7 +39,7 @@ class ExchangeClientUnboundedReader(
      */
     class Factory @Inject constructor(
         private val exchangeClient: ExchangeStreamingClient,
-        private val currencyPairSupply: CurrencyPairSupply
+        private val currencyPairSupply: Supplier<ImmutableList<CurrencyPair>>
     ) : java.io.Serializable {
         /**
          * Creates a new ExchangeClientUnboundedReader instance.
@@ -69,11 +69,11 @@ class ExchangeClientUnboundedReader(
         try {
             logger.atFine().log("Calling currencyPairSupply.get()...")
             pairsToStream = currencyPairSupply.get()
-            checkArgument(pairsToStream.isNotEmpty(), "CurrencyPairSupply returned empty list via currencyPairs()")
-            logger.atInfo().log("Obtained %d currency pairs from CurrencyPairSupply.", pairsToStream.size)
+            checkArgument(pairsToStream.isNotEmpty(), "CurrencyPair Supplier returned empty list via currencyPairs()")
+            logger.atInfo().log("Obtained %d currency pairs from CurrencyPair Supplier.", pairsToStream.size)
         } catch (e: Exception) {
-            logger.atSevere().withCause(e).log("Failed to get currency pairs from CurrencyPairSupply")
-            throw IOException("Failed to get currency pairs from CurrencyPairSupply", e)
+            logger.atSevere().withCause(e).log("Failed to get currency pairs from CurrencyPair Supplier")
+            throw IOException("Failed to get currency pairs from CurrencyPair Supplier", e)
         }
 
         logger.atInfo().log("Calling exchangeClient.startStreaming for %d pairs.", pairsToStream.size)

--- a/src/main/java/com/verlumen/tradestream/marketdata/ExchangeClientUnboundedReader.kt
+++ b/src/main/java/com/verlumen/tradestream/marketdata/ExchangeClientUnboundedReader.kt
@@ -67,8 +67,8 @@ class ExchangeClientUnboundedReader(
 
         val pairsToStream: ImmutableList<CurrencyPair>
         try {
-            logger.atFine().log("Calling currencyPairSupply.currencyPairs()...")
-            pairsToStream = currencyPairSupply.currencyPairs()
+            logger.atFine().log("Calling currencyPairSupply.get()...")
+            pairsToStream = currencyPairSupply.get()
             checkArgument(pairsToStream.isNotEmpty(), "CurrencyPairSupply returned empty list via currencyPairs()")
             logger.atInfo().log("Obtained %d currency pairs from CurrencyPairSupply.", pairsToStream.size)
         } catch (e: Exception) {

--- a/src/test/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/test/java/com/verlumen/tradestream/marketdata/BUILD
@@ -62,7 +62,6 @@ java_test(
     deps = [
         "//protos:marketdata_java_proto",
         "//src/main/java/com/verlumen/tradestream/instruments:currency_pair",
-        "//src/main/java/com/verlumen/tradestream/instruments:currency_pair_supply",
         "//src/main/java/com/verlumen/tradestream/marketdata:exchange_client_unbounded_reader",
         "//src/main/java/com/verlumen/tradestream/marketdata:exchange_client_unbounded_source",
         "//src/main/java/com/verlumen/tradestream/marketdata:exchange_client_unbounded_source_impl",

--- a/src/test/java/com/verlumen/tradestream/marketdata/ExchangeClientUnboundedSourceImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/marketdata/ExchangeClientUnboundedSourceImplTest.java
@@ -12,13 +12,13 @@ import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
 import com.verlumen.tradestream.instruments.CurrencyPair;
-import com.verlumen.tradestream.instruments.CurrencyPairSupply;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.extensions.protobuf.ProtoCoder;
@@ -43,7 +43,7 @@ public class ExchangeClientUnboundedSourceImplTest {
 
   @Bind
   @Mock
-  private CurrencyPairSupply mockCurrencyPairSupply;
+  private Supplier<ImmutableList<CurrencyPair>> mockCurrencyPairSupply;
   
   // Mockito rule to initialize mocks
   @Rule
@@ -66,7 +66,7 @@ public class ExchangeClientUnboundedSourceImplTest {
   @Before
   public void setUp() {
     // Configure mock
-    when(mockCurrencyPairSupply.currencyPairs()).thenReturn(TEST_PAIRS);
+    when(mockCurrencyPairSupply.get()).thenReturn(TEST_PAIRS);
     
     // Create an injector with BoundFieldModule and FactoryModule
     Injector injector = Guice.createInjector(


### PR DESCRIPTION
This PR refactors the `CurrencyPairSupply` interface to simplify its implementation by removing the default method `currencyPairs()` and directly relying on the `Supplier<ImmutableList<CurrencyPair>>` interface.

### Key Changes
1. **Refactored `CurrencyPairSupply`:**
   - Removed the `currencyPairs()` method and retained only the `Supplier` interface, simplifying the class structure.
2. **Updated Dependency Injection:**
   - Modified `InstrumentsModule` to provide `Supplier<ImmutableList<CurrencyPair>>` via `CurrencyPairSupplyProvider`.
   - Adjusted binding in `InstrumentsModule` to replace the use of `CurrencyPairSupply` with `Supplier<ImmutableList<CurrencyPair>>`.
3. **Updated `ExchangeClientUnboundedReader`:**
   - Replaced all instances of `CurrencyPairSupply` with `Supplier<ImmutableList<CurrencyPair>>` in the constructor, factory, and logging.
4. **Removed Unused Dependencies:**
   - Cleaned up the `BUILD` files by removing unnecessary references to `currency_pair_supply` where no longer needed.
5. **Updated Unit Tests:**
   - Refactored `ExchangeClientUnboundedSourceImplTest` to use `Supplier<ImmutableList<CurrencyPair>>` and modified Mockito mock behavior to match the new interface.

### Rationale
- This refactor reduces interface complexity and leverages the standard `Supplier` interface, which enhances maintainability and reduces potential method duplication.
- Improves testability by simplifying dependency injection and mock setup.

### Impact
- No changes in functionality.
- Minimal risk due to the interface change being backward-compatible with the underlying behavior.