### PR TITLE
Enable Flink Checkpointing and High Availability with Persistent Volumes (MINOR)

### DIFF
--- a/charts/tradestream/templates/checkpoint-pvc.yaml
+++ b/charts/tradestream/templates/checkpoint-pvc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "tradestream.fullname" . }}-checkpoints
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "tradestream.name" . }}
+    component: data-pipeline
+    release: {{ .Release.Name }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 20Gi
+  storageClassName: standard

--- a/charts/tradestream/templates/ha-pvc.yaml
+++ b/charts/tradestream/templates/ha-pvc.yaml
@@ -13,4 +13,4 @@ spec:
   resources:
     requests:
       storage: 5Gi
-  storageClassName: cbs-rbd
+  storageClassName: standard

--- a/charts/tradestream/templates/ha-pvc.yaml
+++ b/charts/tradestream/templates/ha-pvc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "tradestream.fullname" . }}-ha
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "tradestream.name" . }}
+    component: data-pipeline
+    release: {{ .Release.Name }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: cbs-rbd

--- a/charts/tradestream/templates/pipeline.yaml
+++ b/charts/tradestream/templates/pipeline.yaml
@@ -15,11 +15,39 @@ spec:
     {{- toYaml .Values.pipeline.configuration | nindent 4 }}
     # Ensure Flink itself uses the writable directory for its I/O temp
     io.tmp.dirs: "/opt/flink/writable-tmp"
+    
+    # Enable checkpointing
+    execution.checkpointing.enabled: "true"
+    execution.checkpointing.interval: "60000"
+    execution.checkpointing.min-pause: "30000"
+    execution.checkpointing.timeout: "600000"
+    execution.checkpointing.mode: "EXACTLY_ONCE"
+    execution.checkpointing.max-concurrent-checkpoints: "1"
+    
+    # Configure state backend
+    state.backend: "filesystem"
+    state.checkpoints.dir: "file:///flink-checkpoints"
+    state.savepoints.dir: "file:///flink-savepoints"
+    
+    # Enable monitoring
+    metrics.enabled: "true"
+    metrics.latency.interval: "60000"
+    metrics.system-resource: "true"
+    metrics.system-resource-probing-interval: "5000"
+    
+    # High Availability Configuration
+    high-availability: "org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory"
+    high-availability.storageDir: "file:///flink-ha"
+    high-availability.kubernetes.leader-election.lease-duration: "15s"
+    high-availability.kubernetes.leader-election.renew-deadline: "15s"
+    high-availability.kubernetes.leader-election.retry-period: "5s"
+    
   serviceAccount: {{ .Values.pipeline.serviceAccount }}
   jobManager:
     resource:
       memory: {{ .Values.pipeline.jobManager.memory }}
       cpu: {{ .Values.pipeline.jobManager.cpu }}
+    replicas: 1
   taskManager:
     resource:
       memory: {{ .Values.pipeline.taskManager.memory }}
@@ -40,13 +68,17 @@ spec:
       volumes:
         - name: flink-writable-volume
           emptyDir: {}
+        - name: checkpoint-volume
+          persistentVolumeClaim:
+            claimName: {{ include "tradestream.fullname" . }}-checkpoints
+        - name: ha-volume
+          persistentVolumeClaim:
+            claimName: {{ include "tradestream.fullname" . }}-ha
       containers:
         - name: flink-main-container
           env:
-            # Add this environment variable
             - name: TMPDIR
               value: /opt/flink/writable-tmp
-            # Keep your existing env vars
             - name: COINMARKETCAP_API_KEY
               valueFrom:
                 secretKeyRef:
@@ -55,5 +87,13 @@ spec:
           volumeMounts:
             - name: flink-writable-volume
               mountPath: /opt/flink/writable-tmp
-              # This mount MUST be writable
+              readOnly: false
+            - name: checkpoint-volume
+              mountPath: /flink-checkpoints
+              readOnly: false
+            - name: checkpoint-volume
+              mountPath: /flink-savepoints
+              readOnly: false
+            - name: ha-volume
+              mountPath: /flink-ha
               readOnly: false


### PR DESCRIPTION
This PR introduces support for Flink checkpointing and high availability (HA) by adding the following key changes:

- **PersistentVolumeClaims**:  
  - Added `checkpoint-pvc.yaml` and `ha-pvc.yaml` templates to provision storage for Flink checkpoints and HA metadata respectively.
  
- **Pipeline Configuration Enhancements**:  
  - Enabled Flink checkpointing with configurable intervals, timeout, and exactly-once semantics.
  - Configured a filesystem-based state backend with defined directories for checkpoints and savepoints.
  - Enabled resource and latency monitoring with custom probing intervals.
  - Activated Kubernetes-based HA using Flink’s Kubernetes HA Services Factory, with specified leader election settings.

- **Volume Mounts**:  
  - Mounted the new PVCs into the Flink container for checkpoints (`/flink-checkpoints`), savepoints (`/flink-savepoints`), and HA data (`/flink-ha`).

These changes introduce non-breaking but functional improvements to the pipeline’s fault tolerance and observability capabilities.
