### PR TITLE
Remove unused CandleStreamWithDefaults import and dependency

### DIFF
--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -13,7 +13,6 @@ import com.google.protobuf.util.Timestamps;
 import com.verlumen.tradestream.execution.RunMode;
 import com.verlumen.tradestream.instruments.CurrencyPair;
 import com.verlumen.tradestream.marketdata.Candle;
-import com.verlumen.tradestream.marketdata.CandleStreamWithDefaults;
 import com.verlumen.tradestream.marketdata.MultiTimeframeCandleTransform;
 import com.verlumen.tradestream.marketdata.Trade;
 import com.verlumen.tradestream.marketdata.TradeSource;

--- a/src/main/java/com/verlumen/tradestream/pipeline/BUILD
+++ b/src/main/java/com/verlumen/tradestream/pipeline/BUILD
@@ -19,7 +19,6 @@ java_binary(
         "//protos:marketdata_java_proto",
         "//src/main/java/com/verlumen/tradestream/execution:run_mode",
         "//src/main/java/com/verlumen/tradestream/instruments:currency_pair",
-        "//src/main/java/com/verlumen/tradestream/marketdata:candle_stream_with_defaults",
         "//src/main/java/com/verlumen/tradestream/marketdata:multi_timeframe_candle_transform",
         "//src/main/java/com/verlumen/tradestream/marketdata:trade_source",
         "//src/main/java/com/verlumen/tradestream/strategies:strategy_engine_pipeline",


### PR DESCRIPTION
This PR removes the unused `CandleStreamWithDefaults` import from `App.java` and cleans up the corresponding build dependency in `BUILD`.  
No functional changes were made to the application. This is a simple cleanup to improve code hygiene and maintain an accurate build specification.
