### PR TITLE
Refactor CandleStreamWithDefaults to Use Supplier for Currency Pairs

### DIFF
--- a/src/main/java/com/verlumen/tradestream/marketdata/CandleStreamWithDefaults.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/CandleStreamWithDefaults.java
@@ -2,7 +2,7 @@ package com.verlumen.tradestream.marketdata;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
-import java.util.Supplier;
+import java.util.function.Supplier;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.Flatten;

--- a/src/main/java/com/verlumen/tradestream/marketdata/CandleStreamWithDefaults.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/CandleStreamWithDefaults.java
@@ -2,6 +2,7 @@ package com.verlumen.tradestream.marketdata;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
+import java.util.Supplier;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.Flatten;
@@ -39,10 +40,10 @@ public class CandleStreamWithDefaults extends PTransform<PCollection<KV<String, 
     private final Duration windowDuration;
     private final Duration slideDuration;
     private final int bufferSize;
-    private final List<String> currencyPairs;
+    private final Supplier<List<String>> currencyPairs;
     private final double defaultPrice;
 
-    public CandleStreamWithDefaults(Duration windowDuration, Duration slideDuration, int bufferSize, List<String> currencyPairs, double defaultPrice) {
+    public CandleStreamWithDefaults(Duration windowDuration, Duration slideDuration, int bufferSize, Supplier<List<String>> currencyPairs, double defaultPrice) {
         this.windowDuration = windowDuration;
         this.slideDuration = slideDuration;
         this.bufferSize = bufferSize;
@@ -54,7 +55,7 @@ public class CandleStreamWithDefaults extends PTransform<PCollection<KV<String, 
     public PCollection<KV<String, ImmutableList<Candle>>> expand(PCollection<KV<String, Trade>> input) {
         // 1. Create keys for all currency pairs.
         PCollection<KV<String, Void>> keys = input.getPipeline()
-            .apply("CreateCurrencyPairKeys", Create.of(currencyPairs))
+            .apply("CreateCurrencyPairKeys", Create.of(currencyPairs.get()))
             .apply("PairWithVoid", MapElements.via(new SimpleFunction<String, KV<String, Void>>() {
                 @Override
                 public KV<String, Void> apply(String input) {

--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -4,6 +4,7 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.Iterables.getLast;
 
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.flogger.FluentLogger;
 import com.google.inject.Guice;
@@ -141,7 +142,7 @@ public final class App {
                 timingConfig.windowDuration(), // Use the same 1-minute window for candle aggregation.
                 Duration.standardSeconds(30), // Slide duration for the candle aggregator.
                 5, // Buffer size for base candle consolidation.
-                Arrays.asList("BTC/USD", "ETH/USD"),
+                Suppliers.ofInstance(ImmutableList.of("BTC/USD", "ETH/USD")),
                 10000.0 // Default price for synthetic trades.
                 ));
 

--- a/src/test/java/com/verlumen/tradestream/marketdata/CandleStreamWithDefaultsTest.java
+++ b/src/test/java/com/verlumen/tradestream/marketdata/CandleStreamWithDefaultsTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
-import java.util.Arrays;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.values.KV;
@@ -41,7 +40,7 @@ public class CandleStreamWithDefaultsTest {
                         Duration.standardMinutes(1),
                         Duration.standardSeconds(30),
                         5,
-                        Arrays.asList("BTC/USD", "ETH/USD"),
+                        Suppliers.ofInstance(ImmutableList.of("BTC/USD", "ETH/USD")),
                         10000.0))
         ).satisfies(iterable -> {
             boolean foundBTC = false;
@@ -71,7 +70,7 @@ public class CandleStreamWithDefaultsTest {
                         Duration.standardMinutes(1),
                         Duration.standardSeconds(30),
                         5,
-                        Arrays.asList("BTC/USD", "ETH/USD"),
+                        Suppliers.ofInstance(ImmutableList.of("BTC/USD", "ETH/USD")),
                         10000.0))
         ).satisfies(iterable -> {
             int count = 0;
@@ -130,7 +129,7 @@ public class CandleStreamWithDefaultsTest {
                     Duration.standardMinutes(1),
                     Duration.standardSeconds(30),
                     2, // bufferSize = 2
-                    Arrays.asList("BTC/USD"),
+                    Suppliers.ofInstance(ImmutableList.of("BTC/USD")),
                     10000.0))
         ).satisfies(iterable -> {
             for (KV<String, ImmutableList<Candle>> kv : iterable) {

--- a/src/test/java/com/verlumen/tradestream/marketdata/CandleStreamWithDefaultsTest.java
+++ b/src/test/java/com/verlumen/tradestream/marketdata/CandleStreamWithDefaultsTest.java
@@ -3,6 +3,7 @@ package com.verlumen.tradestream.marketdata;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;


### PR DESCRIPTION
This change refactors the `CandleStreamWithDefaults` transform to accept a `Supplier<List<String>>` for the `currencyPairs` parameter instead of a direct list. This provides greater flexibility for deferred or dynamic evaluation of currency pairs at pipeline execution time.

### Summary of Changes:
- Updated the constructor of `CandleStreamWithDefaults` to accept a `Supplier<List<String>>`.
- Replaced direct list usage in the transform with a `.get()` invocation.
- Updated instantiations in `App.java` and unit tests to use `Suppliers.ofInstance(...)` for consistent behavior.

This is a non-breaking internal refactor aimed at improving configurability and aligning with lazy evaluation patterns. No behavioral changes to the transform logic or output.

_No version label is needed; this is a patch-level update._