### PR TITLE
Make `HttpClient` Interface Serializable

### DIFF
--- a/src/main/java/com/verlumen/tradestream/http/HttpClient.java
+++ b/src/main/java/com/verlumen/tradestream/http/HttpClient.java
@@ -1,8 +1,9 @@
 package com.verlumen.tradestream.http;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Map;
 
-public interface HttpClient {
+public interface HttpClient extends Serializable {
     String get(String url, Map<String, String> headers) throws IOException;
 }


### PR DESCRIPTION
This change updates the `HttpClient` interface to extend `Serializable`. This allows implementations of `HttpClient` to be safely serialized, which is often required for distributed systems, caching, or session persistence mechanisms.

No changes were made to the interface methods; this is a structural update to support broader use cases such as Java serialization and compatibility with frameworks that require serializable dependencies.