### PR TITLE
Add `Serializable` to `WebSocketConnector` for serialization support

### DIFF
--- a/src/main/java/com/verlumen/tradestream/marketdata/CoinbaseStreamingClient.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/CoinbaseStreamingClient.java
@@ -13,6 +13,7 @@ import com.google.gson.JsonParser;
 import com.google.inject.Inject;
 import com.verlumen.tradestream.instruments.CurrencyPair;
 import java.io.IOException;
+import java.io.Serializable;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -265,7 +266,7 @@ final class CoinbaseStreamingClient implements ExchangeStreamingClient {
         }
     }
 
-    private static class WebSocketConnector {
+    private static class WebSocketConnector implements Serializable {
         private static final FluentLogger logger = FluentLogger.forEnclosingClass();
         private final CoinbaseStreamingClient client;
 


### PR DESCRIPTION
#### Summary
- Updated the `WebSocketConnector` class in `CoinbaseStreamingClient.java` to implement `Serializable`.
- This change allows instances of `WebSocketConnector` to be serialized, which is useful for scenarios where object persistence or transmission is required.

#### Context
- Implementing `Serializable` ensures that the `WebSocketConnector` can be stored or transferred reliably.
- No changes were made to the behavior or functionality of the class, maintaining compatibility with existing WebSocket operations.
