### PR TITLE
Add `BacktestRequestFactoryImpl` and corresponding test for constructing backtest requests (MINOR)

### DIFF
--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -13,6 +13,19 @@ kt_jvm_library(
     ],
 )
 
+kt_jvm_library(
+    name = "backtest_request_factory_impl",
+    srcs = ["BacktestRequestFactoryImpl.kt"],
+    deps = [
+        ":backtest_request_factory",
+        "//protos:backtesting_java_proto",
+        "//protos:marketdata_java_proto",
+        "//protos:strategies_java_proto",
+        "//third_party:flogger",
+        "//third_party:guice",
+    ],
+)
+
 java_library(
     name = "backtest_runner",
     srcs = ["BacktestRunner.java"],

--- a/src/main/java/com/verlumen/tradestream/backtesting/BacktestRequestFactoryImpl.kt
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BacktestRequestFactoryImpl.kt
@@ -1,0 +1,39 @@
+package com.verlumen.tradestream.backtesting
+
+import com.google.common.flogger.FluentLogger
+import com.google.inject.Inject
+import com.verlumen.tradestream.backtesting.BacktestRequest
+import com.verlumen.tradestream.strategies.Strategy
+import com.verlumen.tradestream.marketdata.Candle
+
+/**
+ * Implementation of [BacktestRequestFactory] that builds [BacktestRequest] objects.
+ *
+ * This implementation uses standard constructor injection for dependencies.
+ */
+class BacktestRequestFactoryImpl @Inject constructor() : BacktestRequestFactory {
+
+    // Initialize FluentLogger for logging within this class
+    private val logger = FluentLogger.forEnclosingClass()
+
+    /**
+     * Creates a [BacktestRequest] using the provided candles and strategy.
+     * Logs the creation event.
+     *
+     * @param candles The list of historical price candles.
+     * @param strategy The trading strategy to be backtested.
+     * @return A configured [BacktestRequest] object.
+     */
+    override fun create(candles: List<Candle>, strategy: Strategy): BacktestRequest {
+        logger.atFine().log("Creating BacktestRequest for strategy: %s with %d candles.", strategy.javaClass.simpleName, candles.size)
+
+        // Build the BacktestRequest using the protobuf builder
+        val request = BacktestRequest.newBuilder()
+            .addAllCandles(candles) // AddAll handles the List<Candle>
+            .setStrategy(strategy)  // Set the strategy
+            .build()
+
+        logger.atFine().log("BacktestRequest created successfully.")
+        return request
+    }
+}

--- a/src/test/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/test/java/com/verlumen/tradestream/backtesting/BUILD
@@ -1,4 +1,31 @@
 load("@rules_java//java:defs.bzl", "java_test")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
+
+kt_jvm_test(
+    name = "BacktestRequestFactoryImplTest",
+    srcs = ["BacktestRequestFactoryImplTest.kt"],
+    # If using Kotlin 1.6+, you might need:
+    # jvm_target = "17",
+    # toolchain = "@rules_kotlin//toolchains/kotlin_jvm:kt_jvm_toolchain_alias",
+    test_class = "com.verlumen.tradestream.backtesting.BacktestRequestFactoryImplTest",
+    deps = [
+        # Library under test
+        "//src/main/java/com/verlumen/tradestream/backtesting:backtest_request_factory_impl",
+        # Interface (needed if the test references the interface type)
+        "//src/main/java/com/verlumen/tradestream/backtesting:backtest_request_factory",
+        # Protobuf dependencies
+        "//protos:backtesting_java_proto",
+        "//protos:marketdata_java_proto",
+        "//protos:strategies_java_proto",
+        # Testing libraries
+        "//third_party:junit",
+        "//third_party:truth",
+        # Other direct dependencies (if any are added to the test)
+        "//third_party:flogger", # Included because the Impl uses it, might be needed for test setup/verification later
+        "//third_party:protobuf_java_util", # For Timestamps
+        "//third_party:guava", # For ImmutableList if used directly in test
+    ],
+)
 
 java_test(
     name = "BacktestRunnerImplTest",

--- a/src/test/java/com/verlumen/tradestream/backtesting/BacktestRequestFactoryImplTest.kt
+++ b/src/test/java/com/verlumen/tradestream/backtesting/BacktestRequestFactoryImplTest.kt
@@ -1,0 +1,81 @@
+package com.verlumen.tradestream.backtesting
+
+import com.google.common.truth.Truth.assertThat
+import com.google.protobuf.Any // Import Any
+import com.google.protobuf.Timestamp
+import com.verlumen.tradestream.marketdata.Candle
+import com.verlumen.tradestream.strategies.Strategy
+import com.verlumen.tradestream.strategies.StrategyType
+import java.time.Instant
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class BacktestRequestFactoryImplTest {
+
+    private lateinit var factory: BacktestRequestFactoryImpl
+    private lateinit var sampleCandles: List<Candle>
+    private lateinit var sampleStrategy: Strategy
+
+    @Before
+    fun setUp() {
+        // Simple constructor, no mocks needed for instantiation
+        factory = BacktestRequestFactoryImpl()
+
+        // Create sample candle data
+        val nowMillis = Instant.now().toEpochMilli()
+        sampleCandles = listOf(
+            Candle.newBuilder()
+                .setTimestamp(Timestamp.newBuilder().setSeconds(nowMillis / 1000).setNanos((nowMillis % 1000).toInt() * 1_000_000))
+                .setCurrencyPair("BTC/USD")
+                .setOpen(50000.0)
+                .setHigh(51000.0)
+                .setLow(49000.0)
+                .setClose(50500.0)
+                .setVolume(10.0)
+                .build(),
+            Candle.newBuilder()
+                .setTimestamp(Timestamp.newBuilder().setSeconds((nowMillis + 60000) / 1000).setNanos(((nowMillis + 60000) % 1000).toInt() * 1_000_000))
+                .setCurrencyPair("BTC/USD")
+                .setOpen(50500.0)
+                .setHigh(51500.0)
+                .setLow(50000.0)
+                .setClose(51000.0)
+                .setVolume(12.0)
+                .build()
+        )
+
+        // Create a sample strategy
+        sampleStrategy = Strategy.newBuilder()
+            .setType(StrategyType.SMA_RSI)
+            .setParameters(Any.newBuilder().build()) // Using default/empty parameters for simplicity
+            .build()
+    }
+
+    @Test
+    fun create_withCandlesAndStrategy_returnsCorrectBacktestRequest() {
+        // Act
+        val backtestRequest = factory.create(sampleCandles, sampleStrategy)
+
+        // Assert
+        assertThat(backtestRequest).isNotNull()
+        assertThat(backtestRequest.candlesList).isEqualTo(sampleCandles)
+        assertThat(backtestRequest.strategy).isEqualTo(sampleStrategy)
+    }
+
+    @Test
+    fun create_withEmptyCandles_returnsRequestWithEmptyCandlesList() {
+        // Arrange
+        val emptyCandles = emptyList<Candle>()
+
+        // Act
+        val backtestRequest = factory.create(emptyCandles, sampleStrategy)
+
+        // Assert
+        assertThat(backtestRequest).isNotNull()
+        assertThat(backtestRequest.candlesList).isEmpty()
+        assertThat(backtestRequest.strategy).isEqualTo(sampleStrategy)
+    }
+}


### PR DESCRIPTION
This PR introduces a new implementation of the `BacktestRequestFactory` interface:

- **New Kotlin class**: `BacktestRequestFactoryImpl` implements logic for constructing `BacktestRequest` objects from provided candle data and strategy configurations. It leverages the builder pattern from protobuf and includes structured logging via FluentLogger.
- **New Bazel target**: `backtest_request_factory_impl` added to the `BUILD` file for inclusion in builds.
- **Unit tests added**: `BacktestRequestFactoryImplTest` validates correct construction of requests, including cases for populated and empty candle lists.
- **Test target defined**: A new `kt_jvm_test` Bazel rule has been added to run the test.

(MINOR) version bump justified due to the introduction of a new factory implementation, which extends the functionality of the system without breaking existing interfaces.