### PR TITLE
Implement `Serializable` for `CoinMarketCapConfig` record

### DIFF
--- a/src/main/java/com/verlumen/tradestream/instruments/CoinMarketCapConfig.java
+++ b/src/main/java/com/verlumen/tradestream/instruments/CoinMarketCapConfig.java
@@ -1,6 +1,8 @@
 package com.verlumen.tradestream.instruments;
 
-record CoinMarketCapConfig(int topN, String apiKey) {
+import java.io.Serializable;
+
+record CoinMarketCapConfig(int topN, String apiKey) implements Serializable {
   static CoinMarketCapConfig create(int topN, String apiKey) {
       return new CoinMarketCapConfig(topN, apiKey);
   }


### PR DESCRIPTION
This change modifies the `CoinMarketCapConfig` record to implement `Serializable`. This is necessary to support scenarios where the configuration needs to be serialized—for example, when caching or distributing configuration objects across JVM boundaries.

### Summary of Changes:
- Added `implements Serializable` to the `CoinMarketCapConfig` record.
- Added the necessary `import java.io.Serializable`.

No behavior or logic changes were introduced. This update ensures compatibility with systems or libraries that require serialization of configuration objects.