### PR TITLE
Reduce TimingConfig Duration for Allowed Lateness and Timestamp Skew 

### DIFF
--- a/src/main/java/com/verlumen/tradestream/pipeline/TimingConfig.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/TimingConfig.java
@@ -6,14 +6,14 @@ record TimingConfig(
     Duration allowedLateness,
     Duration windowDuration,
     Duration allowedTimestampSkew) {
-  private static final Duration FIVE_SECONDS = Duration.standardSeconds(5);
+  private static final Duration TWO_SECONDS = Duration.standardSeconds(2);
   private static final Duration ONE_MINUTE = Duration.standardMinutes(1);
-  private static final Duration THIRTY_MINUTES = Duration.standardMinutes(30);
+  private static final Duration TWO_MINUTES = Duration.standardMinutes(2);
 
   static TimingConfig create() {
     return new TimingConfig(
-        FIVE_SECONDS,
+        TWO_SECONDS,
         ONE_MINUTE,
-        THIRTY_MINUTES);
+        TWO_MINUTES);
   }
 }


### PR DESCRIPTION
This PR updates the default duration values in `TimingConfig.java` to reduce the timing thresholds:  
- `allowedLateness` duration is decreased from **5 seconds** to **2 seconds**.  
- `allowedTimestampSkew` duration is decreased from **30 minutes** to **2 minutes**.  

These adjustments aim to improve responsiveness and reduce delays in the trade stream pipeline by tightening the allowed timing window.  

No functional changes beyond the timing adjustments are introduced.