### PR TITLE
(MINOR) Migrate `Currency` and `CurrencyPair` to Java Records and Remove AutoValue Dependency

### DIFF
--- a/src/main/java/com/verlumen/tradestream/instruments/BUILD
+++ b/src/main/java/com/verlumen/tradestream/instruments/BUILD
@@ -10,9 +10,6 @@ java_library(
 java_library(
     name = "currency",
     srcs = ["Currency.java"],
-    deps = [
-        "//third_party:auto_value",
-    ],
 )
 
 java_library(

--- a/src/main/java/com/verlumen/tradestream/instruments/BUILD
+++ b/src/main/java/com/verlumen/tradestream/instruments/BUILD
@@ -16,8 +16,8 @@ java_library(
     name = "currency_pair",
     srcs = ["CurrencyPair.java"],
     deps = [
-        "//third_party:guava",
         ":currency",
+        "//third_party:guava",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/instruments/BUILD
+++ b/src/main/java/com/verlumen/tradestream/instruments/BUILD
@@ -19,7 +19,6 @@ java_library(
     name = "currency_pair",
     srcs = ["CurrencyPair.java"],
     deps = [
-        "//third_party:auto_value",
         "//third_party:guava",
         ":currency",
     ],

--- a/src/main/java/com/verlumen/tradestream/instruments/Currency.java
+++ b/src/main/java/com/verlumen/tradestream/instruments/Currency.java
@@ -1,6 +1,6 @@
 package com.verlumen.tradestream.instruments;
 
-import com.google.auto.value.AutoValue;
+import java.io.Serializable;
 
 /**
  * Represents a currency with a unique symbol.
@@ -8,8 +8,7 @@ import com.google.auto.value.AutoValue;
  * A {@link Currency} object encapsulates the symbol of a currency, which can be used in contexts
  * such as trading, forex, or financial applications.
  */
-@AutoValue
-public abstract class Currency {
+public record Currency(String symbol) implements Serializable {
   /**
    * Factory method to create a {@link Currency} instance.
    *
@@ -22,16 +21,6 @@ public abstract class Currency {
     if (symbol == null || symbol.isEmpty()) {
       throw new IllegalArgumentException("Currency symbol must not be null or empty.");
     }
-    return new AutoValue_Currency(symbol);
+    return new Currency(symbol);
   }
-
-  /**
-   * Returns the symbol of the currency.
-   *
-   * The symbol is typically a three-character code (e.g., "USD", "EUR", "JPY"), but it can also
-   * represent other forms of currency identifiers, such as cryptocurrency symbols (e.g., "BTC").
-   *
-   * @return the symbol of the currency.
-   */
-  public abstract String symbol();
 }

--- a/src/main/java/com/verlumen/tradestream/instruments/CurrencyPair.java
+++ b/src/main/java/com/verlumen/tradestream/instruments/CurrencyPair.java
@@ -4,8 +4,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
-import com.google.auto.value.AutoValue;
-import com.google.common.base.Splitter;
+-import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import java.util.NoSuchElementException;
 import java.util.stream.Stream;
@@ -24,8 +23,7 @@ import java.util.stream.Stream;
  * EUR).
  * </p>
  */
-@AutoValue
-public abstract class CurrencyPair {
+public record class CurrencyPair {
   // Constants for possible delimiters in the currency pair symbol.
   private static final String FORWARD_SLASH = "/";
   private static final String HYPHEN = "-";
@@ -57,7 +55,7 @@ public abstract class CurrencyPair {
     ImmutableList<String> symbolParts = splitSymbol(symbol);
     Currency base = Currency.create(symbolParts.get(0));
     Currency counter = Currency.create(symbolParts.get(1));
-    return create(base, counter);
+    return new CurrencyPair(base, counter);
   }
 
   /**
@@ -94,36 +92,6 @@ public abstract class CurrencyPair {
           String.format("Unable to parse currency pair, invalid symbol: \"%s\".", symbol), e);
     }
   }
-
-  /**
-   * Creates a {@link CurrencyPair} instance from the given base and counter currencies.
-   *
-   * @param base the base currency (e.g., EUR in EUR/USD)
-   * @param counter the counter currency (e.g., USD in EUR/USD)
-   * @return a new {@link CurrencyPair} instance
-   */
-  private static CurrencyPair create(Currency base, Currency counter) {
-    return new AutoValue_CurrencyPair(base, counter);
-  }
-
-  /**
-   * Returns the base currency of this currency pair.
-   *
-   * <p>The base currency is the first currency listed in the pair and is the one being traded.
-   *
-   * @return the base {@link Currency}
-   */
-  public abstract Currency base();
-
-  /**
-   * Returns the counter currency of this currency pair.
-   *
-   * <p>The counter currency is the second currency listed in the pair and is the one used to quote
-   * the value of the base currency.
-   *
-   * @return the counter {@link Currency}
-   */
-  public abstract Currency counter();
 
   public String symbol() {
     return base().symbol() + FORWARD_SLASH + counter().symbol();

--- a/src/main/java/com/verlumen/tradestream/instruments/CurrencyPair.java
+++ b/src/main/java/com/verlumen/tradestream/instruments/CurrencyPair.java
@@ -24,7 +24,7 @@ import java.util.stream.Stream;
  * EUR).
  * </p>
  */
-public record class CurrencyPair(Currency base, Currency counter) implements Serializable {
+public record CurrencyPair(Currency base, Currency counter) implements Serializable {
   // Constants for possible delimiters in the currency pair symbol.
   private static final String FORWARD_SLASH = "/";
   private static final String HYPHEN = "-";

--- a/src/main/java/com/verlumen/tradestream/instruments/CurrencyPair.java
+++ b/src/main/java/com/verlumen/tradestream/instruments/CurrencyPair.java
@@ -6,6 +6,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
+import java.io.Serializable;
 import java.util.NoSuchElementException;
 import java.util.stream.Stream;
 
@@ -23,7 +24,7 @@ import java.util.stream.Stream;
  * EUR).
  * </p>
  */
-public record class CurrencyPair {
+public record class CurrencyPair(Currency base, Currency counter) implements Serializable {
   // Constants for possible delimiters in the currency pair symbol.
   private static final String FORWARD_SLASH = "/";
   private static final String HYPHEN = "-";

--- a/src/main/java/com/verlumen/tradestream/instruments/CurrencyPair.java
+++ b/src/main/java/com/verlumen/tradestream/instruments/CurrencyPair.java
@@ -4,7 +4,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
--import com.google.common.base.Splitter;
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import java.util.NoSuchElementException;
 import java.util.stream.Stream;


### PR DESCRIPTION
### Summary
- Migrated `Currency` and `CurrencyPair` classes to use Java records, replacing the previous `@AutoValue` implementation.
- Removed `AutoValue` dependency and related annotations.
- Updated `Currency.java`:
  - Converted to a record implementing `Serializable`.
  - Simplified the `create` method to directly return a `Currency` instance.
  - Removed `symbol()` method, as records automatically generate accessor methods.
- Updated `CurrencyPair.java`:
  - Converted to a record implementing `Serializable`.
  - Simplified the `fromSymbol` method to instantiate `CurrencyPair` directly.
  - Removed `base()` and `counter()` methods, as records automatically provide these.
- Updated `BUILD` file:
  - Removed `auto_value` dependency from both `currency` and `currency_pair` targets.

### Motivation
- Migrating to Java records simplifies the code by reducing boilerplate, improving maintainability, and ensuring immutability.
- Removing `AutoValue` reduces external dependencies and improves build efficiency.

### Impact
- No changes to public APIs or functionality.
- Codebase is now cleaner and more efficient with fewer dependencies.