### PR TITLE
chore(ci): update Bazel setup action to v0.14.0

### DIFF
--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: bazel-contrib/setup-bazel@0.9.1
+    - uses: bazel-contrib/setup-bazel@0.14.0
       with:
         # Avoid downloading Bazel every time.
         bazelisk-cache: true


### PR DESCRIPTION
This PR updates the GitHub Actions workflow for Bazel testing by upgrading the `bazel-contrib/setup-bazel` action from version `0.9.1` to `0.14.0`.  

### Context
- Ensures compatibility with newer Bazel versions and benefits from recent improvements and bug fixes in the setup-bazel action.
- No changes to the build or test logic itself; this is an infrastructure maintenance update.
