### PR TITLE
Fix type incompatibility in Guice provider by switching to Guava's `Supplier`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/instruments/CurrencyPairSupplier.kt
+++ b/src/main/java/com/verlumen/tradestream/instruments/CurrencyPairSupplier.kt
@@ -1,5 +1,6 @@
 package com.verlumen.tradestream.instruments
 
+import com.google.common.base.Supplier
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
@@ -7,7 +8,6 @@ import com.google.inject.Inject
 import com.verlumen.tradestream.http.HttpClient
 import java.io.IOException
 import java.io.Serializable
-import java.util.function.Supplier
 
 internal class CurrencyPairSupplier @Inject constructor(
     private val coinMarketCapConfig: CoinMarketCapConfig,

--- a/src/main/java/com/verlumen/tradestream/instruments/CurrencyPairSupplier.kt
+++ b/src/main/java/com/verlumen/tradestream/instruments/CurrencyPairSupplier.kt
@@ -12,7 +12,7 @@ import java.io.Serializable
 internal class CurrencyPairSupplier @Inject constructor(
     private val coinMarketCapConfig: CoinMarketCapConfig,
     private val httpClient: HttpClient
-) : Serializable, Supplier<List<CurrencyPair>> {
+) : Serializable, Supplier<@JvmSuppressWildcards List<CurrencyPair>> {
     override fun get(): List<CurrencyPair> {
         val url = "https://pro-api.coinmarketcap.com/v1/cryptocurrency/listings/latest"
         

--- a/src/main/java/com/verlumen/tradestream/instruments/InstrumentsModule.java
+++ b/src/main/java/com/verlumen/tradestream/instruments/InstrumentsModule.java
@@ -32,7 +32,7 @@ public abstract class InstrumentsModule extends AbstractModule {
   @Singleton
   Supplier<List<CurrencyPair>> provideCurrencyPairSupply(CurrencyPairSupplier supplier) {
     return Suppliers.memoizeWithExpiration(
-      supplier::get,
+      supplier,
       INSTRUMENT_REFRESH_INTERVAL.toMillis(),
       TimeUnit.MILLISECONDS);
   }


### PR DESCRIPTION
This patch resolves a type mismatch issue by replacing Java's `java.util.function.Supplier` with Guava's `com.google.common.base.Supplier` in `CurrencyPairSupplier`. The change ensures compatibility with the `Suppliers.memoizeWithExpiration` utility in `InstrumentsModule`, which expects a Guava `Supplier`.

**Summary of changes:**
- Replaced `java.util.function.Supplier` with Guava's `Supplier` in `CurrencyPairSupplier`.
- Adjusted the class signature to use `@JvmSuppressWildcards` to avoid Kotlin-Java wildcard issues.
- Updated the `InstrumentsModule` binding to pass the supplier instance directly, now compatible with Guava's memoization API.

No new functionality was introduced, so this qualifies as a patch-level change.