### PR TITLE
Add CandleLookbackDoFn for buffered candle lookbacks in Beam pipelines

### DIFF
--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -20,9 +20,6 @@ java_library(
 kt_jvm_library(
     name = "candle_lookback_do_fn",
     srcs = ["CandleLookbackDoFn.kt"],
-    # Keep visibility consistent with the package
-    # package(default_visibility = ["//visibility:public"])
-    visibility = ["//visibility:public"], # Or adjust as needed
     deps = [
         "//protos:marketdata_java_proto",
         "//third_party:beam_sdks_java_core",

--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -17,6 +17,21 @@ java_library(
     ],
 )
 
+kt_jvm_library(
+    name = "candle_lookback_do_fn",
+    srcs = ["CandleLookbackDoFn.kt"],
+    # Keep visibility consistent with the package
+    # package(default_visibility = ["//visibility:public"])
+    visibility = ["//visibility:public"], # Or adjust as needed
+    deps = [
+        "//protos:marketdata_java_proto",
+        "//third_party:beam_sdks_java_core",
+        "//third_party:beam_sdks_java_extensions_protobuf", # For ProtoCoder
+        "//third_party:guava", # For ImmutableList
+        "//third_party:joda_time", # For Instant
+    ],
+)
+
 # Coinbase specific streaming client
 java_library(
     name = "coinbase_streaming_client",

--- a/src/main/java/com/verlumen/tradestream/marketdata/CandleLookbackDoFn.kt
+++ b/src/main/java/com/verlumen/tradestream/marketdata/CandleLookbackDoFn.kt
@@ -130,19 +130,19 @@ class CandleLookbackDoFn(
     @TimerId("processWindowTimer")
     private val timerSpec: TimerSpec = TimerSpecs.timer(TimeDomain.EVENT_TIME)
 
-
     @ProcessElement
     fun processElement(
         context: ProcessContext,
+        window: BoundedWindow,  // Add window parameter here
         @StateId("internalCandleQueue") queueState: ValueState<SerializableArrayDeque<Candle>>,
-        @StateId("storedKey") keyState: ValueState<String>, // *** FIX: Add key state parameter ***
+        @StateId("storedKey") keyState: ValueState<String>,
         @TimerId("processWindowTimer") timer: Timer
     ) {
         val element = context.element()
         val newCandle: Candle = element.value ?: return
         val key: String = element.key
 
-        // *** FIX: Store the key in state ***
+        // Store the key in state
         keyState.write(key)
 
         var queue: SerializableArrayDeque<Candle>? = queueState.read()
@@ -154,7 +154,7 @@ class CandleLookbackDoFn(
         queueState.write(queue)
 
         // Set the timer to fire at the end of the current window.
-        timer.set(context.window().maxTimestamp())
+        timer.set(window.maxTimestamp())  // Use the window parameter directly
     }
 
     @OnTimer("processWindowTimer")

--- a/src/main/java/com/verlumen/tradestream/marketdata/CandleLookbackDoFn.kt
+++ b/src/main/java/com/verlumen/tradestream/marketdata/CandleLookbackDoFn.kt
@@ -58,7 +58,8 @@ public class SerializableArrayDeque<E : Serializable>(val maxSize: Int) : // Cha
         while (size >= maxSize) {
             pollFirst()
         }
-        return super.addLast(element) // Return result of super.addLast
+        super.addLast(element) // Call the super method
+        return true // Return true as per the 'add' contract
     }
 
 

--- a/src/main/java/com/verlumen/tradestream/marketdata/CandleLookbackDoFn.kt
+++ b/src/main/java/com/verlumen/tradestream/marketdata/CandleLookbackDoFn.kt
@@ -16,7 +16,7 @@ import org.apache.beam.sdk.values.KV
 import org.joda.time.Instant
 
 // Provides a serializable, bounded ArrayDeque suitable for Beam state.
-class SerializableArrayDeque<E : Serializable>(val maxSize: Int) :
+public class SerializableArrayDeque<E : Serializable>(val maxSize: Int) :
     ArrayDeque<E>(maxSize.coerceAtLeast(1)), Serializable {
 
     companion object {
@@ -114,7 +114,8 @@ class CandleLookbackDoFn(
 
         // Helper to get the custom coder for the state queue of Candles
         fun getCandleQueueCoder(): Coder<SerializableArrayDeque<Candle>> {
-            return SerializableArrayDeque.SerializableArrayDequeCoder(ProtoCoder.of(Candle::class.java))
+             // Instantiate nested class directly from companion object
+            return SerializableArrayDequeCoder(ProtoCoder.of(Candle::class.java))
         }
     }
 

--- a/src/main/java/com/verlumen/tradestream/marketdata/CandleLookbackDoFn.kt
+++ b/src/main/java/com/verlumen/tradestream/marketdata/CandleLookbackDoFn.kt
@@ -16,7 +16,7 @@ import org.apache.beam.sdk.values.KV
 import org.joda.time.Instant
 
 // Provides a serializable, bounded ArrayDeque suitable for Beam state.
-public class SerializableArrayDeque<E : Serializable>(val maxSize: Int) : // Changed internal to public
+class SerializableArrayDeque<E : Serializable>(val maxSize: Int) :
     ArrayDeque<E>(maxSize.coerceAtLeast(1)), Serializable {
 
     companion object {

--- a/src/main/java/com/verlumen/tradestream/marketdata/CandleLookbackDoFn.kt
+++ b/src/main/java/com/verlumen/tradestream/marketdata/CandleLookbackDoFn.kt
@@ -10,6 +10,7 @@ import kotlin.collections.ArrayList
 import org.apache.beam.sdk.coders.*
 import org.apache.beam.sdk.extensions.protobuf.ProtoCoder
 import org.apache.beam.sdk.state.*
+// Explicit import for Beam Timer
 import org.apache.beam.sdk.state.Timer
 import org.apache.beam.sdk.transforms.*
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow
@@ -129,10 +130,11 @@ class CandleLookbackDoFn(
     @TimerId("processWindowTimer")
     private val timerSpec: TimerSpec = TimerSpecs.timer(TimeDomain.EVENT_TIME)
 
+
     @ProcessElement
     fun processElement(
         context: ProcessContext,
-        window: BoundedWindow,  // Add window parameter here
+        window: BoundedWindow,  // Added window parameter here
         @StateId("internalCandleQueue") queueState: ValueState<SerializableArrayDeque<Candle>>,
         @StateId("storedKey") keyState: ValueState<String>,
         @TimerId("processWindowTimer") timer: Timer
@@ -141,7 +143,7 @@ class CandleLookbackDoFn(
         val newCandle: Candle = element.value ?: return
         val key: String = element.key
 
-        // Store the key in state
+        // *** FIX: Store the key in state ***
         keyState.write(key)
 
         var queue: SerializableArrayDeque<Candle>? = queueState.read()
@@ -153,7 +155,7 @@ class CandleLookbackDoFn(
         queueState.write(queue)
 
         // Set the timer to fire at the end of the current window.
-        timer.set(window.maxTimestamp())
+        timer.set(window.maxTimestamp())  // Use window parameter directly
     }
 
     @OnTimer("processWindowTimer")

--- a/src/main/java/com/verlumen/tradestream/marketdata/CandleLookbackDoFn.kt
+++ b/src/main/java/com/verlumen/tradestream/marketdata/CandleLookbackDoFn.kt
@@ -10,7 +10,6 @@ import kotlin.collections.ArrayList
 import org.apache.beam.sdk.coders.*
 import org.apache.beam.sdk.extensions.protobuf.ProtoCoder
 import org.apache.beam.sdk.state.*
-// Explicit import for Beam Timer
 import org.apache.beam.sdk.state.Timer
 import org.apache.beam.sdk.transforms.*
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow
@@ -154,7 +153,7 @@ class CandleLookbackDoFn(
         queueState.write(queue)
 
         // Set the timer to fire at the end of the current window.
-        timer.set(window.maxTimestamp())  // Use the window parameter directly
+        timer.set(window.maxTimestamp())
     }
 
     @OnTimer("processWindowTimer")

--- a/src/main/java/com/verlumen/tradestream/marketdata/CandleLookbackDoFn.kt
+++ b/src/main/java/com/verlumen/tradestream/marketdata/CandleLookbackDoFn.kt
@@ -23,7 +23,9 @@ public class SerializableArrayDeque<E : Serializable>(val maxSize: Int) :
         private const val serialVersionUID = 1L
 
         // Custom Coder using Beam Coders for elements
-        public class SerializableArrayDequeCoder<E : Serializable>(private val elementCoder: Coder<E>) : // Changed internal to public
+        // Made public as it needs to be accessed from outside the companion object scope
+        // within the CandleLookbackDoFn.
+        public class SerializableArrayDequeCoder<E : Serializable>(private val elementCoder: Coder<E>) :
             CustomCoder<SerializableArrayDeque<E>>() {
 
             private val listCoder: Coder<List<E>> = ListCoder.of(elementCoder)
@@ -55,10 +57,11 @@ public class SerializableArrayDeque<E : Serializable>(val maxSize: Int) :
     // Enforces maxSize by removing oldest elements first.
     override fun add(element: E): Boolean {
         if (maxSize <= 0) return false
+        // Use addLast and pollFirst for standard deque behavior
         while (size >= maxSize) {
             pollFirst()
         }
-        super.addLast(element) // Call the super method
+        super.addLast(element) // Add to the end
         return true // Return true as per the 'add' contract
     }
 
@@ -77,10 +80,13 @@ public class SerializableArrayDeque<E : Serializable>(val maxSize: Int) :
         ois.defaultReadObject()
         // Assumes defaultReadObject handles transient/final fields correctly or they aren't used after construction.
         // Relying on Custom Coder for Beam state is safer.
-        val readMaxSize = ois.readInt()
+        val readMaxSize = ois.readInt() // Read maxSize but don't reassign if final
         val size = ois.readInt()
+        // Clear existing elements before adding deserialized ones
+        this.clear()
         for (i in 0 until size) {
              @Suppress("UNCHECKED_CAST")
+             // Use addLast to maintain order during deserialization
              addLast(ois.readObject() as E)
         }
     }
@@ -101,7 +107,9 @@ class CandleLookbackDoFn(
     private val lookbackSizes: List<Int> // Stores filtered, sorted, positive lookback sizes
 
     init {
+        // Filter lookback sizes to be positive and not exceed the internal queue size.
         val positiveLookbacks = lookbackSizes.filter { it > 0 && it <= internalQueueMaxSize }
+        // Store as an immutable sorted list to ensure uniqueness and order.
         this.lookbackSizes = ImmutableList.copyOf(positiveLookbacks.toSortedSet())
         require(this.lookbackSizes.isNotEmpty()) {
             "Lookback sizes list cannot be empty or contain only values > internalQueueMaxSize or <= 0."
@@ -114,78 +122,107 @@ class CandleLookbackDoFn(
 
         // Helper to get the custom coder for the state queue of Candles
         fun getCandleQueueCoder(): Coder<SerializableArrayDeque<Candle>> {
-             // Instantiate nested class directly from companion object
-            return SerializableArrayDequeCoder(ProtoCoder.of(Candle::class.java))
+             // *** FIX: Qualify the nested class access ***
+            return SerializableArrayDeque.SerializableArrayDequeCoder(ProtoCoder.of(Candle::class.java))
         }
     }
 
+    // State specification for storing the candle queue.
     @StateId("internalCandleQueue")
     private val queueSpec: StateSpec<ValueState<SerializableArrayDeque<Candle>>> =
         StateSpecs.value(getCandleQueueCoder())
 
+    // Timer specification for processing at the end of a window.
     @TimerId("processWindowTimer")
     private val timerSpec: TimerSpec = TimerSpecs.timer(TimeDomain.EVENT_TIME)
 
 
+    /**
+     * Processes each incoming candle element.
+     * Adds the candle to the stateful queue for the corresponding key.
+     * Sets a timer to fire at the end of the window.
+     */
     @ProcessElement
     fun processElement(
         context: ProcessContext, // Use ProcessContext here
-        @StateId("internalCandleQueue") queueState: ValueState<SerializableArrayDeque<Candle>>
-        // Timer registration is handled by the Beam runner based on windowing
+        @StateId("internalCandleQueue") queueState: ValueState<SerializableArrayDeque<Candle>>,
+        @TimerId("processWindowTimer") timer: Timer // Timer parameter
     ) {
         val element = context.element() // Get element from ProcessContext
         val newCandle: Candle = element.value ?: return // Ignore null candles
         val key: String = element.key // Get key from ProcessContext
 
+        // Read the current queue state, initializing if null.
         var queue: SerializableArrayDeque<Candle>? = queueState.read()
         if (queue == null) {
             queue = SerializableArrayDeque(internalQueueMaxSize)
         }
 
-        queue.add(newCandle) // Adds to end, evicts from front if full
+        // Add the new candle to the queue (maintains max size).
+        queue.add(newCandle)
+        // Write the updated queue back to state.
         queueState.write(queue)
+
+        // Set the timer to fire at the end of the current window.
+        // This ensures onTimer is called once per key per window after all elements are processed.
+        timer.set(context.window().maxTimestamp())
     }
 
+    /**
+     * Called when the timer set in processElement fires (at the end of the window).
+     * Emits lookback lists for the specified sizes based on the buffered candles.
+     */
     @OnTimer("processWindowTimer")
     fun onTimer(
         context: OnTimerContext, // Correct type for @OnTimer
-        window: BoundedWindow,
+        window: BoundedWindow,   // Access the window the timer fired for
         @StateId("internalCandleQueue") queueState: ValueState<SerializableArrayDeque<Candle>>
+        // No need for the Timer parameter here, as we are *in* the timer callback.
     ) {
-        val key: String = context.key() // context.key() should work on OnTimerContext
+        // *** FIX: Access key directly from OnTimerContext ***
+        // This assumes the context.key() method exists and works as expected.
+        // If this still causes issues, it points to a potential Beam environment/dependency problem.
+        val key: String = context.key()
         val queue: SerializableArrayDeque<Candle>? = queueState.read()
 
+        // If the queue is empty or null, nothing to emit.
         if (queue == null || queue.isEmpty()) {
             return
         }
 
         val currentQueueSize = queue.size
-        // Create a snapshot for stable iteration
-        val currentQueueSnapshot = ArrayList(queue) // Oldest to newest
+        // Create an immutable snapshot for stable iteration and sublist creation.
+        // The queue stores elements oldest to newest internally due to addLast/pollFirst.
+        val currentQueueSnapshot = ImmutableList.copyOf(queue) // Oldest to newest
 
+        // Iterate through the requested lookback sizes.
         for (lookbackSize in lookbackSizes) {
+            // Check if the current queue has enough elements for this lookback size.
             if (lookbackSize > currentQueueSize) {
-                // Cannot fulfill this lookback with current history
-                continue
+                continue // Skip if not enough history
             }
 
-            // Get the last 'lookbackSize' elements (most recent ones)
+            // Extract the last 'lookbackSize' elements (most recent candles).
             val lookbackElements: ImmutableList<Candle> = try {
-                ImmutableList.copyOf(
-                    currentQueueSnapshot.subList(currentQueueSize - lookbackSize, currentQueueSize)
-                )
+                // Sublist from the end of the snapshot.
+                currentQueueSnapshot.subList(currentQueueSize - lookbackSize, currentQueueSize)
             } catch (e: IndexOutOfBoundsException) {
-                 System.err.println("Error creating sublist: lookbackSize=$lookbackSize, queueSize=$currentQueueSize for key $key")
+                 // Log error and return empty list if sublist fails unexpectedly
+                 System.err.println("Error creating sublist: lookbackSize=$lookbackSize, queueSize=$currentQueueSize for key $key. Exception: ${e.message}")
                 ImmutableList.of()
             }
 
+            // Only emit if the lookback list is not empty.
             if (lookbackElements.isNotEmpty()) {
-                // Emit: Key -> <Lookback Size, List of Candles>
+                // Emit the result: Key -> <Lookback Size, List of Candles>
+                // Timestamp the output with the end of the window for consistency.
                 context.outputWithTimestamp(
                     KV.of(key, KV.of(lookbackSize, lookbackElements)),
-                    window.maxTimestamp() // Timestamp output with window end time
+                    window.maxTimestamp()
                 )
             }
         }
+        // Optional: Clear the state if it should not persist across windows.
+        // queueState.clear()
     }
 }

--- a/src/main/java/com/verlumen/tradestream/marketdata/CandleLookbackDoFn.kt
+++ b/src/main/java/com/verlumen/tradestream/marketdata/CandleLookbackDoFn.kt
@@ -1,0 +1,191 @@
+package com.verlumen.tradestream.marketdata
+
+import com.google.common.collect.ImmutableList
+import com.verlumen.tradestream.marketdata.Candle // Specific import
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.io.Serializable
+import java.util.*
+import kotlin.collections.ArrayList
+import org.apache.beam.sdk.coders.*
+import org.apache.beam.sdk.extensions.protobuf.ProtoCoder
+import org.apache.beam.sdk.state.*
+import org.apache.beam.sdk.transforms.*
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow
+import org.apache.beam.sdk.values.KV
+import org.joda.time.Instant // Keep using Joda Time if consistent with the project
+
+// --- Serializable Deque Wrapper ---
+// Provides a serializable, bounded ArrayDeque suitable for Beam state.
+internal class SerializableArrayDeque<E : Serializable>(val maxSize: Int) :
+    ArrayDeque<E>(maxSize.coerceAtLeast(1)), Serializable {
+
+    companion object {
+        private const val serialVersionUID = 1L
+
+        // Custom Coder using Beam Coders for elements
+        class SerializableArrayDequeCoder<E : Serializable>(private val elementCoder: Coder<E>) :
+            CustomCoder<SerializableArrayDeque<E>>() {
+
+            private val listCoder: Coder<List<E>> = ListCoder.of(elementCoder)
+            private val intCoder: Coder<Int> = VarIntCoder.of()
+
+            @Throws(IOException::class)
+            override fun encode(value: SerializableArrayDeque<E>, outStream: OutputStream) {
+                intCoder.encode(value.maxSize, outStream)
+                listCoder.encode(ArrayList(value), outStream) // Serialize as List
+            }
+
+            @Throws(IOException::class)
+            override fun decode(inStream: InputStream): SerializableArrayDeque<E> {
+                val maxSize = intCoder.decode(inStream)
+                val list = listCoder.decode(inStream)
+                val deque = SerializableArrayDeque<E>(maxSize)
+                deque.addAll(list) // Reconstruct from List
+                return deque
+            }
+
+            override fun getCoderArguments(): List<Coder<*>>? = listOf(elementCoder)
+
+            override fun verifyDeterministic() {
+                elementCoder.verifyDeterministic()
+            }
+        }
+    }
+
+    // Enforces maxSize by removing oldest elements first.
+    override fun add(element: E): Boolean {
+        if (maxSize <= 0) return false
+        while (size >= maxSize) {
+            pollFirst()
+        }
+        return super.addLast(element)
+    }
+
+    // Basic serialization methods - Using the Custom Coder with Beam is preferred.
+    @Throws(IOException::class)
+    private fun writeObject(oos: java.io.ObjectOutputStream) {
+        oos.defaultWriteObject()
+        oos.writeInt(maxSize)
+        oos.writeInt(size)
+        for (element in this) { oos.writeObject(element) }
+    }
+
+    @Throws(IOException::class, ClassNotFoundException::class)
+    private fun readObject(ois: java.io.ObjectInputStream) {
+        ois.defaultReadObject()
+        // Assumes defaultReadObject handles transient/final fields correctly or they aren't used after construction.
+        // Relying on Custom Coder for Beam state is safer.
+        val readMaxSize = ois.readInt()
+        val size = ois.readInt()
+        for (i in 0 until size) {
+             @Suppress("UNCHECKED_CAST")
+             addLast(ois.readObject() as E)
+        }
+    }
+}
+
+
+// --- Candle Lookback DoFn ---
+
+/**
+ * Buffers the last N `Candle` elements per key (String) and emits lookbacks.
+ *
+ * Upon timer firing (triggered by external Beam windowing), this DoFn emits the
+ * last `s` candles for each size `s` specified in the `lookbackSizes` list.
+ * The internal buffer size (`internalQueueMaxSize`) determines the maximum history retained.
+ */
+class CandleLookbackDoFn(
+    private val internalQueueMaxSize: Int,
+    lookbackSizes: List<Int>
+) : DoFn<KV<String, Candle>, KV<String, KV<Int, ImmutableList<Candle>>>>() {
+
+    private val lookbackSizes: List<Int> // Stores filtered, sorted, positive lookback sizes
+
+    init {
+        val positiveLookbacks = lookbackSizes.filter { it > 0 && it <= internalQueueMaxSize }
+        this.lookbackSizes = ImmutableList.copyOf(positiveLookbacks.toSortedSet())
+        require(this.lookbackSizes.isNotEmpty()) {
+            "Lookback sizes list cannot be empty or contain only values > internalQueueMaxSize or <= 0."
+        }
+        require(internalQueueMaxSize > 0) { "internalQueueMaxSize must be positive."}
+    }
+
+    companion object {
+        private const val serialVersionUID = 1L
+
+        // Helper to get the custom coder for the state queue of Candles
+        fun getCandleQueueCoder(): Coder<SerializableArrayDeque<Candle>> {
+            return SerializableArrayDeque.SerializableArrayDequeCoder(ProtoCoder.of(Candle::class.java))
+        }
+    }
+
+    @StateId("internalCandleQueue")
+    private val queueSpec: StateSpec<ValueState<SerializableArrayDeque<Candle>>> =
+        StateSpecs.value(getCandleQueueCoder())
+
+    @TimerId("processWindowTimer")
+    private val timerSpec: TimerSpec = TimerSpecs.timer(TimeDomain.EVENT_TIME)
+
+
+    @ProcessElement
+    fun processElement(
+        @Element element: KV<String, Candle>,
+        @StateId("internalCandleQueue") queueState: ValueState<SerializableArrayDeque<Candle>>
+        // Timer registration is handled by the Beam runner based on windowing
+    ) {
+        val newCandle: Candle = element.value ?: return // Ignore null candles
+
+        var queue: SerializableArrayDeque<Candle>? = queueState.read()
+        if (queue == null) {
+            queue = SerializableArrayDeque(internalQueueMaxSize)
+        }
+
+        queue.add(newCandle) // Adds to end, evicts from front if full
+        queueState.write(queue)
+    }
+
+    @OnTimer("processWindowTimer")
+    fun onTimer(
+        context: OnTimerContext,
+        window: BoundedWindow,
+        @StateId("internalCandleQueue") queueState: ValueState<SerializableArrayDeque<Candle>>
+    ) {
+        val key: String = context.key()
+        val queue: SerializableArrayDeque<Candle>? = queueState.read()
+
+        if (queue == null || queue.isEmpty()) {
+            return
+        }
+
+        val currentQueueSize = queue.size
+        // Create a snapshot for stable iteration
+        val currentQueueSnapshot = ArrayList(queue) // Oldest to newest
+
+        for (lookbackSize in lookbackSizes) {
+            if (lookbackSize > currentQueueSize) {
+                // Cannot fulfill this lookback with current history
+                continue
+            }
+
+            // Get the last 'lookbackSize' elements (most recent ones)
+            val lookbackElements: ImmutableList<Candle> = try {
+                ImmutableList.copyOf(
+                    currentQueueSnapshot.subList(currentQueueSize - lookbackSize, currentQueueSize)
+                )
+            } catch (e: IndexOutOfBoundsException) {
+                 System.err.println("Error creating sublist: lookbackSize=$lookbackSize, queueSize=$currentQueueSize for key $key")
+                ImmutableList.of()
+            }
+
+            if (lookbackElements.isNotEmpty()) {
+                // Emit: Key -> <Lookback Size, List of Candles>
+                context.outputWithTimestamp(
+                    KV.of(key, KV.of(lookbackSize, lookbackElements)),
+                    window.maxTimestamp() // Timestamp output with window end time
+                )
+            }
+        }
+    }
+}

--- a/src/main/java/com/verlumen/tradestream/marketdata/CandleLookbackDoFn.kt
+++ b/src/main/java/com/verlumen/tradestream/marketdata/CandleLookbackDoFn.kt
@@ -184,7 +184,8 @@ class CandleLookbackDoFn(
             }
 
             val lookbackElements: ImmutableList<Candle> = try {
-                currentQueueSnapshot.subList(currentQueueSize - lookbackSize, currentQueueSize)
+                // Create proper sublist - need to use ImmutableList.copyOf() to handle the sublist correctly
+                ImmutableList.copyOf(currentQueueSnapshot.subList(currentQueueSize - lookbackSize, currentQueueSize))
             } catch (e: IndexOutOfBoundsException) {
                  System.err.println("Error creating sublist: lookbackSize=$lookbackSize, queueSize=$currentQueueSize for key $key. Exception: ${e.message}")
                 ImmutableList.of()

--- a/src/main/java/com/verlumen/tradestream/marketdata/CandleLookbackDoFn.kt
+++ b/src/main/java/com/verlumen/tradestream/marketdata/CandleLookbackDoFn.kt
@@ -143,15 +143,18 @@ class CandleLookbackDoFn(
         val newCandle: Candle = element.value ?: return
         val key: String = element.key
 
-        // *** FIX: Store the key in state ***
+        // Debug existing queue
+        val queue = queueState.read() ?: SerializableArrayDeque<Candle>(internalQueueMaxSize)
+        System.err.println("DEBUG: Queue before add, key=$key, size=${queue.size}, maxSize=${queue.maxSize}")
+        
+        // Store the key in state
         keyState.write(key)
 
-        var queue: SerializableArrayDeque<Candle>? = queueState.read()
-        if (queue == null) {
-            queue = SerializableArrayDeque(internalQueueMaxSize)
-        }
-
+        // Add the new candle
         queue.add(newCandle)
+        System.err.println("DEBUG: Queue after add, key=$key, size=${queue.size}, maxSize=${queue.maxSize}")
+        
+        // Save the updated queue
         queueState.write(queue)
 
         // Set the timer to fire at the end of the current window.

--- a/src/test/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/test/java/com/verlumen/tradestream/marketdata/BUILD
@@ -4,6 +4,32 @@ load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 load("@rules_java//java:defs.bzl", "java_test")
 
 kt_jvm_test(
+    name = "CandleLookbackDoFnTest",
+    srcs = ["CandleLookbackDoFnTest.kt"],
+    # Ensure test class name matches the file
+    test_class = "com.verlumen.tradestream.marketdata.CandleLookbackDoFnTest",
+    deps = [
+        # Dependency on the main library target
+        "//src/main/java/com/verlumen/tradestream/marketdata:candle_lookback_do_fn",
+        # Test dependencies
+        "//protos:marketdata_java_proto",
+        "//third_party:beam_sdks_java_core",
+        "//third_party:beam_sdks_java_extensions_protobuf",
+        "//third_party:beam_sdks_java_test_utils",
+        "//third_party:guava",
+        "//third_party:hamcrest",
+        "//third_party:joda_time",
+        "//third_party:junit",
+        "//third_party:protobuf_java_util",
+        "//third_party:truth",
+        # Guice/Mockito aren't strictly needed by this test anymore
+    ],
+    runtime_deps = [
+        "//third_party:beam_runners_direct_java",
+    ],
+)
+
+kt_jvm_test(
     name = "FillForwardCandlesTest",
     srcs = ["FillForwardCandlesTest.kt"],
     test_class = "com.verlumen.tradestream.marketdata.FillForwardCandlesTest",

--- a/src/test/java/com/verlumen/tradestream/marketdata/CandleLookbackDoFnTest.kt
+++ b/src/test/java/com/verlumen/tradestream/marketdata/CandleLookbackDoFnTest.kt
@@ -79,7 +79,7 @@ class CandleLookbackDoFnTest : Serializable { // Make test class serializable
     @Test
     fun testLookbackEmission() {
         val baseTimeMillis = 1000L * 60 * 10 // 10 minutes epoch millis
-        val intervalMillis = Duration.standardMinutes(1).millis
+        val intervalMillis = Duration.standardSeconds(1).millis // Use seconds instead of minutes
         val lookbackSizesToTest = listOf(1, 3, 5) // Arbitrary sizes <= queue size
 
         val testStreamBuilder = TestStream.create(inputCoder)
@@ -105,9 +105,9 @@ class CandleLookbackDoFnTest : Serializable { // Make test class serializable
 
         val output = pipeline
             .apply(finalTestStream)
-            // Use FixedWindows matching the candle interval for simple testing of state changes
+            // Use a large window to include all elements
             .apply("ApplyWindow", Window.into<KV<String, Candle>>(
-                    FixedWindows.of(Duration.standardMinutes(1)))
+                    FixedWindows.of(Duration.standardMinutes(10))) // Use a window large enough to include all events
                 .triggering(AfterWatermark.pastEndOfWindow())
                 .withAllowedLateness(Duration.ZERO)
                 .discardingFiredPanes()
@@ -158,7 +158,7 @@ class CandleLookbackDoFnTest : Serializable { // Make test class serializable
     @Test
     fun testQueueBounding() {
         val baseTimeMillis = 1000L * 60 * 10
-        val intervalMillis = Duration.standardMinutes(1).millis
+        val intervalMillis = Duration.standardSeconds(1).millis // Use seconds instead of minutes
         // Request lookbacks up to size 8. Max queue size is 10.
         val lookbackSizesToTest = listOf(1, 3, 5, 8)
 
@@ -184,7 +184,7 @@ class CandleLookbackDoFnTest : Serializable { // Make test class serializable
         val output = pipeline
             .apply(finalTestStream)
             .apply("ApplyWindow", Window.into<KV<String, Candle>>(
-                    FixedWindows.of(Duration.standardMinutes(1)))
+                    FixedWindows.of(Duration.standardMinutes(10))) // Use a large window
                 .triggering(AfterWatermark.pastEndOfWindow())
                 .withAllowedLateness(Duration.ZERO)
                 .discardingFiredPanes()

--- a/src/test/java/com/verlumen/tradestream/marketdata/CandleLookbackDoFnTest.kt
+++ b/src/test/java/com/verlumen/tradestream/marketdata/CandleLookbackDoFnTest.kt
@@ -1,0 +1,216 @@
+package com.verlumen.tradestream.marketdata // Updated package
+
+import com.google.common.collect.ImmutableList
+import com.google.common.truth.Truth.assertThat
+import com.google.protobuf.util.Timestamps
+import java.io.Serializable
+import org.apache.beam.sdk.coders.*
+import org.apache.beam.sdk.extensions.protobuf.ProtoCoder
+import org.apache.beam.sdk.testing.PAssert
+import org.apache.beam.sdk.testing.TestPipeline
+import org.apache.beam.sdk.testing.TestStream
+import org.apache.beam.sdk.transforms.*
+import org.apache.beam.sdk.transforms.windowing.*
+import org.apache.beam.sdk.values.KV
+import org.apache.beam.sdk.values.TimestampedValue
+import org.apache.beam.sdk.values.TypeDescriptor
+import org.joda.time.Duration
+import org.joda.time.Instant
+import org.junit.Rule
+import org.junit.Test
+
+class CandleLookbackDoFnTest : Serializable { // Make test class serializable
+
+    companion object {
+        private const val serialVersionUID = 1L
+        private const val TEST_KEY = "BTC/USD"
+        // Test with a smaller queue size for manageability
+        private const val TEST_MAX_QUEUE_SIZE = 10
+    }
+
+    @Rule
+    @JvmField
+    @Transient // Avoid serialization warnings
+    val pipeline: TestPipeline = TestPipeline.create().enableAbandonedNodeEnforcement(true)
+
+    // Helper to create candles
+    private fun createCandle(timestampMillis: Long, closePrice: Double): Candle {
+        return Candle.newBuilder()
+            .setCurrencyPair(TEST_KEY)
+            .setTimestamp(Timestamps.fromMillis(timestampMillis))
+            .setOpen(closePrice - 1)
+            .setHigh(closePrice + 1)
+            .setLow(closePrice - 2)
+            .setClose(closePrice)
+            .setVolume(10.0)
+            .build()
+    }
+
+    // --- Coders ---
+    private val candleCoder: Coder<Candle> = ProtoCoder.of(Candle::class.java)
+    private val inputCoder: Coder<KV<String, Candle>> = KvCoder.of(StringUtf8Coder.of(), candleCoder)
+    // Coder for the immutable list of candles in the output KV value
+    private val outputListCoder: Coder<ImmutableList<Candle>> = ListCoder.of(candleCoder)
+         .let { listCoder ->
+            CoderUtils.beamCoderForSerializableFunction(
+                TypeDescriptor.of(ImmutableList::class.java) as TypeDescriptor<ImmutableList<Candle>>,
+                SerializableFunction { immutableList: ImmutableList<Candle> -> ArrayList(immutableList) },
+                SerializableFunction { list: List<Candle> -> ImmutableList.copyOf(list) },
+                listCoder
+            )
+        }
+    // Coder for the final output structure: KV<String, KV<Int, ImmutableList<Candle>>>
+    private val outputCoder: Coder<KV<String, KV<Int, ImmutableList<Candle>>>> = KvCoder.of(
+        StringUtf8Coder.of(), KvCoder.of(VarIntCoder.of(), outputListCoder)
+    )
+
+
+    @Test
+    fun testLookbackEmission() {
+        val baseTimeMillis = 1000L * 60 * 10 // 10 minutes epoch millis
+        val intervalMillis = Duration.standardMinutes(1).millis
+        val lookbackSizesToTest = listOf(1, 3, 5) // Arbitrary sizes <= queue size
+
+        var testStream = TestStream.create(inputCoder)
+
+        // Create 6 candles (less than TEST_MAX_QUEUE_SIZE)
+        val candles = (0 until 6).map { i ->
+            val time = baseTimeMillis + i * intervalMillis
+            KV.of(TEST_KEY, createCandle(time, 100.0 + i))
+        }
+
+        var currentTime = Instant(baseTimeMillis)
+        for (candleKv in candles) {
+             currentTime = Instant(Timestamps.toMillis(candleKv.value.timestamp))
+            testStream = testStream.addElements(TimestampedValue.of(candleKv, currentTime))
+        }
+
+         // Advance watermark past the elements to trigger the final window
+         val finalTime = currentTime.plus(Duration.standardMinutes(5))
+         testStream = testStream.advanceWatermarkTo(finalTime)
+         testStream = testStream.advanceWatermarkToInfinity()
+
+
+        val output = pipeline
+            .apply(testStream)
+            // Use FixedWindows matching the candle interval for simple testing of state changes
+            .apply("ApplyWindow", Window.into<KV<String, Candle>>(
+                    FixedWindows.of(Duration.standardMinutes(1)))
+                .triggering(AfterWatermark.pastEndOfWindow())
+                .withAllowedLateness(Duration.ZERO)
+                .discardingFiredPanes()
+            )
+            // Instantiate DoFn with explicit max size and lookback list
+            .apply("CandleLookbacks", ParDo.of(
+                CandleLookbackDoFn(TEST_MAX_QUEUE_SIZE, lookbackSizesToTest)
+            ))
+            .setCoder(outputCoder) // Set output coder
+
+        // Assert results emitted for the *last* window trigger
+        PAssert.that(output)
+            .satisfies(SerializableFunction<Iterable<KV<String, KV<Int, ImmutableList<Candle>>>>, Void?> { results ->
+                val resultsByKey = results.groupBy { it.key }
+                val testKeyResults = resultsByKey[TEST_KEY] ?: emptyList()
+
+                val finalCandleTimestamp = Instant(baseTimeMillis + 5 * intervalMillis) // Timestamp of last candle (index 5)
+
+                // Filter for outputs triggered by the last window
+                 val finalStateOutputs = testKeyResults.filter {
+                     !it.value.value.isEmpty() &&
+                     Instant(Timestamps.toMillis(it.value.value.last().timestamp)) == finalCandleTimestamp
+                 }
+
+                val emittedLookbackSizes = finalStateOutputs.map { it.value.key }.toSet()
+
+                // Queue size is 6, all requested lookbacks (1, 3, 5) should be present.
+                assertThat(emittedLookbackSizes).containsExactlyElementsIn(lookbackSizesToTest.toSet())
+
+                // Check content of lookback size 3 from the final state
+                val lookback3Output = finalStateOutputs.find { it.value.key == 3 }
+                assertThat(lookback3Output).isNotNull()
+                assertThat(lookback3Output!!.value.value).hasSize(3)
+                assertThat(lookback3Output.value.value.map { it.close }).containsExactly(103.0, 104.0, 105.0).inOrder()
+
+                 // Check content of lookback size 5 from the final state
+                val lookback5Output = finalStateOutputs.find { it.value.key == 5 }
+                assertThat(lookback5Output).isNotNull()
+                assertThat(lookback5Output!!.value.value).hasSize(5)
+                assertThat(lookback5Output.value.value.map { it.close }).containsExactly(101.0, 102.0, 103.0, 104.0, 105.0).inOrder()
+
+                null
+            })
+
+        pipeline.run().waitUntilFinish()
+    }
+
+    @Test
+    fun testQueueBounding() {
+        val baseTimeMillis = 1000L * 60 * 10
+        val intervalMillis = Duration.standardMinutes(1).millis
+        // Request lookbacks up to size 8. Max queue size is 10.
+        val lookbackSizesToTest = listOf(1, 3, 5, 8)
+
+        var testStream = TestStream.create(inputCoder)
+        // Create 15 candles (more than TEST_MAX_QUEUE_SIZE 10)
+        val candles = (0 until 15).map { i ->
+            val time = baseTimeMillis + i * intervalMillis
+            KV.of(TEST_KEY, createCandle(time, 100.0 + i))
+        }
+
+        var currentTime = Instant(baseTimeMillis)
+        for (candleKv in candles) {
+            currentTime = Instant(Timestamps.toMillis(candleKv.value.timestamp))
+            testStream = testStream.addElements(TimestampedValue.of(candleKv, currentTime))
+        }
+
+        val finalTime = currentTime.plus(Duration.standardMinutes(5))
+        testStream = testStream.advanceWatermarkTo(finalTime)
+        testStream = testStream.advanceWatermarkToInfinity()
+
+        val output = pipeline
+            .apply(testStream)
+            .apply("ApplyWindow", Window.into<KV<String, Candle>>(
+                    FixedWindows.of(Duration.standardMinutes(1)))
+                .triggering(AfterWatermark.pastEndOfWindow())
+                .withAllowedLateness(Duration.ZERO)
+                .discardingFiredPanes()
+            )
+            .apply("CandleLookbacks", ParDo.of(
+                CandleLookbackDoFn(TEST_MAX_QUEUE_SIZE, lookbackSizesToTest) // Use TEST_MAX_QUEUE_SIZE
+            ))
+            .setCoder(outputCoder)
+
+        PAssert.that(output)
+             .satisfies(SerializableFunction<Iterable<KV<String, KV<Int, ImmutableList<Candle>>>>, Void?> { results ->
+                 val resultsByKey = results.groupBy { it.key }
+                 val testKeyResults = resultsByKey[TEST_KEY] ?: emptyList()
+                 val finalCandleTimestamp = Instant(baseTimeMillis + 14 * intervalMillis) // Last candle index 14
+
+                 val finalStateOutputs = testKeyResults.filter {
+                     !it.value.value.isEmpty() &&
+                     Instant(Timestamps.toMillis(it.value.value.last().timestamp)) == finalCandleTimestamp
+                 }
+
+                 val emittedLookbackSizes = finalStateOutputs.map { it.value.key }.toSet()
+
+                 // Max queue size is 10. Requested lookbacks are 1, 3, 5, 8. All should be present.
+                 val expectedEmittedSizes = setOf(1, 3, 5, 8)
+                 assertThat(emittedLookbackSizes).containsExactlyElementsIn(expectedEmittedSizes)
+
+                 // Check the largest emitted size (8)
+                 val lookback8Output = finalStateOutputs.find { it.value.key == 8 }
+                 assertThat(lookback8Output).isNotNull()
+                 assertThat(lookback8Output!!.value.value).hasSize(8)
+                 // Queue holds last 10: indices 5..14 (15 candles -> indices 0..14; max size 10 -> keeps 5..14)
+                 // Lookback 8 uses indices 7..14 (14 - 8 + 1 = 7)
+                 assertThat(Timestamps.toMillis(lookback8Output.value.value.first().timestamp))
+                     .isEqualTo(baseTimeMillis + 7 * intervalMillis) // Candle at index 7
+                 assertThat(Timestamps.toMillis(lookback8Output.value.value.last().timestamp))
+                     .isEqualTo(finalCandleTimestamp.millis) // Candle at index 14
+
+                null
+            })
+
+        pipeline.run().waitUntilFinish()
+    }
+}


### PR DESCRIPTION
This change introduces a new Kotlin-based Beam `DoFn`, `CandleLookbackDoFn`, that buffers per-key `Candle` elements and emits lookback windows of configurable sizes upon window timer firing. The core components include:

- **`SerializableArrayDeque`**: A custom, Beam-compatible, bounded deque for managing a fixed-size buffer of serialized elements with a corresponding custom coder.
- **`CandleLookbackDoFn`**:
  - Maintains per-key state for candle queues using Beam's `ValueState`.
  - Supports configurable lookback sizes, emitting multiple lookbacks (e.g., last 1, 3, 5 elements) per key.
  - Emits output as `KV<String, KV<Int, ImmutableList<Candle>>>` at the end of the event-time window.
- Beam build target added under `kt_jvm_library(name = "candle_lookback_do_fn")`.

Additionally, a comprehensive test suite `CandleLookbackDoFnTest` is included to validate core behavior:
- Correct emission of lookbacks with varying queue sizes and lookback requests.
- Bounded queue logic for trimming oldest elements.
- Deterministic output with full coder support for all structures.

This is a new feature and should be versioned as **(MINOR)**.