### PR TITLE
Remove unused Gson dependency from CurrencyPairSupplyProvider

### DIFF
--- a/src/main/java/com/verlumen/tradestream/instruments/CurrencyPairSupplyProvider.java
+++ b/src/main/java/com/verlumen/tradestream/instruments/CurrencyPairSupplyProvider.java
@@ -1,7 +1,6 @@
 package com.verlumen.tradestream.instruments;
 
 import com.google.common.collect.ImmutableList;
-import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -15,13 +14,11 @@ import java.util.Map;
 
 final class CurrencyPairSupplyProvider implements Provider<CurrencyPairSupply> {
     private final CoinMarketCapConfig coinMarketCapConfig;
-    private final Gson gson;
     private final HttpClient httpClient;
 
     @Inject
-    CurrencyPairSupplyProvider(CoinMarketCapConfig coinMarketCapConfig, Gson gson, HttpClient httpClient) {
+    CurrencyPairSupplyProvider(CoinMarketCapConfig coinMarketCapConfig, HttpClient httpClient) {
         this.coinMarketCapConfig = coinMarketCapConfig;
-        this.gson = gson;
         this.httpClient = httpClient;
     }
 


### PR DESCRIPTION
- **Summary:**  
  The `Gson` dependency was removed from `CurrencyPairSupplyProvider` as it was no longer used in the class.  
  - Updated the constructor to remove the `Gson` parameter.
  - Cleaned up unused import statements in `CurrencyPairSupplyProvider.java`.
  
- **Context:**  
  This change simplifies the class by eliminating an unnecessary dependency, improving maintainability and reducing the risk of potential errors from unused components.

- **Testing:**  
  - Verified that the application builds successfully.
  - Ensured that all existing unit and integration tests pass without modification.

No version bump required as this is a minor cleanup.