### PR TITLE
Refactor CandleStreamWithDefaults to use `CurrencyPair` objects instead of raw strings

### DIFF
--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -11,6 +11,7 @@ java_library(
         ":last_candles_fn",
         ":sliding_candle_aggregator",
         "//protos:marketdata_java_proto",
+        "//src/main/java/com/verlumen/tradestream/instruments:currency_pair",
         "//third_party:beam_sdks_java_core",
         "//third_party:beam_sdks_java_extensions_protobuf",
         "//third_party:guava",

--- a/src/main/java/com/verlumen/tradestream/marketdata/CandleStreamWithDefaults.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/CandleStreamWithDefaults.java
@@ -1,6 +1,9 @@
 package com.verlumen.tradestream.marketdata;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
 import com.google.common.collect.ImmutableList;
+import com.verlumen.tradestream.instruments.CurrencyPair;
 import java.util.List;
 import java.util.function.Supplier;
 import org.apache.beam.sdk.Pipeline;
@@ -40,10 +43,10 @@ public class CandleStreamWithDefaults extends PTransform<PCollection<KV<String, 
     private final Duration windowDuration;
     private final Duration slideDuration;
     private final int bufferSize;
-    private final Supplier<List<String>> currencyPairs;
+    private final Supplier<List<CurrencyPair>> currencyPairs;
     private final double defaultPrice;
 
-    public CandleStreamWithDefaults(Duration windowDuration, Duration slideDuration, int bufferSize, Supplier<List<String>> currencyPairs, double defaultPrice) {
+    public CandleStreamWithDefaults(Duration windowDuration, Duration slideDuration, int bufferSize, Supplier<List<CurrencyPair>> currencyPairs, double defaultPrice) {
         this.windowDuration = windowDuration;
         this.slideDuration = slideDuration;
         this.bufferSize = bufferSize;
@@ -55,7 +58,7 @@ public class CandleStreamWithDefaults extends PTransform<PCollection<KV<String, 
     public PCollection<KV<String, ImmutableList<Candle>>> expand(PCollection<KV<String, Trade>> input) {
         // 1. Create keys for all currency pairs.
         PCollection<KV<String, Void>> keys = input.getPipeline()
-            .apply("CreateCurrencyPairKeys", Create.of(currencyPairs.get()))
+            .apply("CreateCurrencyPairKeys", Create.of(currencyPairs.get().stream().map(CurrencyPair::symbol).collect(toImmutableList())))
             .apply("PairWithVoid", MapElements.via(new SimpleFunction<String, KV<String, Void>>() {
                 @Override
                 public KV<String, Void> apply(String input) {

--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -142,7 +142,7 @@ public final class App {
                 timingConfig.windowDuration(), // Use the same 1-minute window for candle aggregation.
                 Duration.standardSeconds(30), // Slide duration for the candle aggregator.
                 5, // Buffer size for base candle consolidation.
-                Suppliers.ofInstance(ImmutableList.of("BTC/USD", "ETH/USD")),
+                currencyPairs,
                 10000.0 // Default price for synthetic trades.
                 ));
 

--- a/src/test/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/test/java/com/verlumen/tradestream/marketdata/BUILD
@@ -6,6 +6,7 @@ java_test(
     srcs = ["CandleStreamWithDefaultsTest.java"],
     deps = [
         "//protos:marketdata_java_proto",
+        "//src/main/java/com/verlumen/tradestream/instruments:currency_pair",
         "//src/main/java/com/verlumen/tradestream/marketdata:candle_stream_with_defaults",
         "//third_party:beam_sdks_java_core",
         "//third_party:beam_sdks_java_extensions_protobuf",

--- a/src/test/java/com/verlumen/tradestream/marketdata/CandleStreamWithDefaultsTest.java
+++ b/src/test/java/com/verlumen/tradestream/marketdata/CandleStreamWithDefaultsTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
+import java.util.stream.Stream;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.values.KV;
@@ -41,7 +42,7 @@ public class CandleStreamWithDefaultsTest {
                         Duration.standardMinutes(1),
                         Duration.standardSeconds(30),
                         5,
-                        Suppliers.ofInstance(ImmutableList.of("BTC/USD", "ETH/USD")),
+                        Suppliers.ofInstance(Stream.of("BTC/USD", "ETH/USD").map(CurrencyPair::fromSymbol).collect(toImmutableList())),
                         10000.0))
         ).satisfies(iterable -> {
             boolean foundBTC = false;
@@ -71,7 +72,7 @@ public class CandleStreamWithDefaultsTest {
                         Duration.standardMinutes(1),
                         Duration.standardSeconds(30),
                         5,
-                        Suppliers.ofInstance(ImmutableList.of("BTC/USD", "ETH/USD")),
+                        Suppliers.ofInstance(Stream.of("BTC/USD", "ETH/USD").map(CurrencyPair::fromSymbol).collect(toImmutableList())),
                         10000.0))
         ).satisfies(iterable -> {
             int count = 0;
@@ -130,7 +131,7 @@ public class CandleStreamWithDefaultsTest {
                     Duration.standardMinutes(1),
                     Duration.standardSeconds(30),
                     2, // bufferSize = 2
-                    Suppliers.ofInstance(ImmutableList.of("BTC/USD")),
+                    Suppliers.ofInstance(Stream.of("BTC/USD").map(CurrencyPair::fromSymbol).collect(toImmutableList())),
                     10000.0))
         ).satisfies(iterable -> {
             for (KV<String, ImmutableList<Candle>> kv : iterable) {

--- a/src/test/java/com/verlumen/tradestream/marketdata/CandleStreamWithDefaultsTest.java
+++ b/src/test/java/com/verlumen/tradestream/marketdata/CandleStreamWithDefaultsTest.java
@@ -1,10 +1,12 @@
 package com.verlumen.tradestream.marketdata;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
+import com.verlumen.tradestream.instruments.CurrencyPair;
 import java.util.stream.Stream;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;


### PR DESCRIPTION
This change replaces the use of raw `String` symbols for currency pairs with strongly-typed `CurrencyPair` objects within the `CandleStreamWithDefaults` transform and associated test cases.

### Summary of Changes:
- Updated `CandleStreamWithDefaults` constructor to accept `Supplier<List<CurrencyPair>>` instead of `Supplier<List<String>>`.
- Modified pipeline logic to extract currency pair symbols via `CurrencyPair::symbol` before creating keys.
- Updated test code to construct `CurrencyPair` instances using `CurrencyPair.fromSymbol(...)`.
- Adjusted Bazel build targets to include the `currency_pair` dependency.

This refactor improves type safety and consistency when handling currency pair data across the system.

(MINOR) – Introduces a backward-compatible improvement by using a dedicated data structure.