### PR TITLE
Add configurable candle lookback support using Fibonacci defaults (MINOR)

### DIFF
--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -48,6 +48,14 @@ public final class App {
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
   private static final String CMC_API_KEY_ENV_VAR = "COINMARKETCAP_API_KEY";
+  /**
+   * A constant string holding the Fibonacci sequence values less than 526,000.
+   *
+   * The upper limit (526,000) was chosen as it approximates the number of
+   * minutes in an average Gregorian year (365.25 days).
+   * Calculation: 365.25 days * 24 hours/day * 60 minutes/hour = 525,960 minutes.
+   */
+  private static final String FIBONACCI_UNDER_APPROX_MINUTES_IN_YEAR = "0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987, 1597, 2584, 4181, 6765, 10946, 17711, 28657, 46368, 75025, 121393, 196418, 317811, 514229";
   private static final Duration ONE_MINUTE = Duration.standardMinutes(1);
 
   public interface Options extends StreamingOptions {
@@ -92,7 +100,7 @@ public final class App {
     void setCoinMarketCapTopCurrencyCount(int value);
     
     @Description("Candle lookback sizes (comma-separated list of integers)")
-    @Default.String("1,5,15,30,60")
+    @Default.String(FIBONACCI_UNDER_APPROX_MINUTES_IN_YEAR)
     String getCandleLookbackSizes();
     void setCandleLookbackSizes(String value);
   }
@@ -170,6 +178,8 @@ public final class App {
         .map(String::trim)
         .filter(s -> !s.isEmpty())
         .map(Integer::parseInt)
+        .filter(i -> i > 0)
+        .distinct()
         .toList();
   }
   

--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -95,11 +95,6 @@ public final class App {
     @Default.String("1,5,15,30,60")
     String getCandleLookbackSizes();
     void setCandleLookbackSizes(String value);
-    
-    @Description("Maximum size of the internal lookback buffer per key")
-    @Default.Integer(100)
-    int getMaxCandleLookbackSize();
-    void setMaxCandleLookbackSize(int value);
   }
 
   private final Supplier<List<CurrencyPair>> currencyPairs;
@@ -156,14 +151,11 @@ public final class App {
             .triggering(DefaultTrigger.of())
             .discardingFiredPanes());
             
-    // 5. Parse lookback sizes from options
+    // 5. Parse lookback sizes from options and add lookback processing
     List<Integer> lookbackSizes = parseLookbackSizes(options.getCandleLookbackSizes());
-    int maxLookbackSize = options.getMaxCandleLookbackSize();
-    
-    // 6. Add lookback processing
     PCollection<KV<String, KV<Integer, ImmutableList<Candle>>>> lookbacks = windowedCandles.apply(
         "Generate Candle Lookbacks",
-        ParDo.of(new CandleLookbackDoFn(maxLookbackSize, lookbackSizes)));
+        ParDo.of(new CandleLookbackDoFn(lookbackSizes)));
         
     // 7. Log lookback results for debugging
     lookbacks.apply("Log Lookbacks", ParDo.of(new LogLookbacksDoFn()));

--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -13,6 +13,7 @@ import com.google.protobuf.util.Timestamps;
 import com.verlumen.tradestream.execution.RunMode;
 import com.verlumen.tradestream.instruments.CurrencyPair;
 import com.verlumen.tradestream.marketdata.Candle;
+import com.verlumen.tradestream.marketdata.CandleLookbackDoFn;
 import com.verlumen.tradestream.marketdata.FillForwardCandles;
 import com.verlumen.tradestream.marketdata.MultiTimeframeCandleTransform;
 import com.verlumen.tradestream.marketdata.Trade;
@@ -20,6 +21,7 @@ import com.verlumen.tradestream.marketdata.TradeSource;
 import com.verlumen.tradestream.marketdata.TradeToCandle;
 import com.verlumen.tradestream.strategies.StrategyEnginePipeline;
 import java.util.List;
+import java.util.Arrays;
 import java.util.function.Supplier;
 import org.apache.beam.runners.flink.FlinkPipelineOptions;
 import org.apache.beam.sdk.Pipeline;
@@ -88,6 +90,16 @@ public final class App {
     @Default.Integer(10)
     int getCoinMarketCapTopCurrencyCount();
     void setCoinMarketCapTopCurrencyCount(int value);
+    
+    @Description("Candle lookback sizes (comma-separated list of integers)")
+    @Default.String("1,5,15,30,60")
+    String getCandleLookbackSizes();
+    void setCandleLookbackSizes(String value);
+    
+    @Description("Maximum size of the internal lookback buffer per key")
+    @Default.Integer(100)
+    int getMaxCandleLookbackSize();
+    void setMaxCandleLookbackSize(int value);
   }
 
   private final Supplier<List<CurrencyPair>> currencyPairs;
@@ -114,7 +126,7 @@ public final class App {
   }
 
   /** Build the Beam pipeline, integrating all components. */
-  private Pipeline buildPipeline(Pipeline pipeline) {
+  private Pipeline buildPipeline(Pipeline pipeline, Options options) {
     logger.atInfo().log("Starting to build the pipeline.");
 
     // 1. Read trades.
@@ -135,15 +147,61 @@ public final class App {
     // 3. Create candles from trades.
     PCollection<KV<String, Candle>> candles = tradesWithTimestamps
       .apply("Create Candle", tradeToCandle);
+      
+    // 4. Apply window for candle processing - use a single large window for stateful processing
+    Duration windowDuration = Duration.standardMinutes(options.getCandleDurationMinutes() * 10);
+    PCollection<KV<String, Candle>> windowedCandles = candles.apply(
+        "Apply Processing Window",
+        Window.<KV<String, Candle>>into(FixedWindows.of(windowDuration))
+            .triggering(DefaultTrigger.of())
+            .discardingFiredPanes());
+            
+    // 5. Parse lookback sizes from options
+    List<Integer> lookbackSizes = parseLookbackSizes(options.getCandleLookbackSizes());
+    int maxLookbackSize = options.getMaxCandleLookbackSize();
+    
+    // 6. Add lookback processing
+    PCollection<KV<String, KV<Integer, ImmutableList<Candle>>>> lookbacks = windowedCandles.apply(
+        "Generate Candle Lookbacks",
+        ParDo.of(new CandleLookbackDoFn(maxLookbackSize, lookbackSizes)));
+        
+    // 7. Log lookback results for debugging
+    lookbacks.apply("Log Lookbacks", ParDo.of(new LogLookbacksDoFn()));
 
     logger.atInfo().log("Pipeline building complete. Returning pipeline.");
     return pipeline;
   }
 
-  private void runPipeline(Pipeline pipeline) throws Exception {
+  /** Parse the comma-separated lookback sizes into a List of Integers */
+  private List<Integer> parseLookbackSizes(String sizesString) {
+    return Arrays.stream(sizesString.split(","))
+        .map(String::trim)
+        .filter(s -> !s.isEmpty())
+        .map(Integer::parseInt)
+        .toList();
+  }
+  
+  /** DoFn to log lookback results */
+  private static class LogLookbacksDoFn extends DoFn<KV<String, KV<Integer, ImmutableList<Candle>>>, Void> {
+    private static final FluentLogger logger = FluentLogger.forEnclosingClass();
+    
+    @ProcessElement
+    public void processElement(ProcessContext c) {
+      KV<String, KV<Integer, ImmutableList<Candle>>> element = c.element();
+      String currencyPair = element.getKey();
+      int lookbackSize = element.getValue().getKey();
+      ImmutableList<Candle> candles = element.getValue().getValue();
+      
+      logger.atInfo().log(
+          "Generated lookback for %s: size=%d, elements=%d",
+          currencyPair, lookbackSize, candles.size());
+    }
+  }
+
+  private void runPipeline(Pipeline pipeline, Options options) throws Exception {
     logger.atInfo().log("Running the pipeline.");
 
-    buildPipeline(pipeline);
+    buildPipeline(pipeline, options);
     pipeline.run();
   }
 
@@ -204,6 +262,6 @@ public final class App {
     // Create and run the Beam pipeline.
     Pipeline pipeline = Pipeline.create(options);
     logger.atInfo().log("Created Beam pipeline.");
-    app.runPipeline(pipeline);
+    app.runPipeline(pipeline, options);
   }
 }

--- a/src/main/java/com/verlumen/tradestream/pipeline/BUILD
+++ b/src/main/java/com/verlumen/tradestream/pipeline/BUILD
@@ -19,6 +19,7 @@ java_binary(
         "//protos:marketdata_java_proto",
         "//src/main/java/com/verlumen/tradestream/execution:run_mode",
         "//src/main/java/com/verlumen/tradestream/instruments:currency_pair",
+        "//src/main/java/com/verlumen/tradestream/marketdata:candle_lookback_do_fn",
         "//src/main/java/com/verlumen/tradestream/marketdata:fill_forward_candles",
         "//src/main/java/com/verlumen/tradestream/marketdata:multi_timeframe_candle_transform",
         "//src/main/java/com/verlumen/tradestream/marketdata:trade_source",


### PR DESCRIPTION
This change introduces support for configurable candle lookback processing in the Beam pipeline, using Fibonacci-based default values approximating the number of minutes in a Gregorian year.

### Summary of Changes:
- **(MINOR)**: Added `getCandleLookbackSizes()` to the `Options` interface, with a default set of Fibonacci values under ~526,000 minutes.
- Integrated a new `CandleLookbackDoFn` that computes multiple candle lookbacks based on configured sizes.
- Applied fixed-windowing to the candle stream to support stateful lookback processing.
- Implemented `LogLookbacksDoFn` for logging lookback results for debugging purposes.
- Updated `buildPipeline()` and `runPipeline()` to pass and utilize pipeline options.
- Modified BUILD file to include the new `candle_lookback_do_fn` dependency.

This enhancement enables flexible strategy modeling over historical windows, supporting experimentation with multi-horizon technical indicators or trend analysis.