### PR TITLE
Add TradeToCandle Transform to Pipeline for 1-Minute Candle Aggregation (MINOR)

### DIFF
--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -45,7 +45,7 @@ public final class App {
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
   private static final String CMC_API_KEY_ENV_VAR = "COINMARKETCAP_API_KEY";
-  private static final Duration ONE_MINUTE = Duration.standardMinutes(1)
+  private static final Duration ONE_MINUTE = Duration.standardMinutes(1);
 
   public interface Options extends StreamingOptions {
     @Description("Comma-separated list of Kafka bootstrap servers.")

--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -45,6 +45,7 @@ public final class App {
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
   private static final String CMC_API_KEY_ENV_VAR = "COINMARKETCAP_API_KEY";
+  private static final Duration ONE_MINUTE = Duration.standardMinutes(1)
 
   public interface Options extends StreamingOptions {
     @Description("Comma-separated list of Kafka bootstrap servers.")

--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -119,6 +119,12 @@ public final class App {
                     })
                 .withAllowedTimestampSkew(timingConfig.allowedTimestampSkew()));
 
+    // 3. Create candles from trades.
+    PCollection<Candle> candles = tradesWithTimestamps.apply(
+        "Create Candle"
+        tradeToCandleFactory.create(ONE_MINUTE)
+    );
+
     logger.atInfo().log("Pipeline building complete. Returning pipeline.");
     return pipeline;
   }

--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -120,7 +120,7 @@ public final class App {
                 .withAllowedTimestampSkew(timingConfig.allowedTimestampSkew()));
 
     // 3. Create candles from trades.
-    PCollection<Candle> candles = tradesWithTimestamps.apply(
+    PCollection<KV<String, Candle>> candles = tradesWithTimestamps.apply(
         "Create Candle",
         tradeToCandleFactory.create(ONE_MINUTE)
     );

--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -16,6 +16,7 @@ import com.verlumen.tradestream.marketdata.Candle;
 import com.verlumen.tradestream.marketdata.MultiTimeframeCandleTransform;
 import com.verlumen.tradestream.marketdata.Trade;
 import com.verlumen.tradestream.marketdata.TradeSource;
+import com.verlumen.tradestream.marketdata.TradeToCandle;
 import com.verlumen.tradestream.strategies.StrategyEnginePipeline;
 import java.util.List;
 import java.util.function.Supplier;

--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -82,17 +82,20 @@ public final class App {
   private final StrategyEnginePipeline strategyEnginePipeline;
   private final TimingConfig timingConfig;
   private final TradeSource tradeSource;
+  private final TradeToCandle.Factory tradeToCandleFactory;
 
   @Inject
   App(
       Supplier<List<CurrencyPair>> currencyPairs,
       StrategyEnginePipeline strategyEnginePipeline,
       TimingConfig timingConfig,
-      TradeSource tradeSource) {
+      TradeSource tradeSource,
+      TradeToCandle.Factory tradeToCandleFactory) {
     this.currencyPairs = currencyPairs;
     this.strategyEnginePipeline = strategyEnginePipeline;
     this.timingConfig = timingConfig;
     this.tradeSource = tradeSource;
+    this.tradeToCandleFactory = tradeToCandleFactory;
   }
 
   /** Build the Beam pipeline, integrating all components. */

--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -121,7 +121,7 @@ public final class App {
 
     // 3. Create candles from trades.
     PCollection<Candle> candles = tradesWithTimestamps.apply(
-        "Create Candle"
+        "Create Candle",
         tradeToCandleFactory.create(ONE_MINUTE)
     );
 

--- a/src/main/java/com/verlumen/tradestream/pipeline/BUILD
+++ b/src/main/java/com/verlumen/tradestream/pipeline/BUILD
@@ -21,6 +21,7 @@ java_binary(
         "//src/main/java/com/verlumen/tradestream/instruments:currency_pair",
         "//src/main/java/com/verlumen/tradestream/marketdata:multi_timeframe_candle_transform",
         "//src/main/java/com/verlumen/tradestream/marketdata:trade_source",
+        "//src/main/java/com/verlumen/tradestream/marketdata:trade_to_candle",
         "//src/main/java/com/verlumen/tradestream/strategies:strategy_engine_pipeline",
         "//third_party:beam_runners_flink_java",
         "//third_party:beam_sdks_java_core",

--- a/src/main/java/com/verlumen/tradestream/pipeline/container-structure-test.yaml
+++ b/src/main/java/com/verlumen/tradestream/pipeline/container-structure-test.yaml
@@ -10,4 +10,4 @@ commandTests:
       - '--runMode=dry'
     expectedError:
       - 'DRY/RUN'
-      - '.*Starting TradeToCandle transform \(Combine\.perKey version\) with window duration: PT60S'
+      - 'Starting TradeToCandle transform \(Combine\.perKey version\) with window duration: PT60S'

--- a/src/main/java/com/verlumen/tradestream/pipeline/container-structure-test.yaml
+++ b/src/main/java/com/verlumen/tradestream/pipeline/container-structure-test.yaml
@@ -10,3 +10,4 @@ commandTests:
       - '--runMode=dry'
     expectedError:
       - 'DRY/RUN'
+      - "Starting TradeToCandle transform (Combine.perKey version) with window duration: %s"

--- a/src/main/java/com/verlumen/tradestream/pipeline/container-structure-test.yaml
+++ b/src/main/java/com/verlumen/tradestream/pipeline/container-structure-test.yaml
@@ -10,5 +10,4 @@ commandTests:
       - '--runMode=dry'
     expectedError:
       - 'DRY/RUN'
-    expectedOutput:
       - "INFO: Starting TradeToCandle transform (Combine.perKey version) with window duration: PT60S"

--- a/src/main/java/com/verlumen/tradestream/pipeline/container-structure-test.yaml
+++ b/src/main/java/com/verlumen/tradestream/pipeline/container-structure-test.yaml
@@ -10,4 +10,4 @@ commandTests:
       - '--runMode=dry'
     expectedError:
       - 'DRY/RUN'
-      - "Starting TradeToCandle transform (Combine.perKey version) with window duration: %s"
+      - "Starting TradeToCandle transform (Combine.perKey version) with window duration: PT60S"

--- a/src/main/java/com/verlumen/tradestream/pipeline/container-structure-test.yaml
+++ b/src/main/java/com/verlumen/tradestream/pipeline/container-structure-test.yaml
@@ -10,4 +10,5 @@ commandTests:
       - '--runMode=dry'
     expectedError:
       - 'DRY/RUN'
-      - "Starting TradeToCandle transform (Combine.perKey version) with window duration: PT60S"
+    expectedOutput:
+      - "INFO: Starting TradeToCandle transform (Combine.perKey version) with window duration: PT60S"

--- a/src/main/java/com/verlumen/tradestream/pipeline/container-structure-test.yaml
+++ b/src/main/java/com/verlumen/tradestream/pipeline/container-structure-test.yaml
@@ -10,4 +10,4 @@ commandTests:
       - '--runMode=dry'
     expectedError:
       - 'DRY/RUN'
-      - "INFO: Starting TradeToCandle transform (Combine.perKey version) with window duration: PT60S"
+      - '.*Starting TradeToCandle transform \(Combine\.perKey version\) with window duration: PT60S'


### PR DESCRIPTION
### Summary of Changes
- Integrated `TradeToCandle` transformation into the Beam pipeline to aggregate trades into 1-minute candles.
- Injected `TradeToCandle.Factory` into the `App` constructor for configurable candle creation.
- Updated the `BUILD` file to include the `trade_to_candle` target as a dependency.
- Enhanced `container-structure-test.yaml` to validate the expected log output for the new `TradeToCandle` transform.

### Context
This enhancement enables the pipeline to automatically generate and process 1-minute candlestick data from the incoming trade stream, facilitating downstream analytical operations. The change is backward-compatible and introduces new functionality, warranting a (MINOR) version increment.
