### PR TITLE
Add `BacktestRequestFactory` interface and Bazel target for backtesting module

### DIFF
--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -3,6 +3,16 @@ load("@rules_java//java:defs.bzl", "java_binary", "java_library")
 
 package(default_visibility = ["//visibility:public"])
 
+kt_jvm_library(
+    name = "backtest_request_factory",
+    srcs = ["BacktestRequestFactory.kt"],
+    deps = [
+        "//protos:backtesting_java_proto",
+        "//protos:marketdata_java_proto",
+        "//protos:strategies_java_proto",
+    ],
+)
+
 java_library(
     name = "backtest_runner",
     srcs = ["BacktestRunner.java"],

--- a/src/main/java/com/verlumen/tradestream/backtesting/BacktestRequestFactory.kt
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BacktestRequestFactory.kt
@@ -1,0 +1,19 @@
+package com.verlumen.tradestream.backtesting
+
+import com.verlumen.tradestream.marketdata.Candle
+import com.verlumen.tradestream.strategies.Strategy
+import com.verlumen.tradestream.backtesting.BacktestRequest
+
+/**
+ * Interface for creating BacktestRequest objects.
+ */
+interface BacktestRequestFactory {
+    /**
+     * Creates a BacktestRequest based on the provided candles and strategy.
+     *
+     * @param candles The list of historical price candles.
+     * @param strategy The trading strategy to be backtested.
+     * @return A configured BacktestRequest object.
+     */
+    fun create(candles: List<Candle>, strategy: Strategy): BacktestRequest
+}


### PR DESCRIPTION
This PR introduces a new Kotlin interface, `BacktestRequestFactory`, to the `backtesting` module. The interface defines a contract for constructing `BacktestRequest` instances from a list of `Candle` objects and a `Strategy`. This supports more flexible and testable backtest construction logic.

Additionally, the corresponding Bazel target `kt_jvm_library(name = "backtest_request_factory")` has been added to the `BUILD` file, with necessary dependencies on the related proto libraries.

No behavior changes were made to existing components.
