### PR TITLE
Inject `RunMode` into `InstrumentsModule` to enable environment-specific behavior

### DIFF
--- a/src/main/java/com/verlumen/tradestream/instruments/BUILD
+++ b/src/main/java/com/verlumen/tradestream/instruments/BUILD
@@ -43,6 +43,7 @@ java_library(
         ":coin_market_cap_config",
         ":currency_pair",
         ":currency_pair_supplier",
+        "//src/main/java/com/verlumen/tradestream/execution:run_mode",
         "//third_party:auto_value",
         "//third_party:guava",
         "//third_party:guice",

--- a/src/main/java/com/verlumen/tradestream/instruments/InstrumentsModule.java
+++ b/src/main/java/com/verlumen/tradestream/instruments/InstrumentsModule.java
@@ -2,11 +2,13 @@ package com.verlumen.tradestream.instruments;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
+import com.verlumen.tradestream.execution.RunMode;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -14,12 +16,13 @@ import java.util.function.Supplier;
 
 @AutoValue
 public abstract class InstrumentsModule extends AbstractModule {
-  public static InstrumentsModule create(String coinMarketCapApiKey, int topCryptocurrencyCount) {
-    return new AutoValue_InstrumentsModule(coinMarketCapApiKey, topCryptocurrencyCount);
+  public static InstrumentsModule create(RunMode runMode, String coinMarketCapApiKey, int topCryptocurrencyCount) {
+    return new AutoValue_InstrumentsModule(runMode, coinMarketCapApiKey, topCryptocurrencyCount);
   }
 
   private static final Duration INSTRUMENT_REFRESH_INTERVAL = Duration.ofDays(1);
 
+  abstract RunMode runMode();
   abstract String coinMarketCapApiKey();
   abstract int topCryptocurrencyCount();
 
@@ -31,6 +34,10 @@ public abstract class InstrumentsModule extends AbstractModule {
   @Provides
   @Singleton
   Supplier<List<CurrencyPair>> provideCurrencyPairSupply(CurrencyPairSupplier supplier) {
+    if (RunMode.DRY.equals(runMode())) {
+      return Suppliers.ofInstance(ImmutableList.of(CurrencyPair.fromSymbol("DRY/RUN")));
+    }
+
     return Suppliers.memoizeWithExpiration(
       supplier,
       INSTRUMENT_REFRESH_INTERVAL.toMillis(),

--- a/src/main/java/com/verlumen/tradestream/pipeline/PipelineModule.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/PipelineModule.java
@@ -39,16 +39,12 @@ abstract class PipelineModule extends AbstractModule {
   protected void configure() {
       install(BacktestingModule.create());
       install(HttpModule.create());
-      install(InstrumentsModule.create(coinMarketCapApiKey(), topCurrencyCount()));
+      install(InstrumentsModule.create(runMode(), coinMarketCapApiKey(), topCurrencyCount()));
       install(KafkaModule.create(bootstrapServers()));
-      install(marketDataModule());
+      install(MarketDataModule.create(exchangeName(), runMode()));
       install(SignalsModule.create(signalTopic()));
       install(StrategiesModule.create());
       install(Ta4jModule.create());
-  }
-
-  MarketDataModule marketDataModule() {
-    return MarketDataModule.create(exchangeName(), runMode());
   }
 
   @Provides


### PR DESCRIPTION
This change updates the `InstrumentsModule` to accept `RunMode` as a constructor parameter. This allows environment-specific logic within the module, specifically:

- When `RunMode.DRY` is active, the module returns a stubbed currency pair (`DRY/RUN`) instead of querying real data.
- The module is now instantiated with `runMode` in `PipelineModule`, aligning it with other environment-sensitive modules.
- Updated the `BUILD` file to include the `run_mode` dependency.

This refactor improves testability and supports safer dry runs or sandboxed environments.