### PR TITLE
Integrate BuildBuddy Remote Caching and Enhance Bazel Build Settings (MINOR)

### DIFF
--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -15,10 +15,13 @@ jobs:
       with:
         # Avoid downloading Bazel every time.
         bazelisk-cache: true
-        # Store build cache per workflow.
-        disk-cache: ${{ github.workflow }}
-        # Share repository cache between workflows.
-        repository-cache: true
+        bazelrc: |
+          build --color=yes
+          build --show_timestamps
+          build --bes_results_url=https://app.buildbuddy.io/invocation/
+          build --bes_backend=grpcs://remote.buildbuddy.io
+          build --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }}
+
     - run: |
         bazel test //... \
           --experimental_ui_max_stdouterr_bytes=2097152 \

--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -29,4 +29,5 @@ jobs:
           --test_output=all \
           --verbose_failures \
           --nolegacy_important_outputs \
-          --experimental_remote_cache_compression
+          --experimental_remote_cache_compression \
+          --experimental_remote_cache_compression_threshold=100

--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -16,8 +16,6 @@ jobs:
         # Avoid downloading Bazel every time.
         bazelisk-cache: true
         bazelrc: |
-          build --color=yes
-          build --show_timestamps
           build --bes_results_url=https://app.buildbuddy.io/invocation/
           build --bes_backend=grpcs://remote.buildbuddy.io
           build --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }}

--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -18,6 +18,9 @@ jobs:
         bazelrc: |
           build --bes_results_url=https://app.buildbuddy.io/invocation/
           build --bes_backend=grpcs://remote.buildbuddy.io
+          build --remote_cache=grpcs://remote.buildbuddy.io
+          build --noremote_upload_local_results # Uploads logs & artifacts without writing to cache
+          build --remote_timeout=10m
           build --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }}
 
     - run: |

--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -28,4 +28,5 @@ jobs:
           --experimental_ui_max_stdouterr_bytes=2097152 \
           --test_output=all \
           --verbose_failures \
-          --nolegacy_important_outputs
+          --nolegacy_important_outputs \
+          --experimental_remote_cache_compression

--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -27,4 +27,5 @@ jobs:
         bazel test //... \
           --experimental_ui_max_stdouterr_bytes=2097152 \
           --test_output=all \
-          --verbose_failures
+          --verbose_failures \
+          --nolegacy_important_outputs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,8 +38,13 @@ jobs:
       - uses: bazel-contrib/setup-bazel@0.9.1
         with:
           bazelisk-cache: true
-          disk-cache: ${{ github.workflow }}
-          repository-cache: true
+          bazelrc: |
+            build --bes_results_url=https://app.buildbuddy.io/invocation/
+            build --bes_backend=grpcs://remote.buildbuddy.io
+            build --remote_cache=grpcs://remote.buildbuddy.io
+            build --noremote_upload_local_results # Uploads logs & artifacts without writing to cache
+            build --remote_timeout=10m
+            build --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }}
 
       - name: Build and Load Images
         run: |
@@ -48,6 +53,9 @@ jobs:
           # Build and push pipeline image
           bazel run //src/main/java/com/verlumen/tradestream/pipeline:push_image \
             --verbose_failures \
+            --nolegacy_important_outputs \
+            --experimental_remote_cache_compression \
+            --experimental_remote_cache_compression_threshold=100 \
             -- \
             --repository localhost:5000/tradestream-data-pipeline \
             --tag "latest"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,16 +53,22 @@ jobs:
         with:
           # Avoid downloading Bazel every time
           bazelisk-cache: true
-          # Store build cache per workflow
-          disk-cache: ${{ github.workflow }}
-          # Share repository cache between workflows
-          repository-cache: true
+          bazelrc: |
+            build --bes_results_url=https://app.buildbuddy.io/invocation/
+            build --bes_backend=grpcs://remote.buildbuddy.io
+            build --remote_cache=grpcs://remote.buildbuddy.io
+            build --noremote_upload_local_results # Uploads logs & artifacts without writing to cache
+            build --remote_timeout=10m
+            build --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }}
 
       - name: Push the Pipeline image
         run: |
           bazel run //src/main/java/com/verlumen/tradestream/pipeline:push_image \
             --verbose_failures \
             --sandbox_debug \
+            --nolegacy_important_outputs \
+            --experimental_remote_cache_compression \
+            --experimental_remote_cache_compression_threshold=100 \
             -- \
             --tag ${{ steps.version.outputs.version_tag }}
 


### PR DESCRIPTION
This PR updates the Bazel configurations across GitHub Actions workflows (`bazel-test.yaml`, `ci.yaml`, and `release.yaml`) to integrate BuildBuddy remote caching and results reporting. It also improves Bazel build reliability and performance through additional build flags.

### Changes
- Replaced local disk and repository cache settings with BuildBuddy remote caching integration via `.bazelrc` entries:
  - Configured `--remote_cache` and `--bes_backend` with BuildBuddy endpoints.
  - Enabled log and artifact uploads without remote cache writes.
  - Set remote timeout and authentication header using a GitHub secret (`BUILDBUDDY_API_KEY`).
- Added Bazel build optimizations:
  - `--nolegacy_important_outputs`
  - `--experimental_remote_cache_compression`
  - `--experimental_remote_cache_compression_threshold=100`
- Applied these updates uniformly across `bazel-test.yaml`, `ci.yaml`, and `release.yaml` workflows.

### Context
The transition to BuildBuddy enables centralized build results, faster incremental builds through remote caching, and better observability of build/test runs. The additional experimental flags aim to further reduce cache size and improve Bazel execution efficiency.
