### PR TITLE
Add support for Tiingo API key via options and environment variable

### DIFF
--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -230,6 +230,14 @@ public final class App {
       return options.getCoinMarketCapApiKey();
   }
 
+  private static String getTiingoApiKey(Options options) {
+      if (isNullOrEmpty(options.getTiingoApiKey())) {
+           return System.getenv().getOrDefault(TIINGO_API_KEY_ENV_VAR, "INVALID_API_KEY");
+      } 
+
+      return options.getTiingoApiKey();
+  }
+
   public static void main(String[] args) throws Exception {
     logger.atInfo().log("Application starting with arguments: %s", (Object) args);
 

--- a/src/main/java/com/verlumen/tradestream/pipeline/App.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/App.java
@@ -48,6 +48,8 @@ public final class App {
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
   private static final String CMC_API_KEY_ENV_VAR = "COINMARKETCAP_API_KEY";
+  private static final String TIINGO_API_KEY_ENV_VAR = "TIINGO_API_KEY";
+
   /**
    * A constant string holding the Fibonacci sequence values less than 526,000.
    *
@@ -103,6 +105,11 @@ public final class App {
     @Default.String(FIBONACCI_UNDER_APPROX_MINUTES_IN_YEAR)
     String getCandleLookbackSizes();
     void setCandleLookbackSizes(String value);
+
+    @Description("Tiingo API Key (default: value of " + TIINGO_API_KEY_ENV_VAR + " environment variable)")
+    @Default.String("")
+    String getTiingoApiKey();
+    void setTiingoApiKey(String value);
   }
 
   private final Supplier<List<CurrencyPair>> currencyPairs;


### PR DESCRIPTION
This patch adds support for configuring the Tiingo API key in the application. A new constant `TIINGO_API_KEY_ENV_VAR` is introduced, and the `Options` interface now includes getter and setter methods for `TiingoApiKey`, with a corresponding description and default value. A helper method `getTiingoApiKey()` was added to resolve the API key from the options or fallback to the environment variable.
