### PR TITLE
Add Serializable to ExchangeStreamingClient interface (MINOR)

### DIFF
--- a/src/main/java/com/verlumen/tradestream/marketdata/ExchangeStreamingClient.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/ExchangeStreamingClient.java
@@ -4,6 +4,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.common.collect.ImmutableList;
 import com.verlumen.tradestream.instruments.CurrencyPair;
+import java.io.Serializable;
 import java.util.function.Consumer;
 
 /**

--- a/src/main/java/com/verlumen/tradestream/marketdata/ExchangeStreamingClient.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/ExchangeStreamingClient.java
@@ -11,7 +11,7 @@ import java.util.function.Consumer;
  * This allows different exchanges to provide their own implementations
  * while maintaining a consistent interface for the data ingestion system.
  */
-public interface ExchangeStreamingClient {
+public interface ExchangeStreamingClient extends Serializable {
     /**
      * Starts streaming market data for the given currency pairs.
      *


### PR DESCRIPTION
#### Summary
- Updated `ExchangeStreamingClient` interface to extend `Serializable` to ensure compatibility with object serialization.
- This change allows instances of `ExchangeStreamingClient` to be serialized, which may be required for distributed systems or caching frameworks.

#### Rationale
- Adding `Serializable` provides greater flexibility for handling instances of the interface, especially when transmitting objects or persisting state.
- No breaking changes introduced, as this modification only enhances the existing functionality.

#### Scope
- Affects `ExchangeStreamingClient.java` in the `marketdata` package.

#### Versioning
- Marked as (MINOR) due to the introduction of enhanced functionality without altering existing behavior.