### PR TITLE
Add Serializable to CurrencyPairMetadata for object serialization

### DIFF
--- a/src/main/java/com/verlumen/tradestream/instruments/CurrencyPairMetadata.java
+++ b/src/main/java/com/verlumen/tradestream/instruments/CurrencyPairMetadata.java
@@ -1,15 +1,13 @@
 package com.verlumen.tradestream.instruments;
 
+import java.io.Serializable;
 import java.math.BigDecimal;
 
 /**
  * Represents metadata for a currency pair, including its {@link CurrencyPair}
  * and associated market capitalization.
  */
-record CurrencyPairMetadata(
-  CurrencyPair currencyPair,
-  BigDecimal marketCap
-) {
+record CurrencyPairMetadata(CurrencyPair currencyPair, BigDecimal marketCap) implements Serializable {
 
   /**
    * Factory method to create a {@link CurrencyPairMetadata} instance from a symbol and market cap value.


### PR DESCRIPTION
#### Summary
- Updated `CurrencyPairMetadata` to implement `Serializable` to enable object serialization.
- This change allows instances of `CurrencyPairMetadata` to be serialized and deserialized when necessary, ensuring compatibility with systems that require object persistence or transmission.

#### Context
- `CurrencyPairMetadata` now explicitly implements `Serializable`, which is often essential for distributing or persisting objects in distributed systems.
- No changes were made to the core functionality or structure of the class beyond the implementation of `Serializable`.

#### Reason for Change
- Adding `Serializable` ensures that `CurrencyPairMetadata` can be safely serialized, which is a common requirement in trading systems or services that rely on object transmission or persistence.

#### Impact
- No breaking changes expected.
- Serialization support added without modifying existing behavior.

No version update required, as this is a minor internal change.