### PR TITLE
Improve Bazel build/test configuration and clean up obsolete test target

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -8,3 +8,10 @@ build --tool_java_language_version=17
 
 # Enable platform-based toolchain resolution
 build --incompatible_enable_cc_toolchain_resolution
+
+test --experimental_ui_max_stdouterr_bytes=2097152
+test --test_output=all
+test --verbose_failures
+test --nolegacy_important_outputs
+test --experimental_remote_cache_compression
+test --experimental_remote_cache_compression_threshold=100

--- a/.bazelrc
+++ b/.bazelrc
@@ -9,6 +9,9 @@ build --tool_java_language_version=17
 # Enable platform-based toolchain resolution
 build --incompatible_enable_cc_toolchain_resolution
 
+build --verbose_failures
+build --sandbox_debug
+
 test --experimental_ui_max_stdouterr_bytes=2097152
 test --test_output=all
 test --verbose_failures

--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -20,7 +20,4 @@ jobs:
         # Share repository cache between workflows.
         repository-cache: true
     - run: |
-        bazel test //... \
-          --experimental_ui_max_stdouterr_bytes=2097152 \
-          --test_output=all \
-          --verbose_failures
+        bazel test //...

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,6 @@ jobs:
 
           # Build and push pipeline image
           bazel run //src/main/java/com/verlumen/tradestream/pipeline:push_image \
-            --verbose_failures \
             -- \
             --repository localhost:5000/tradestream-data-pipeline \
             --tag "latest"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,8 +61,6 @@ jobs:
       - name: Push the Pipeline image
         run: |
           bazel run //src/main/java/com/verlumen/tradestream/pipeline:push_image \
-            --verbose_failures \
-            --sandbox_debug \
             -- \
             --tag ${{ steps.version.outputs.version_tag }}
 

--- a/src/test/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/test/java/com/verlumen/tradestream/marketdata/BUILD
@@ -147,34 +147,3 @@ java_test(
         "//third_party:hamcrest",
     ],
 )
-
-kt_jvm_test(
-    name = "TradeToCandleTest",
-    srcs = ["TradeToCandleTest.kt"],
-    test_class = "com.verlumen.tradestream.marketdata.TradeToCandleTest",
-    deps = [
-        "//protos:marketdata_java_proto",
-        "//src/main/java/com/verlumen/tradestream/instruments:currency_pair",
-        "//src/main/java/com/verlumen/tradestream/marketdata:candle_creator_fn", # Still needed by TradeToCandle
-        "//src/main/java/com/verlumen/tradestream/marketdata:market_data_module", # For Guice setup
-        "//src/main/java/com/verlumen/tradestream/marketdata:trade_to_candle",
-        "//third_party:beam_sdks_java_core",
-        "//third_party:beam_sdks_java_extensions_protobuf", # For ProtoCoder
-        "//third_party:beam_sdks_java_test_utils",
-        "//third_party:flogger",
-        "//third_party:guava",
-        "//third_party:guice",
-        "//third_party:guice_assistedinject", # For TradeToCandle factory
-        "//third_party:guice_testlib",
-        "//third_party:joda_time",
-        "//third_party:junit",
-        "//third_party:mockito_core",
-        "//third_party:protobuf_java",
-        "//third_party:protobuf_java_util",
-        "//third_party:truth",
-    ],
-    runtime_deps = [
-        "//third_party:beam_runners_direct_java",
-        "//third_party:hamcrest",
-    ],
-)


### PR DESCRIPTION
### Summary of Changes
- Enhanced `.bazelrc` with additional build and test flags for improved debugging and caching:
  - Added `--verbose_failures`, `--sandbox_debug`, `--test_output=all`, `--experimental_ui_max_stdouterr_bytes`, and remote cache compression flags.
- Cleaned up GitHub Actions workflows:
  - Removed redundant Bazel flags (`--verbose_failures`, `--sandbox_debug`, etc.) from `bazel-test.yaml`, `ci.yaml`, and `release.yaml` since they are now configured globally via `.bazelrc`.
- Removed obsolete Kotlin test target `TradeToCandleTest` from `marketdata/BUILD`.

### Context
These updates centralize Bazel configuration for better maintainability and simplify CI workflows by reducing duplicated flag definitions. The `TradeToCandleTest` was removed as it appears to no longer be in use or necessary.
