### PR TITLE
Remove unused imports in `CandleStreamWithDefaults.java`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/marketdata/CandleStreamWithDefaults.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/CandleStreamWithDefaults.java
@@ -2,7 +2,6 @@ package com.verlumen.tradestream.marketdata;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
-import java.util.Arrays;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.Flatten;
@@ -15,8 +14,6 @@ import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
 import org.apache.beam.sdk.transforms.windowing.Window;
-import org.apache.beam.sdk.transforms.windowing.AfterProcessingTime;
-import org.apache.beam.sdk.transforms.windowing.Repeatedly;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionList;


### PR DESCRIPTION
This pull request removes unused imports from the `CandleStreamWithDefaults.java` file, including:
- `java.util.Arrays`
- `org.apache.beam.sdk.transforms.windowing.AfterProcessingTime`
- `org.apache.beam.sdk.transforms.windowing.Repeatedly`

These imports were not utilized in the current implementation, and their removal helps maintain cleaner and more efficient code. This change is purely a cleanup with no impact on functionality.