### PR TITLE
Add `TiingoCryptoFetcherFn` for Fetching and Emitting Tiingo Crypto Candles

### DIFF
--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -254,6 +254,25 @@ java_library(
     ],
 )
 
+kt_jvm_library(
+    name = "tiingo_crypto_fetcher_fn",
+    srcs = ["TiingoCryptoFetcherFn.kt"],
+    visibility = ["//visibility:public"], # Allow visibility for tests and other modules
+    deps = [
+        ":tiingo_response_parser", # From PR 1
+        "//protos:marketdata_java_proto",
+        "//src/main/java/com/verlumen/tradestream/http:http_client",
+        "//third_party:beam_sdks_java_core",
+        "//third_party:beam_sdks_java_extensions_protobuf",
+        "//third_party:flogger",
+        "//third_party:guice", # Keep for @Inject on HttpClient for now
+        "//third_party:joda_time", # Added for Duration parameter
+        "//third_party:protobuf_java",
+        "//third_party:protobuf_java_util",
+         # Add assistedinject later when wiring it up
+    ],
+)
+
 # Tiingo Response Parser
 kt_jvm_library(
     name = "tiingo_response_parser",

--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -257,19 +257,17 @@ java_library(
 kt_jvm_library(
     name = "tiingo_crypto_fetcher_fn",
     srcs = ["TiingoCryptoFetcherFn.kt"],
-    visibility = ["//visibility:public"], # Allow visibility for tests and other modules
     deps = [
-        ":tiingo_response_parser", # From PR 1
+        ":tiingo_response_parser",
         "//protos:marketdata_java_proto",
         "//src/main/java/com/verlumen/tradestream/http:http_client",
         "//third_party:beam_sdks_java_core",
         "//third_party:beam_sdks_java_extensions_protobuf",
         "//third_party:flogger",
-        "//third_party:guice", # Keep for @Inject on HttpClient for now
-        "//third_party:joda_time", # Added for Duration parameter
+        "//third_party:guice",
+        "//third_party:joda_time",
         "//third_party:protobuf_java",
         "//third_party:protobuf_java_util",
-         # Add assistedinject later when wiring it up
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFn.kt
+++ b/src/main/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFn.kt
@@ -22,7 +22,7 @@ import java.io.Serializable
  * This version does *not* yet include state management or fill-forward logic.
  */
 class TiingoCryptoFetcherFn @Inject constructor(
-    private val httpClientProvider: Provider<HttpClient>, // Inject Provider
+    @Transient private val httpClientProvider: Provider<HttpClient>, // Inject Provider
     private val granularity: Duration,
     private val apiKey: String
 ) : DoFn<KV<String, Void>, KV<String, Candle>>(), Serializable { // Ensure DoFn implements Serializable
@@ -54,7 +54,7 @@ class TiingoCryptoFetcherFn @Inject constructor(
 
     companion object {
         private val logger = FluentLogger.forEnclosingClass()
-        private val TIINGO_DATE_FORMATTER_DAILY = DateTimeFormatter.ISO_LOCAL_DATE // YYYY-MM-dd for daily
+        private val TIINGO_DATE_FORMATTER_DAILY = DateTimeFormatter.ISO_LOCAL_DATE // yyyy-MM-dd for daily
         private const val DEFAULT_START_DATE = "2019-01-02"
         private const val TIINGO_API_URL = "https://api.tiingo.com/tiingo/crypto/prices"
 

--- a/src/main/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFn.kt
+++ b/src/main/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFn.kt
@@ -2,93 +2,46 @@ package com.verlumen.tradestream.marketdata
 
 import com.google.common.flogger.FluentLogger
 import com.google.inject.Inject
-import com.google.inject.Provider
 import com.verlumen.tradestream.http.HttpClient
 import org.apache.beam.sdk.transforms.DoFn
 import org.apache.beam.sdk.transforms.DoFn.ProcessContext
 import org.apache.beam.sdk.transforms.DoFn.ProcessElement
-import org.apache.beam.sdk.transforms.DoFn.StartBundle
-import org.apache.beam.sdk.transforms.DoFn.Setup
 import org.apache.beam.sdk.values.KV
 import org.joda.time.Duration
 import java.io.IOException
-import java.time.format.DateTimeFormatter
 import java.io.Serializable
-
-// NOTE: This is a basic implementation. State and AssistedInject will be added later.
+import java.time.format.DateTimeFormatter
 
 /**
  * A basic DoFn to fetch cryptocurrency candle data from the Tiingo API for a specific currency pair.
- * This version does *not* yet include state management or fill-forward logic.
+ * State and AssistedInject will be added later.
  */
 class TiingoCryptoFetcherFn @Inject constructor(
-    private val httpClientProvider: Provider<HttpClient>, // Inject Provider
+    private val httpClient: HttpClient,
     private val granularity: Duration,
     private val apiKey: String
-) : DoFn<KV<String, Void>, KV<String, Candle>>(), Serializable { // Ensure DoFn implements Serializable
-
-    @Transient
-    private var httpClient: HttpClient? = null
-    
-    @Setup
-    fun setup() {
-        try {
-            httpClient = httpClientProvider.get()
-            logger.atInfo().log("HttpClient initialized in Setup")
-        } catch (e: Exception) {
-            logger.atSevere().withCause(e).log("Failed to initialize HttpClient in Setup")
-        }
-    }
-    
-    @StartBundle
-    fun startBundle() {
-        try {
-            if (httpClient == null) {
-                httpClient = httpClientProvider.get()
-                logger.atInfo().log("HttpClient initialized in StartBundle")
-            }
-        } catch (e: Exception) {
-            logger.atSevere().withCause(e).log("Failed to initialize HttpClient in StartBundle")
-        }
-    }
+) : DoFn<KV<String, Void>, KV<String, Candle>>(), Serializable {
 
     companion object {
         private val logger = FluentLogger.forEnclosingClass()
-        private val TIINGO_DATE_FORMATTER_DAILY = DateTimeFormatter.ISO_LOCAL_DATE // yyyy-MM-dd for daily
+        private val TIINGO_DATE_FORMATTER_DAILY = DateTimeFormatter.ISO_LOCAL_DATE
         private const val DEFAULT_START_DATE = "2019-01-02"
         private const val TIINGO_API_URL = "https://api.tiingo.com/tiingo/crypto/prices"
 
-        /** Converts a Joda Duration to a Tiingo resampleFreq parameter string. */
+        /** Convert a Joda Duration into Tiingo’s `resampleFreq` string. */
         fun durationToResampleFreq(duration: Duration): String {
             return when {
-                duration.standardDays >= 1 -> "${duration.standardDays}day"
-                duration.standardHours >= 1 -> "${duration.standardHours}hour"
+                duration.standardDays >= 1   -> "${duration.standardDays}day"
+                duration.standardHours >= 1  -> "${duration.standardHours}hour"
                 duration.standardMinutes > 0 -> "${duration.standardMinutes}min"
-                else -> "1min"
+                else                         -> "1min"
             }
         }
-
-        /** Determines if the granularity is daily or intraday based on Joda Duration. */
-        fun isDailyGranularity(duration: Duration): Boolean =
-            duration.isLongerThan(Duration.standardHours(23))
     }
 
     @ProcessElement
-    fun processElement(context: ProcessContext) {
-        // Last resort: try to get a client if still null
-        if (httpClient == null) {
-            try {
-                httpClient = httpClientProvider.get()
-                logger.atInfo().log("HttpClient initialized in ProcessElement")
-            } catch (e: Exception) {
-                logger.atSevere().withCause(e).log("Failed to initialize HttpClient in ProcessElement")
-                // Continue with null client and let it fail with clear error message
-            }
-        }
-        
-        val currencyPair = context.element().key
-        val ticker = currencyPair.replace("/", "").lowercase()
-        val resampleFreq = durationToResampleFreq(granularity)
+    fun processElement(ctx: ProcessContext) {
+        val currencyPair = ctx.element().key
 
         if (apiKey.isBlank() || apiKey == "YOUR_TIINGO_API_KEY_HERE") {
             logger.atWarning()
@@ -96,42 +49,35 @@ class TiingoCryptoFetcherFn @Inject constructor(
             return
         }
 
-        logger.atInfo()
-            .log("Fetching Tiingo data for: %s (ticker: %s) with granularity: %s",
-                 currencyPair, ticker, resampleFreq)
+        val ticker       = currencyPair.replace("/", "").lowercase()
+        val resampleFreq = durationToResampleFreq(granularity)
+        val url = "$TIINGO_API_URL?tickers=$ticker" +
+                  "&startDate=$DEFAULT_START_DATE" +
+                  "&resampleFreq=$resampleFreq" +
+                  "&token=$apiKey"
 
-        val startDate = DEFAULT_START_DATE
-        val url = "$TIINGO_API_URL?tickers=$ticker&startDate=$startDate&resampleFreq=$resampleFreq&token=$apiKey"
-        logger.atFine().log("Requesting URL: %s", url)
+        logger.atInfo()
+            .log("Fetching Tiingo data for %s (ticker=%s, freq=%s)", currencyPair, ticker, resampleFreq)
+        logger.atFine().log("Request URL: %s", url)
 
         try {
-            if (httpClient == null) {
-                throw IllegalStateException("HttpClient is null, cannot fetch data")
-            }
-            
-            val response = httpClient!!.get(url, emptyMap())
-            val fetchedCandles = TiingoResponseParser.parseCandles(response, currencyPair)
+            val response = httpClient.get(url, emptyMap())
+            val candles  = TiingoResponseParser.parseCandles(response, currencyPair)
 
-            if (fetchedCandles.isNotEmpty()) {
-                logger.atInfo()
-                    .log("Parsed %d candles for %s with granularity %s",
-                         fetchedCandles.size, currencyPair, resampleFreq)
-                fetchedCandles.forEach { candle ->
-                    context.output(KV.of(currencyPair, candle))
-                }
+            if (candles.isNotEmpty()) {
+                logger.atInfo().log("Parsed %d candles for %s", candles.size, currencyPair)
+                candles.forEach { ctx.output(KV.of(currencyPair, it)) }
             } else {
                 logger.atInfo()
-                    .log("No candle data returned from Tiingo for %s starting %s",
-                         currencyPair, startDate)
+                    .log("No candle data from Tiingo for %s starting %s", currencyPair, DEFAULT_START_DATE)
             }
+
         } catch (e: IOException) {
             logger.atSevere().withCause(e)
-                .log("Failed to fetch or parse Tiingo data for %s from URL: %s",
-                     currencyPair, url)
+                .log("I/O error fetching/parsing Tiingo data for %s: %s", currencyPair, e.message)
         } catch (e: Exception) {
             logger.atSevere().withCause(e)
-                .log("Unexpected error fetching Tiingo data for %s from URL: %s",
-                     currencyPair, url)
+                .log("Unexpected error fetching Tiingo data for %s: %s", currencyPair, e.message)
         }
     }
 }

--- a/src/main/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFn.kt
+++ b/src/main/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFn.kt
@@ -22,7 +22,7 @@ import java.io.Serializable
  * This version does *not* yet include state management or fill-forward logic.
  */
 class TiingoCryptoFetcherFn @Inject constructor(
-    @Transient private val httpClientProvider: Provider<HttpClient>, // Inject Provider
+    private val httpClientProvider: Provider<HttpClient>, // Inject Provider
     private val granularity: Duration,
     private val apiKey: String
 ) : DoFn<KV<String, Void>, KV<String, Candle>>(), Serializable { // Ensure DoFn implements Serializable

--- a/src/main/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFn.kt
+++ b/src/main/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFn.kt
@@ -55,7 +55,7 @@ class TiingoCryptoFetcherFn @Inject constructor( // Temporarily use @Inject for 
     @ProcessElement
     fun processElement(context: ProcessContext) {
         val currencyPair = context.element().key
-        val ticker = currencyPair.replace("/", "").toLowerCase()
+        val ticker = currencyPair.replace("/", "").lowercase()
         val resampleFreq = durationToResampleFreq(granularity)
 
          // Basic API Key validation

--- a/src/main/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFn.kt
+++ b/src/main/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFn.kt
@@ -1,0 +1,105 @@
+package com.verlumen.tradestream.marketdata
+
+import com.google.common.flogger.FluentLogger
+import com.google.inject.Inject
+import com.verlumen.tradestream.http.HttpClient
+import org.apache.beam.sdk.transforms.DoFn
+import org.apache.beam.sdk.values.KV
+import org.joda.time.Duration
+import java.io.IOException
+import java.time.format.DateTimeFormatter
+
+// NOTE: This is a basic implementation. State and AssistedInject will be added later.
+
+/**
+ * A basic DoFn to fetch cryptocurrency candle data from the Tiingo API for a specific currency pair.
+ * This version does *not* yet include state management or fill-forward logic.
+ */
+class TiingoCryptoFetcherFn @Inject constructor( // Temporarily use @Inject for HttpClient
+    private val httpClient: HttpClient,
+    // Temporary direct constructor args for config (will become @Assisted)
+    private val granularity: Duration,
+    private val apiKey: String
+) : DoFn<KV<String, Void>, KV<String, Candle>>() { // Input KV<PairSymbol, Void>, Output KV<PairSymbol, Candle>
+
+    companion object {
+        private val logger = FluentLogger.forEnclosingClass()
+        private val TIINGO_DATE_FORMATTER_DAILY = DateTimeFormatter.ISO_LOCAL_DATE // yyyy-MM-dd for daily
+        // private val TIINGO_DATE_FORMATTER_INTRADAY = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss") // Not needed yet
+
+        private const val DEFAULT_START_DATE = "2019-01-02" // Always fetch from start for now
+        private const val TIINGO_API_URL = "https://api.tiingo.com/tiingo/crypto/prices"
+
+        // --- Helper Methods ---
+        /**
+         * Converts a Joda Duration to a Tiingo resampleFreq parameter string.
+         */
+        fun durationToResampleFreq(duration: Duration): String {
+            return when {
+                duration.getStandardDays() >= 1 -> "${duration.getStandardDays()}day"
+                duration.getStandardHours() >= 1 -> "${duration.getStandardHours()}hour"
+                duration.getStandardMinutes() > 0 -> "${duration.getStandardMinutes()}min"
+                else -> "1min" // Default to 1min if duration is too small or zero
+            }
+        }
+
+        /**
+         * Determines if the granularity is daily or intraday based on Joda Duration.
+         */
+        fun isDailyGranularity(duration: Duration): Boolean {
+            return duration.isLongerThan(Duration.standardHours(23)) // Consider >= 1 day as daily
+        }
+        // --- End Helper Methods ---
+    }
+
+    @ProcessElement
+    fun processElement(context: ProcessContext) {
+        val currencyPair = context.element().key
+        val ticker = currencyPair.replace("/", "").toLowerCase()
+        val resampleFreq = durationToResampleFreq(granularity)
+
+         // Basic API Key validation
+        if (apiKey.isBlank() || apiKey == "YOUR_TIINGO_API_KEY_HERE") {
+             logger.atWarning().log("Tiingo API Key is missing or using placeholder for %s. Skipping fetch.", currencyPair)
+             return // Skip processing if key is invalid
+        }
+
+
+        logger.atInfo().log("Fetching Tiingo data for: %s (ticker: %s) with granularity: %s",
+            currencyPair, ticker, resampleFreq)
+
+        // Use DEFAULT_START_DATE for this PR (stateful logic comes later)
+        val startDate = DEFAULT_START_DATE
+
+        // Construct API URL
+        val url = "$TIINGO_API_URL?tickers=$ticker&startDate=$startDate&resampleFreq=$resampleFreq&token=$apiKey"
+        logger.atFine().log("Requesting URL: %s", url)
+
+        try {
+            val response = httpClient.get(url, emptyMap()) // Assuming GET request
+            logger.atFine().log("Received response for %s (length: %d)", currencyPair, response.length)
+
+            val fetchedCandles = TiingoResponseParser.parseCandles(response, currencyPair)
+
+            if (fetchedCandles.isNotEmpty()) {
+                logger.atInfo().log("Parsed %d candles for %s with granularity %s",
+                    fetchedCandles.size, currencyPair, resampleFreq)
+
+                fetchedCandles.forEach { candle ->
+                    // Output KV pair
+                    context.output(KV.of(currencyPair, candle))
+                }
+            } else {
+                logger.atInfo().log("No candle data returned from Tiingo for %s starting %s",
+                    currencyPair, startDate)
+            }
+        } catch (e: IOException) {
+            logger.atSevere().withCause(e).log("Failed to fetch or parse Tiingo data for %s from URL: %s",
+                currencyPair, url)
+            // Basic error handling for now
+        } catch (e: Exception) {
+             logger.atSevere().withCause(e).log("Unexpected error fetching Tiingo data for %s from URL: %s",
+                currencyPair, url)
+        }
+    }
+}

--- a/src/main/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFn.kt
+++ b/src/main/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFn.kt
@@ -20,7 +20,7 @@ class TiingoCryptoFetcherFn @Inject constructor(
     private val httpClient: HttpClient,
     private val granularity: Duration,
     private val apiKey: String
-) : DoFn<KV<String, Void>, KV<String, Candle>>(), Serializable {
+) : DoFn<KV<String, Void?>, KV<String, Candle>>(), Serializable {
 
     companion object {
         private val logger = FluentLogger.forEnclosingClass()
@@ -28,7 +28,7 @@ class TiingoCryptoFetcherFn @Inject constructor(
         private const val DEFAULT_START_DATE = "2019-01-02"
         private const val TIINGO_API_URL = "https://api.tiingo.com/tiingo/crypto/prices"
 
-        /** Convert a Joda Duration into Tiingo’s `resampleFreq` string. */
+        /** Convert a Joda Duration into Tiingo's `resampleFreq` string. */
         fun durationToResampleFreq(duration: Duration): String {
             return when {
                 duration.standardDays >= 1   -> "${duration.standardDays}day"

--- a/src/main/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFn.kt
+++ b/src/main/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFn.kt
@@ -4,6 +4,8 @@ import com.google.common.flogger.FluentLogger
 import com.google.inject.Inject
 import com.verlumen.tradestream.http.HttpClient
 import org.apache.beam.sdk.transforms.DoFn
+import org.apache.beam.sdk.transforms.DoFn.ProcessContext
+import org.apache.beam.sdk.transforms.DoFn.ProcessElement
 import org.apache.beam.sdk.values.KV
 import org.joda.time.Duration
 import java.io.IOException
@@ -15,41 +17,31 @@ import java.time.format.DateTimeFormatter
  * A basic DoFn to fetch cryptocurrency candle data from the Tiingo API for a specific currency pair.
  * This version does *not* yet include state management or fill-forward logic.
  */
-class TiingoCryptoFetcherFn @Inject constructor( // Temporarily use @Inject for HttpClient
+class TiingoCryptoFetcherFn @Inject constructor(
     private val httpClient: HttpClient,
-    // Temporary direct constructor args for config (will become @Assisted)
     private val granularity: Duration,
     private val apiKey: String
-) : DoFn<KV<String, Void>, KV<String, Candle>>() { // Input KV<PairSymbol, Void>, Output KV<PairSymbol, Candle>
+) : DoFn<KV<String, Void>, KV<String, Candle>>() {
 
     companion object {
         private val logger = FluentLogger.forEnclosingClass()
         private val TIINGO_DATE_FORMATTER_DAILY = DateTimeFormatter.ISO_LOCAL_DATE // yyyy-MM-dd for daily
-        // private val TIINGO_DATE_FORMATTER_INTRADAY = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss") // Not needed yet
-
-        private const val DEFAULT_START_DATE = "2019-01-02" // Always fetch from start for now
+        private const val DEFAULT_START_DATE = "2019-01-02"
         private const val TIINGO_API_URL = "https://api.tiingo.com/tiingo/crypto/prices"
 
-        // --- Helper Methods ---
-        /**
-         * Converts a Joda Duration to a Tiingo resampleFreq parameter string.
-         */
+        /** Converts a Joda Duration to a Tiingo resampleFreq parameter string. */
         fun durationToResampleFreq(duration: Duration): String {
             return when {
-                duration.getStandardDays() >= 1 -> "${duration.getStandardDays()}day"
-                duration.getStandardHours() >= 1 -> "${duration.getStandardHours()}hour"
-                duration.getStandardMinutes() > 0 -> "${duration.getStandardMinutes()}min"
-                else -> "1min" // Default to 1min if duration is too small or zero
+                duration.standardDays >= 1 -> "${duration.standardDays}day"
+                duration.standardHours >= 1 -> "${duration.standardHours}hour"
+                duration.standardMinutes > 0 -> "${duration.standardMinutes}min"
+                else -> "1min"
             }
         }
 
-        /**
-         * Determines if the granularity is daily or intraday based on Joda Duration.
-         */
-        fun isDailyGranularity(duration: Duration): Boolean {
-            return duration.isLongerThan(Duration.standardHours(23)) // Consider >= 1 day as daily
-        }
-        // --- End Helper Methods ---
+        /** Determines if the granularity is daily or intraday based on Joda Duration. */
+        fun isDailyGranularity(duration: Duration): Boolean =
+            duration.isLongerThan(Duration.standardHours(23))
     }
 
     @ProcessElement
@@ -58,48 +50,44 @@ class TiingoCryptoFetcherFn @Inject constructor( // Temporarily use @Inject for 
         val ticker = currencyPair.replace("/", "").lowercase()
         val resampleFreq = durationToResampleFreq(granularity)
 
-         // Basic API Key validation
         if (apiKey.isBlank() || apiKey == "YOUR_TIINGO_API_KEY_HERE") {
-             logger.atWarning().log("Tiingo API Key is missing or using placeholder for %s. Skipping fetch.", currencyPair)
-             return // Skip processing if key is invalid
+            logger.atWarning()
+                .log("Tiingo API Key is missing or placeholder for %s. Skipping fetch.", currencyPair)
+            return
         }
 
+        logger.atInfo()
+            .log("Fetching Tiingo data for: %s (ticker: %s) with granularity: %s",
+                 currencyPair, ticker, resampleFreq)
 
-        logger.atInfo().log("Fetching Tiingo data for: %s (ticker: %s) with granularity: %s",
-            currencyPair, ticker, resampleFreq)
-
-        // Use DEFAULT_START_DATE for this PR (stateful logic comes later)
         val startDate = DEFAULT_START_DATE
-
-        // Construct API URL
         val url = "$TIINGO_API_URL?tickers=$ticker&startDate=$startDate&resampleFreq=$resampleFreq&token=$apiKey"
         logger.atFine().log("Requesting URL: %s", url)
 
         try {
-            val response = httpClient.get(url, emptyMap()) // Assuming GET request
-            logger.atFine().log("Received response for %s (length: %d)", currencyPair, response.length)
-
+            val response = httpClient.get(url, emptyMap())
             val fetchedCandles = TiingoResponseParser.parseCandles(response, currencyPair)
 
             if (fetchedCandles.isNotEmpty()) {
-                logger.atInfo().log("Parsed %d candles for %s with granularity %s",
-                    fetchedCandles.size, currencyPair, resampleFreq)
-
+                logger.atInfo()
+                    .log("Parsed %d candles for %s with granularity %s",
+                         fetchedCandles.size, currencyPair, resampleFreq)
                 fetchedCandles.forEach { candle ->
-                    // Output KV pair
                     context.output(KV.of(currencyPair, candle))
                 }
             } else {
-                logger.atInfo().log("No candle data returned from Tiingo for %s starting %s",
-                    currencyPair, startDate)
+                logger.atInfo()
+                    .log("No candle data returned from Tiingo for %s starting %s",
+                         currencyPair, startDate)
             }
         } catch (e: IOException) {
-            logger.atSevere().withCause(e).log("Failed to fetch or parse Tiingo data for %s from URL: %s",
-                currencyPair, url)
-            // Basic error handling for now
+            logger.atSevere().withCause(e)
+                .log("Failed to fetch or parse Tiingo data for %s from URL: %s",
+                     currencyPair, url)
         } catch (e: Exception) {
-             logger.atSevere().withCause(e).log("Unexpected error fetching Tiingo data for %s from URL: %s",
-                currencyPair, url)
+            logger.atSevere().withCause(e)
+                .log("Unexpected error fetching Tiingo data for %s from URL: %s",
+                     currencyPair, url)
         }
     }
 }

--- a/src/main/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFn.kt
+++ b/src/main/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFn.kt
@@ -2,6 +2,7 @@ package com.verlumen.tradestream.marketdata
 
 import com.google.common.flogger.FluentLogger
 import com.google.inject.Inject
+import com.google.inject.Provider
 import com.verlumen.tradestream.http.HttpClient
 import org.apache.beam.sdk.transforms.DoFn
 import org.apache.beam.sdk.transforms.DoFn.ProcessContext
@@ -10,8 +11,7 @@ import org.apache.beam.sdk.values.KV
 import org.joda.time.Duration
 import java.io.IOException
 import java.time.format.DateTimeFormatter
-import javax.inject.Provider // Import Provider
-import java.io.Serializable // Ensure Serializable is imported
+import java.io.Serializable
 
 // NOTE: This is a basic implementation. State and AssistedInject will be added later.
 

--- a/src/test/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/test/java/com/verlumen/tradestream/marketdata/BUILD
@@ -189,7 +189,6 @@ kt_jvm_test(
     name = "TiingoCryptoFetcherFnTest",
     srcs = ["TiingoCryptoFetcherFnTest.kt"],
     test_class = "com.verlumen.tradestream.marketdata.TiingoCryptoFetcherFnTest",
-    jvm_target = "17",
     deps = [
         # Main library target
         "//src/main/java/com/verlumen/tradestream/marketdata:tiingo_crypto_fetcher_fn",

--- a/src/test/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/test/java/com/verlumen/tradestream/marketdata/BUILD
@@ -192,25 +192,20 @@ kt_jvm_test(
     deps = [
         # Main library target
         "//src/main/java/com/verlumen/tradestream/marketdata:tiingo_crypto_fetcher_fn",
-        # Dependencies needed for testing (mocks, protos, http client interface, etc.)
         "//src/main/java/com/verlumen/tradestream/http:http_client",
         "//protos:marketdata_java_proto",
-        # Beam Test Utils
         "//third_party:beam_sdks_java_core",
         "//third_party:beam_sdks_java_test_utils",
-        # Testing Libs
         "//third_party:guava",
         "//third_party:junit",
         "//third_party:mockito_core",
-        "//third_party:mockito_kotlin",
         "//third_party:protobuf_java_util",
         "//third_party:truth",
-        # Other direct dependencies
         "//third_party:joda_time",
     ],
     runtime_deps = [
          "//third_party:beam_runners_direct_java",
-         "//third_party:hamcrest", # Often used by PAssert internally
+         "//third_party:hamcrest",
     ],
 )
 

--- a/src/test/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/test/java/com/verlumen/tradestream/marketdata/BUILD
@@ -199,6 +199,7 @@ kt_jvm_test(
         "//third_party:guava",
         "//third_party:junit",
         "//third_party:mockito_core",
+        "//third_party:mockito_kotlin",
         "//third_party:protobuf_java_util",
         "//third_party:truth",
         "//third_party:joda_time",

--- a/src/test/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/test/java/com/verlumen/tradestream/marketdata/BUILD
@@ -189,6 +189,7 @@ kt_jvm_test(
     name = "TiingoCryptoFetcherFnTest",
     srcs = ["TiingoCryptoFetcherFnTest.kt"],
     test_class = "com.verlumen.tradestream.marketdata.TiingoCryptoFetcherFnTest",
+    jvm_target = "17",
     deps = [
         # Main library target
         "//src/main/java/com/verlumen/tradestream/marketdata:tiingo_crypto_fetcher_fn",

--- a/src/test/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/test/java/com/verlumen/tradestream/marketdata/BUILD
@@ -200,7 +200,6 @@ kt_jvm_test(
         "//third_party:guava",
         "//third_party:junit",
         "//third_party:mockito_core",
-        "//third_party:mockito_kotlin",
         "//third_party:protobuf_java_util",
         "//third_party:truth",
         "//third_party:joda_time",

--- a/src/test/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/test/java/com/verlumen/tradestream/marketdata/BUILD
@@ -186,6 +186,35 @@ java_test(
 )
 
 kt_jvm_test(
+    name = "TiingoCryptoFetcherFnTest",
+    srcs = ["TiingoCryptoFetcherFnTest.kt"],
+    test_class = "com.verlumen.tradestream.marketdata.TiingoCryptoFetcherFnTest",
+    deps = [
+        # Main library target
+        "//src/main/java/com/verlumen/tradestream/marketdata:tiingo_crypto_fetcher_fn",
+        # Dependencies needed for testing (mocks, protos, http client interface, etc.)
+        "//src/main/java/com/verlumen/tradestream/http:http_client",
+        "//protos:marketdata_java_proto",
+        # Beam Test Utils
+        "//third_party:beam_sdks_java_core",
+        "//third_party:beam_sdks_java_test_utils",
+        # Testing Libs
+        "//third_party:guava",
+        "//third_party:junit",
+        "//third_party:mockito_core",
+        "//third_party:mockito_kotlin",
+        "//third_party:protobuf_java_util",
+        "//third_party:truth",
+        # Other direct dependencies
+        "//third_party:joda_time",
+    ],
+    runtime_deps = [
+         "//third_party:beam_runners_direct_java",
+         "//third_party:hamcrest", # Often used by PAssert internally
+    ],
+)
+
+kt_jvm_test(
     name = "TiingoResponseParserTest",
     srcs = ["TiingoResponseParserTest.kt"],
     test_class = "com.verlumen.tradestream.marketdata.TiingoResponseParserTest",

--- a/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
+++ b/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
@@ -5,6 +5,7 @@ import com.verlumen.tradestream.http.HttpClient
 import org.apache.beam.sdk.testing.PAssert
 import org.apache.beam.sdk.testing.TestPipeline
 import org.apache.beam.sdk.transforms.Create
+import org.apache.beam.sdk.transforms.PTransform
 import org.apache.beam.sdk.transforms.ParDo
 import org.apache.beam.sdk.values.KV
 import org.apache.beam.sdk.values.PCollection
@@ -61,7 +62,8 @@ class TiingoCryptoFetcherFnTest {
         val input = pipeline
             .apply(Create.of(KV.of(pair, null as Void?)))
 
-        val output = input.apply<PCollection<KV<String, Candle>>>("RunFetcherDaily", ParDo.of(fetcherFnDaily))
+        val fetcherTransformDaily: PTransform<in PCollection<KV<String, Void>>, PCollection<KV<String, Candle>>> = ParDo.of(fetcherFnDaily)
+        val output = input.apply("RunFetcherDaily", fetcherTransformDaily)
 
         PAssert.that(output).satisfies { elements ->
             val results = elements.toList()
@@ -84,7 +86,8 @@ class TiingoCryptoFetcherFnTest {
         val input = pipeline
             .apply(Create.of(KV.of(pair, null as Void?)))
 
-        val output = input.apply<PCollection<KV<String, Candle>>>("RunFetcherIOException", ParDo.of(fetcherFnDaily))
+        val fetcherTransformIOException: PTransform<in PCollection<KV<String, Void>>, PCollection<KV<String, Candle>>> = ParDo.of(fetcherFnDaily)
+        val output = input.apply("RunFetcherIOException", fetcherTransformIOException)
 
         PAssert.that(output).empty()
 
@@ -97,7 +100,8 @@ class TiingoCryptoFetcherFnTest {
         val pair = "BTC/USD"
 
         val input  = pipeline.apply(Create.of(KV.of(pair, null as Void?)))
-        val output = input.apply<PCollection<KV<String, Candle>>>("RunFetcherInvalidKey", ParDo.of(invalidFn))
+        val invalidFetcherTransform: PTransform<in PCollection<KV<String, Void>>, PCollection<KV<String, Candle>>> = ParDo.of(invalidFn)
+        val output = input.apply("RunFetcherInvalidKey", invalidFetcherTransform)
 
         PAssert.that(output).empty()
         pipeline.run().waitUntilFinish()

--- a/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
+++ b/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
@@ -7,6 +7,7 @@ import org.apache.beam.sdk.testing.TestPipeline
 import org.apache.beam.sdk.transforms.Create
 import org.apache.beam.sdk.transforms.ParDo
 import org.apache.beam.sdk.values.KV
+import org.apache.beam.sdk.values.PCollection
 import org.joda.time.Duration
 import org.junit.Before
 import org.junit.Rule
@@ -56,8 +57,8 @@ class TiingoCryptoFetcherFnTest {
         Mockito.`when`(mockHttpClient.get(Mockito.anyString(), Mockito.anyMap()))
             .thenReturn(sampleResponseDaily)
 
-        val output = pipeline
-            .apply(Create.of(KV.of(currencyPair, null)))
+        val output: PCollection<KV<String, Candle>> = pipeline
+            .apply(Create.of(KV.of(currencyPair, null as Void?)))
             .apply(ParDo.of(fetcherFnDaily))
 
         PAssert.that(output).satisfies { candles ->
@@ -79,8 +80,8 @@ class TiingoCryptoFetcherFnTest {
         Mockito.`when`(mockHttpClient.get(Mockito.anyString(), Mockito.anyMap()))
             .thenThrow(IOException("network error"))
 
-        val output = pipeline
-            .apply(Create.of(KV.of(currencyPair, null)))
+        val output: PCollection<KV<String, Candle>> = pipeline
+            .apply(Create.of(KV.of(currencyPair, null as Void?)))
             .apply(ParDo.of(fetcherFnDaily))
 
         PAssert.that(output).empty()
@@ -93,8 +94,8 @@ class TiingoCryptoFetcherFnTest {
         val invalidFn = TiingoCryptoFetcherFn(mockHttpClient, Duration.standardDays(1), "")
         val currencyPair = "BTC/USD"
 
-        val output = pipeline
-            .apply(Create.of(KV.of(currencyPair, null)))
+        val output: PCollection<KV<String, Candle>> = pipeline
+            .apply(Create.of(KV.of(currencyPair, null as Void?)))
             .apply(ParDo.of(invalidFn))
 
         PAssert.that(output).empty()

--- a/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
+++ b/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
@@ -62,7 +62,7 @@ class TiingoCryptoFetcherFnTest {
         val input = pipeline
             .apply(Create.of(KV.of(pair, null as Void?)))
 
-        val fetcherTransformDaily: PTransform<in PCollection<KV<String, Void>>, PCollection<KV<String, Candle>>> = ParDo.of(fetcherFnDaily)
+        val fetcherTransformDaily: PTransform<in PCollection<KV<String, Void?>>, PCollection<KV<String, Candle>>> = ParDo.of(fetcherFnDaily)
         val output: PCollection<KV<String, Candle>> = input.apply("RunFetcherDaily", fetcherTransformDaily)
 
         PAssert.that(output).satisfies { elements: Iterable<KV<String, Candle>> ->
@@ -86,7 +86,7 @@ class TiingoCryptoFetcherFnTest {
         val input = pipeline
             .apply(Create.of(KV.of(pair, null as Void?)))
 
-        val fetcherTransformIOException: PTransform<in PCollection<KV<String, Void>>, PCollection<KV<String, Candle>>> = ParDo.of(fetcherFnDaily)
+        val fetcherTransformIOException: PTransform<in PCollection<KV<String, Void?>>, PCollection<KV<String, Candle>>> = ParDo.of(fetcherFnDaily)
         val output: PCollection<KV<String, Candle>> = input.apply("RunFetcherIOException", fetcherTransformIOException)
 
         PAssert.that(output).empty()
@@ -100,7 +100,7 @@ class TiingoCryptoFetcherFnTest {
         val pair = "BTC/USD"
 
         val input = pipeline.apply(Create.of(KV.of(pair, null as Void?)))
-        val invalidFetcherTransform: PTransform<in PCollection<KV<String, Void>>, PCollection<KV<String, Candle>>> = ParDo.of(invalidFn)
+        val invalidFetcherTransform: PTransform<in PCollection<KV<String, Void?>>, PCollection<KV<String, Candle>>> = ParDo.of(invalidFn)
         val output: PCollection<KV<String, Candle>> = input.apply("RunFetcherInvalidKey", invalidFetcherTransform)
 
         PAssert.that(output).empty()

--- a/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
+++ b/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
@@ -55,7 +55,7 @@ class TiingoCryptoFetcherFnTest {
           {"date": "2023-10-27T00:00:00+00:00", "open": 34650, "high": 35000, "low": 34500, "close": 34950, "volume": 1800}
         ]}]
     """.trimIndent()
-    
+
     @Before
     fun setUp() {
         // Use our improved provider implementation

--- a/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
+++ b/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
@@ -7,6 +7,7 @@ import org.apache.beam.sdk.testing.TestPipeline
 import org.apache.beam.sdk.transforms.Create
 import org.apache.beam.sdk.transforms.ParDo
 import org.apache.beam.sdk.values.KV
+import org.apache.beam.sdk.values.PCollection
 import org.joda.time.Duration
 import org.junit.Before
 import org.junit.Rule
@@ -15,6 +16,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.mockito.Mockito
 import java.io.IOException
+import java.io.Serializable
 
 @RunWith(JUnit4::class)
 class TiingoCryptoFetcherFnTest {
@@ -59,7 +61,7 @@ class TiingoCryptoFetcherFnTest {
         val input = pipeline
             .apply(Create.of(KV.of(pair, null as Void?)))
 
-        val output = input.apply(ParDo.of(fetcherFnDaily))
+        val output: PCollection<KV<String, Candle>> = input.apply(ParDo.of(fetcherFnDaily))
 
         PAssert.that(output).satisfies { elements ->
             val results = elements.toList()
@@ -82,7 +84,7 @@ class TiingoCryptoFetcherFnTest {
         val input = pipeline
             .apply(Create.of(KV.of(pair, null as Void?)))
 
-        val output = input.apply(ParDo.of(fetcherFnDaily))
+        val output: PCollection<KV<String, Candle>> = input.apply(ParDo.of(fetcherFnDaily))
 
         PAssert.that(output).empty()
 
@@ -95,7 +97,7 @@ class TiingoCryptoFetcherFnTest {
         val pair = "BTC/USD"
 
         val input  = pipeline.apply(Create.of(KV.of(pair, null as Void?)))
-        val output = input.apply(ParDo.of(invalidFn))
+        val output: PCollection<KV<String, Candle>> = input.apply(ParDo.of(invalidFn))
 
         PAssert.that(output).empty()
         pipeline.run().waitUntilFinish()

--- a/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
+++ b/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
@@ -57,11 +57,11 @@ class TiingoCryptoFetcherFnTest {
         Mockito.`when`(mockHttpClient.get(Mockito.anyString(), Mockito.anyMap()))
             .thenReturn(sampleResponseDaily)
 
-        val input: PCollection<KV<String, Void?>> = pipeline
-            .apply(Create.of<KV<String, Void?>>(KV.of(currencyPair, null as Void?)))
+        val input: PCollection<KV<String, Void>> = pipeline
+            .apply(Create.of<KV<String, Void>>(KV.of(currencyPair, null as Void?)))
 
         val output: PCollection<KV<String, Candle>> = input
-            .apply(ParDo.of<KV<String, Void?>, KV<String, Candle>>(fetcherFnDaily))
+            .apply(ParDo.of<KV<String, Void>, KV<String, Candle>>(fetcherFnDaily))
 
         PAssert.that(output).satisfies { candles: Iterable<KV<String, Candle>> ->
             val results = candles.toList()
@@ -82,11 +82,11 @@ class TiingoCryptoFetcherFnTest {
         Mockito.`when`(mockHttpClient.get(Mockito.anyString(), Mockito.anyMap()))
             .thenThrow(IOException("network error"))
 
-        val input: PCollection<KV<String, Void?>> = pipeline
-            .apply(Create.of<KV<String, Void?>>(KV.of(currencyPair, null as Void?)))
+        val input: PCollection<KV<String, Void>> = pipeline
+            .apply(Create.of<KV<String, Void>>(KV.of(currencyPair, null as Void?)))
 
         val output: PCollection<KV<String, Candle>> = input
-            .apply(ParDo.of<KV<String, Void?>, KV<String, Candle>>(fetcherFnDaily))
+            .apply(ParDo.of<KV<String, Void>, KV<String, Candle>>(fetcherFnDaily))
 
         PAssert.that(output).empty()
 
@@ -98,11 +98,11 @@ class TiingoCryptoFetcherFnTest {
         val invalidFn = TiingoCryptoFetcherFn(mockHttpClient, Duration.standardDays(1), "")
         val currencyPair = "BTC/USD"
 
-        val input: PCollection<KV<String, Void?>> = pipeline
-            .apply(Create.of<KV<String, Void?>>(KV.of(currencyPair, null as Void?)))
+        val input: PCollection<KV<String, Void>> = pipeline
+            .apply(Create.of<KV<String, Void>>(KV.of(currencyPair, null as Void?)))
 
         val output: PCollection<KV<String, Candle>> = input
-            .apply(ParDo.of<KV<String, Void?>, KV<String, Candle>>(invalidFn))
+            .apply(ParDo.of<KV<String, Void>, KV<String, Candle>>(invalidFn))
 
         PAssert.that(output).empty()
 

--- a/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
+++ b/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
@@ -14,13 +14,11 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import org.mockito.ArgumentMatcher // Import standard Mockito matcher
+import org.mockito.ArgumentMatcher
 import org.mockito.Mock
-import org.mockito.Mockito // Import Mockito for verify etc.
+import org.mockito.Mockito
 import org.mockito.junit.MockitoJUnit
 import org.mockito.junit.MockitoRule
-import org.mockito.kotlin.any // Still using mockito-kotlin's any() for simplicity, but not essential
-import org.mockito.kotlin.whenever
 import java.io.IOException
 
 @RunWith(JUnit4::class)
@@ -66,24 +64,27 @@ class TiingoCryptoFetcherFnTest {
 
         // Mock HTTP client for initial fetch (daily)
         val expectedStartDate = "2019-01-02"
-        // Use standard Mockito argThat
+        // Use standard Mockito when() instead of whenever()
         val urlMatcher = argThat(UrlMatcher(
             "startDate=$expectedStartDate",
             "resampleFreq=1day",
             "tickers=btcusd",
             "token=$testApiKey"
         ))
-        whenever(mockHttpClient.get(urlMatcher, any())).thenReturn(sampleResponseDaily)
+        Mockito.`when`(mockHttpClient.get(urlMatcher, emptyMap())).thenReturn(sampleResponseDaily)
 
         val tester = DoFnTester.of(fetcherFnDaily)
+        // Fix processBundle call by using vararg
         val outputKVs = tester.processBundle(input)
 
-        // Assert output (remains the same)
-        assertThat(outputKVs).hasSize(2)
-        assertThat(outputKVs[0].key).isEqualTo(currencyPair)
-        assertThat(outputKVs[0].value.close).isEqualTo(34650.0)
-        assertThat(outputKVs[1].key).isEqualTo(currencyPair)
-        assertThat(outputKVs[1].value.close).isEqualTo(34950.0)
+        // Fix assertion chain with correct methods
+        assertThat(outputKVs.size).isEqualTo(2)
+        val firstResult = outputKVs[0]
+        assertThat(firstResult.key).isEqualTo(currencyPair)
+        assertThat(firstResult.value.close).isEqualTo(34650.0)
+        val secondResult = outputKVs[1]
+        assertThat(secondResult.key).isEqualTo(currencyPair)
+        assertThat(secondResult.value.close).isEqualTo(34950.0)
     }
 
     @Test
@@ -92,22 +93,23 @@ class TiingoCryptoFetcherFnTest {
         val input = KV.of(currencyPair, null as Void?)
 
         val expectedStartDate = "2019-01-02"
-         // Use standard Mockito argThat
+         // Use standard Mockito when() instead of whenever()
         val urlMatcher = argThat(UrlMatcher(
              "startDate=$expectedStartDate",
              "resampleFreq=5min",
              "tickers=btcusd",
              "token=$testApiKey"
         ))
-        whenever(mockHttpClient.get(urlMatcher, any())).thenReturn(sampleResponseMinute)
+        Mockito.`when`(mockHttpClient.get(urlMatcher, emptyMap())).thenReturn(sampleResponseMinute)
 
         val tester = DoFnTester.of(fetcherFnMinute) // Use 5-min fetcher
         val outputKVs = tester.processBundle(input)
 
-        // Assert output (remains the same)
-        assertThat(outputKVs).hasSize(1)
-        assertThat(outputKVs[0].key).isEqualTo(currencyPair)
-        assertThat(outputKVs[0].value.close).isEqualTo(34965.0)
+        // Fix assertion chain with correct methods
+        assertThat(outputKVs.size).isEqualTo(1)
+        val result = outputKVs[0]
+        assertThat(result.key).isEqualTo(currencyPair)
+        assertThat(result.value.close).isEqualTo(34965.0)
     }
 
 
@@ -116,7 +118,7 @@ class TiingoCryptoFetcherFnTest {
         val currencyPair = "BTC/USD"
         val input = KV.of(currencyPair, null as Void?)
         val urlMatcher = argThat(UrlMatcher("token=$testApiKey")) // Ensure key is still passed
-        whenever(mockHttpClient.get(urlMatcher, any())).thenReturn(emptyResponse)
+        Mockito.`when`(mockHttpClient.get(urlMatcher, emptyMap())).thenReturn(emptyResponse)
 
         val tester = DoFnTester.of(fetcherFnDaily)
         val outputKVs = tester.processBundle(input)
@@ -134,8 +136,8 @@ class TiingoCryptoFetcherFnTest {
         val outputKVs = tester.processBundle(input)
 
         assertThat(outputKVs).isEmpty()
-        // Verify httpClient.get was *not* called
-        Mockito.verify(mockHttpClient, Mockito.never()).get(any(), any())
+        // Fix verify with correct Mockito syntax using matchers
+        Mockito.verify(mockHttpClient, Mockito.never()).get(Mockito.anyString(), Mockito.anyMap())
     }
 
     @Test
@@ -143,7 +145,7 @@ class TiingoCryptoFetcherFnTest {
         val currencyPair = "BTC/USD"
         val input = KV.of(currencyPair, null as Void?)
         val urlMatcher = argThat(UrlMatcher("token=$testApiKey"))
-        whenever(mockHttpClient.get(urlMatcher, any())).thenThrow(IOException("Network Error"))
+        Mockito.`when`(mockHttpClient.get(urlMatcher, emptyMap())).thenThrow(IOException("Network Error"))
 
         val tester = DoFnTester.of(fetcherFnDaily)
         val outputKVs = tester.processBundle(input)
@@ -152,13 +154,11 @@ class TiingoCryptoFetcherFnTest {
     }
 
     // --- Standard Mockito ArgumentMatcher Implementation ---
-    // This replaces the need for mockito-kotlin's argThat helper function syntax
-    // and the separate contains() helper.
     private class UrlMatcher(vararg val substrings: String) : ArgumentMatcher<String> {
         override fun matches(argument: String?): Boolean {
             return argument != null && substrings.all { argument.contains(it) }
         }
-         override fun toString(): String = "URL containing $substrings"
+        override fun toString(): String = "URL containing $substrings"
     }
 
     // Helper function to use the standard Mockito matcher

--- a/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
+++ b/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
@@ -57,15 +57,13 @@ class TiingoCryptoFetcherFnTest {
         Mockito.`when`(mockHttpClient.get(Mockito.anyString(), Mockito.anyMap()))
             .thenReturn(sampleResponseDaily)
 
-        // Create input PCollection<KV<String, Void>> with explicit type
-        val input: PCollection<KV<String, Void>> = pipeline
-            .apply(Create.of<KV<String, Void>>(KV.of(currencyPair, null)))
+        val input: PCollection<KV<String, Void?>> = pipeline
+            .apply(Create.of<KV<String, Void?>>(KV.of(currencyPair, null as Void?)))
 
-        // Apply the DoFn with explicit type parameters
         val output: PCollection<KV<String, Candle>> = input
-            .apply(ParDo.<KV<String, Void>, KV<String, Candle>>of(fetcherFnDaily))
+            .apply(ParDo.of<KV<String, Void?>, KV<String, Candle>>(fetcherFnDaily))
 
-        PAssert.that(output).satisfies { candles ->
+        PAssert.that(output).satisfies { candles: Iterable<KV<String, Candle>> ->
             val results = candles.toList()
             assertThat(results).hasSize(2)
             assertThat(results[0].key).isEqualTo(currencyPair)
@@ -84,11 +82,11 @@ class TiingoCryptoFetcherFnTest {
         Mockito.`when`(mockHttpClient.get(Mockito.anyString(), Mockito.anyMap()))
             .thenThrow(IOException("network error"))
 
-        val input: PCollection<KV<String, Void>> = pipeline
-            .apply(Create.of<KV<String, Void>>(KV.of(currencyPair, null)))
+        val input: PCollection<KV<String, Void?>> = pipeline
+            .apply(Create.of<KV<String, Void?>>(KV.of(currencyPair, null as Void?)))
 
         val output: PCollection<KV<String, Candle>> = input
-            .apply(ParDo.<KV<String, Void>, KV<String, Candle>>of(fetcherFnDaily))
+            .apply(ParDo.of<KV<String, Void?>, KV<String, Candle>>(fetcherFnDaily))
 
         PAssert.that(output).empty()
 
@@ -100,11 +98,11 @@ class TiingoCryptoFetcherFnTest {
         val invalidFn = TiingoCryptoFetcherFn(mockHttpClient, Duration.standardDays(1), "")
         val currencyPair = "BTC/USD"
 
-        val input: PCollection<KV<String, Void>> = pipeline
-            .apply(Create.of<KV<String, Void>>(KV.of(currencyPair, null)))
+        val input: PCollection<KV<String, Void?>> = pipeline
+            .apply(Create.of<KV<String, Void?>>(KV.of(currencyPair, null as Void?)))
 
         val output: PCollection<KV<String, Candle>> = input
-            .apply(ParDo.<KV<String, Void>, KV<String, Candle>>of(invalidFn))
+            .apply(ParDo.of<KV<String, Void?>, KV<String, Candle>>(invalidFn))
 
         PAssert.that(output).empty()
 

--- a/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
+++ b/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
@@ -61,7 +61,7 @@ class TiingoCryptoFetcherFnTest {
         val input = pipeline
             .apply(Create.of(KV.of(pair, null as Void?)))
 
-        val output: PCollection<KV<String, Candle>> = input.apply(ParDo.of(fetcherFnDaily))
+        val output = input.apply<PCollection<KV<String, Candle>>>("RunFetcherDaily", ParDo.of(fetcherFnDaily))
 
         PAssert.that(output).satisfies { elements ->
             val results = elements.toList()
@@ -84,7 +84,7 @@ class TiingoCryptoFetcherFnTest {
         val input = pipeline
             .apply(Create.of(KV.of(pair, null as Void?)))
 
-        val output: PCollection<KV<String, Candle>> = input.apply(ParDo.of(fetcherFnDaily))
+        val output = input.apply<PCollection<KV<String, Candle>>>("RunFetcherIOException", ParDo.of(fetcherFnDaily))
 
         PAssert.that(output).empty()
 
@@ -97,7 +97,7 @@ class TiingoCryptoFetcherFnTest {
         val pair = "BTC/USD"
 
         val input  = pipeline.apply(Create.of(KV.of(pair, null as Void?)))
-        val output: PCollection<KV<String, Candle>> = input.apply(ParDo.of(invalidFn))
+        val output = input.apply<PCollection<KV<String, Candle>>>("RunFetcherInvalidKey", ParDo.of(invalidFn))
 
         PAssert.that(output).empty()
         pipeline.run().waitUntilFinish()

--- a/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
+++ b/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
@@ -57,11 +57,13 @@ class TiingoCryptoFetcherFnTest {
         Mockito.`when`(mockHttpClient.get(Mockito.anyString(), Mockito.anyMap()))
             .thenReturn(sampleResponseDaily)
 
-        val input: PCollection<KV<String, Void?>> = pipeline
-            .apply(Create.of(KV.of(currencyPair, null)))
+        // Create input PCollection<KV<String, Void>> with explicit type
+        val input: PCollection<KV<String, Void>> = pipeline
+            .apply(Create.of<KV<String, Void>>(KV.of(currencyPair, null)))
 
+        // Apply the DoFn with explicit type parameters
         val output: PCollection<KV<String, Candle>> = input
-            .apply(ParDo.of(fetcherFnDaily))
+            .apply(ParDo.<KV<String, Void>, KV<String, Candle>>of(fetcherFnDaily))
 
         PAssert.that(output).satisfies { candles ->
             val results = candles.toList()
@@ -82,11 +84,11 @@ class TiingoCryptoFetcherFnTest {
         Mockito.`when`(mockHttpClient.get(Mockito.anyString(), Mockito.anyMap()))
             .thenThrow(IOException("network error"))
 
-        val input: PCollection<KV<String, Void?>> = pipeline
-            .apply(Create.of(KV.of(currencyPair, null)))
+        val input: PCollection<KV<String, Void>> = pipeline
+            .apply(Create.of<KV<String, Void>>(KV.of(currencyPair, null)))
 
         val output: PCollection<KV<String, Candle>> = input
-            .apply(ParDo.of(fetcherFnDaily))
+            .apply(ParDo.<KV<String, Void>, KV<String, Candle>>of(fetcherFnDaily))
 
         PAssert.that(output).empty()
 
@@ -98,11 +100,11 @@ class TiingoCryptoFetcherFnTest {
         val invalidFn = TiingoCryptoFetcherFn(mockHttpClient, Duration.standardDays(1), "")
         val currencyPair = "BTC/USD"
 
-        val input: PCollection<KV<String, Void?>> = pipeline
-            .apply(Create.of(KV.of(currencyPair, null)))
+        val input: PCollection<KV<String, Void>> = pipeline
+            .apply(Create.of<KV<String, Void>>(KV.of(currencyPair, null)))
 
         val output: PCollection<KV<String, Candle>> = input
-            .apply(ParDo.of(invalidFn))
+            .apply(ParDo.<KV<String, Void>, KV<String, Candle>>of(invalidFn))
 
         PAssert.that(output).empty()
 

--- a/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
+++ b/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
@@ -57,8 +57,10 @@ class TiingoCryptoFetcherFnTest {
         Mockito.`when`(mockHttpClient.get(Mockito.anyString(), Mockito.anyMap()))
             .thenReturn(sampleResponseDaily)
 
-        val output: PCollection<KV<String, Candle>> = pipeline
-            .apply(Create.of(KV.of(currencyPair, null as Void?)))
+        val input: PCollection<KV<String, Void?>> = pipeline
+            .apply(Create.of(KV.of(currencyPair, null)))
+
+        val output: PCollection<KV<String, Candle>> = input
             .apply(ParDo.of(fetcherFnDaily))
 
         PAssert.that(output).satisfies { candles ->
@@ -80,8 +82,10 @@ class TiingoCryptoFetcherFnTest {
         Mockito.`when`(mockHttpClient.get(Mockito.anyString(), Mockito.anyMap()))
             .thenThrow(IOException("network error"))
 
-        val output: PCollection<KV<String, Candle>> = pipeline
-            .apply(Create.of(KV.of(currencyPair, null as Void?)))
+        val input: PCollection<KV<String, Void?>> = pipeline
+            .apply(Create.of(KV.of(currencyPair, null)))
+
+        val output: PCollection<KV<String, Candle>> = input
             .apply(ParDo.of(fetcherFnDaily))
 
         PAssert.that(output).empty()
@@ -94,8 +98,10 @@ class TiingoCryptoFetcherFnTest {
         val invalidFn = TiingoCryptoFetcherFn(mockHttpClient, Duration.standardDays(1), "")
         val currencyPair = "BTC/USD"
 
-        val output: PCollection<KV<String, Candle>> = pipeline
-            .apply(Create.of(KV.of(currencyPair, null as Void?)))
+        val input: PCollection<KV<String, Void?>> = pipeline
+            .apply(Create.of(KV.of(currencyPair, null)))
+
+        val output: PCollection<KV<String, Candle>> = input
             .apply(ParDo.of(invalidFn))
 
         PAssert.that(output).empty()

--- a/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
+++ b/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
@@ -2,6 +2,7 @@ package com.verlumen.tradestream.marketdata
 
 import com.google.common.truth.Truth.assertThat
 import com.verlumen.tradestream.http.HttpClient
+import com.google.inject.Provider
 import org.apache.beam.sdk.testing.PAssert
 import org.apache.beam.sdk.testing.TestPipeline
 import org.apache.beam.sdk.transforms.Create
@@ -47,7 +48,7 @@ class TiingoCryptoFetcherFnTest {
 
     @Before
     fun setUp() {
-        fetcherFnDaily = TiingoCryptoFetcherFn(mockHttpClient, Duration.standardDays(1), testApiKey)
+        fetcherFnDaily = TiingoCryptoFetcherFn(Provider { mockHttpClient }, Duration.standardDays(1), testApiKey)
     }
 
     @Test
@@ -95,7 +96,7 @@ class TiingoCryptoFetcherFnTest {
 
     @Test
     fun invalidApiKeySkipsFetch() {
-        val invalidFn = TiingoCryptoFetcherFn(mockHttpClient, Duration.standardDays(1), "")
+        val invalidFn = TiingoCryptoFetcherFn(Provider { mockHttpClient }, Duration.standardDays(1), "")
         val currencyPair = "BTC/USD"
 
         val input: PCollection<KV<String, Void>> = pipeline

--- a/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
+++ b/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
@@ -1,18 +1,14 @@
 package com.verlumen.tradestream.marketdata
 
-import com.google.common.truth.Truth.assertThat // Use Truth for assertions
-import com.google.protobuf.util.Timestamps
+import com.google.common.truth.Truth.assertThat
 import com.verlumen.tradestream.http.HttpClient
-import org.apache.beam.sdk.testing.PAssert
+import org.apache.beam.sdk.testing.DoFnTester
 import org.apache.beam.sdk.testing.TestPipeline
-import org.apache.beam.sdk.transforms.Create
-import org.apache.beam.sdk.transforms.DoFnTester
 import org.apache.beam.sdk.values.KV
 import org.joda.time.Duration
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.Assert // Keep standard Assert for assertTrue/NotNull if preferred
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.mockito.ArgumentMatcher
@@ -20,11 +16,13 @@ import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.junit.MockitoJUnit
 import org.mockito.junit.MockitoRule
-import org.mockito.kotlin.any // Using any() from mockito-kotlin for conciseness
 import org.mockito.kotlin.whenever
 import java.io.IOException
 import java.util.Collections
 
+/**
+ * Tests for the TiingoCryptoFetcherFn DoFn.
+ */
 @RunWith(JUnit4::class)
 class TiingoCryptoFetcherFnTest {
 
@@ -34,39 +32,37 @@ class TiingoCryptoFetcherFnTest {
     @Mock
     lateinit var mockHttpClient: HttpClient
 
-    // Test instances - Manually create with mocks for now
-    lateinit var fetcherFnDaily: TiingoCryptoFetcherFn
-    lateinit var fetcherFnMinute: TiingoCryptoFetcherFn
+    private lateinit var fetcherFnDaily: TiingoCryptoFetcherFn
+    private lateinit var fetcherFnMinute: TiingoCryptoFetcherFn
 
     private val testApiKey = "TEST_API_KEY_123"
 
-    // Sample responses (remain the same)
     private val sampleResponseDaily = """
        [{"ticker": "btcusd", "priceData": [
          {"date": "2023-10-26T00:00:00+00:00", "open": 34500, "high": 34800, "low": 34200, "close": 34650, "volume": 1500},
          {"date": "2023-10-27T00:00:00+00:00", "open": 34650, "high": 35000, "low": 34500, "close": 34950, "volume": 1800}
        ]}]
     """.trimIndent()
-     private val sampleResponseMinute = """
+
+    private val sampleResponseMinute = """
        [{"ticker": "btcusd", "priceData": [
          {"date": "2023-10-27T10:01:00+00:00", "open": 34955, "high": 34970, "low": 34950, "close": 34965, "volume": 8.2}
        ]}]
     """.trimIndent()
+
     private val emptyResponse = "[]"
 
     @Before
     fun setUp() {
-        // Manually instantiate the DoFn with mocks
         fetcherFnDaily = TiingoCryptoFetcherFn(mockHttpClient, Duration.standardDays(1), testApiKey)
         fetcherFnMinute = TiingoCryptoFetcherFn(mockHttpClient, Duration.standardMinutes(5), testApiKey)
     }
 
     @Test
-    fun `processElement daily fetch uses default start date and outputs KVs`() {
+    fun `daily fetch outputs expected candles`() {
         val currencyPair = "BTC/USD"
-        val input: KV<String, Void?> = KV.of(currencyPair, null)
+        val input: KV<String, Void> = KV.of(currencyPair, null)
 
-        // Mock HTTP client for initial fetch (daily)
         val expectedStartDate = "2019-01-02"
         val urlMatcher = UrlMatcher(
             "startDate=$expectedStartDate",
@@ -74,114 +70,93 @@ class TiingoCryptoFetcherFnTest {
             "tickers=btcusd",
             "token=$testApiKey"
         )
-        Mockito.`when`(mockHttpClient.get(Mockito.argThat { arg: String? -> urlMatcher.matches(arg) },
-            Mockito.anyMap())) // Use anyMap() for headers
-            .thenReturn(sampleResponseDaily)
+
+        Mockito.`when`(
+            mockHttpClient.get(Mockito.argThat { arg: String? -> urlMatcher.matches(arg) },
+                               Mockito.anyMap())
+        ).thenReturn(sampleResponseDaily)
 
         val tester = DoFnTester.of(fetcherFnDaily)
-        // Pass input as a list
         val outputs: List<KV<String, Candle>> = tester.processBundle(listOf(input))
 
-        // Use Truth assertions
-        assertThat(outputs).isNotNull()
         assertThat(outputs).hasSize(2)
         assertThat(outputs[0].key).isEqualTo(currencyPair)
         assertThat(outputs[0].value.close).isEqualTo(34650.0)
-        assertThat(outputs[1].key).isEqualTo(currencyPair)
         assertThat(outputs[1].value.close).isEqualTo(34950.0)
     }
 
     @Test
-    fun `processElement minute fetch uses default start date and correct freq`() {
+    fun `minute fetch outputs a single candle`() {
         val currencyPair = "BTC/USD"
-        val input: KV<String, Void?> = KV.of(currencyPair, null)
+        val input: KV<String, Void> = KV.of(currencyPair, null)
 
-        val expectedStartDate = "2019-01-02"
         val urlMatcher = UrlMatcher(
-             "startDate=$expectedStartDate",
-             "resampleFreq=5min",
-             "tickers=btcusd",
-             "token=$testApiKey"
+            "startDate=2019-01-02",
+            "resampleFreq=5min",
+            "tickers=btcusd",
+            "token=$testApiKey"
         )
-         Mockito.`when`(mockHttpClient.get(Mockito.argThat { arg: String? -> urlMatcher.matches(arg) },
-            Mockito.anyMap()))
-            .thenReturn(sampleResponseMinute)
+
+        Mockito.`when`(
+            mockHttpClient.get(Mockito.argThat { arg: String? -> urlMatcher.matches(arg) },
+                               Mockito.anyMap())
+        ).thenReturn(sampleResponseMinute)
 
         val tester = DoFnTester.of(fetcherFnMinute)
-        val outputs = tester.processBundle(listOf(input)) // Pass input as a list
+        val outputs = tester.processBundle(listOf(input))
 
-        assertThat(outputs).isNotNull()
         assertThat(outputs).hasSize(1)
-        assertThat(outputs[0].key).isEqualTo(currencyPair)
         assertThat(outputs[0].value.close).isEqualTo(34965.0)
     }
 
     @Test
-    fun `processElement handles empty api response`() {
+    fun `empty response yields no output`() {
         val currencyPair = "BTC/USD"
-        val input: KV<String, Void?> = KV.of(currencyPair, null)
+        val input: KV<String, Void> = KV.of(currencyPair, null)
 
-        val urlMatcher = UrlMatcher("token=$testApiKey")
-         Mockito.`when`(mockHttpClient.get(Mockito.argThat { arg: String? -> urlMatcher.matches(arg) },
-            Mockito.anyMap()))
-            .thenReturn(emptyResponse)
+        Mockito.`when`(
+            mockHttpClient.get(Mockito.argThat { it!!.contains("token=$testApiKey") },
+                               Mockito.anyMap())
+        ).thenReturn(emptyResponse)
 
         val tester = DoFnTester.of(fetcherFnDaily)
-        val outputs = tester.processBundle(listOf(input)) // Pass input as a list
+        val outputs = tester.processBundle(listOf(input))
 
-        assertThat(outputs).isNotNull()
-        assertThat(outputs).isEmpty() // Use Truth's isEmpty
-    }
-
-    @Test
-    fun `processElement skips fetch if api key is invalid`() {
-        val currencyPair = "BTC/USD"
-        val input: KV<String, Void?> = KV.of(currencyPair, null)
-        val fetcherFnInvalidKey = TiingoCryptoFetcherFn(mockHttpClient, Duration.standardDays(1), "") // Empty Key
-
-        val tester = DoFnTester.of(fetcherFnInvalidKey)
-        val outputs = tester.processBundle(listOf(input)) // Pass input as a list
-
-        assertThat(outputs).isNotNull()
-        assertThat(outputs).isEmpty()
-        // Verify httpClient.get was *not* called
-        Mockito.verify(mockHttpClient, Mockito.never()).get(
-            Mockito.anyString(),
-            Mockito.anyMap() // Use anyMap()
-        )
-    }
-
-    @Test
-    fun `processElement handles http error`() {
-        val currencyPair = "BTC/USD"
-        val input: KV<String, Void?> = KV.of(currencyPair, null)
-
-        val urlMatcher = UrlMatcher("token=$testApiKey")
-         Mockito.`when`(mockHttpClient.get(Mockito.argThat { arg: String? -> urlMatcher.matches(arg) },
-            Mockito.anyMap()))
-            .thenThrow(IOException("Network Error"))
-
-        val tester = DoFnTester.of(fetcherFnDaily)
-        val outputs = tester.processBundle(listOf(input)) // Pass input as a list
-
-        assertThat(outputs).isNotNull()
         assertThat(outputs).isEmpty()
     }
 
-    // --- Mockito ArgumentMatcher Implementation ---
+    @Test
+    fun `invalid api key skips fetch`() {
+        val currencyPair = "BTC/USD"
+        val input: KV<String, Void> = KV.of(currencyPair, null)
+        val invalidFn = TiingoCryptoFetcherFn(mockHttpClient, Duration.standardDays(1), "")
+
+        val tester = DoFnTester.of(invalidFn)
+        val outputs = tester.processBundle(listOf(input))
+
+        assertThat(outputs).isEmpty()
+        Mockito.verify(mockHttpClient, Mockito.never()).get(Mockito.anyString(), Mockito.anyMap())
+    }
+
+    @Test
+    fun `io exception yields no output`() {
+        val currencyPair = "BTC/USD"
+        val input: KV<String, Void> = KV.of(currencyPair, null)
+
+        Mockito.`when`(
+            mockHttpClient.get(Mockito.argThat { it!!.contains("token=$testApiKey") },
+                               Mockito.anyMap())
+        ).thenThrow(IOException("network error"))
+
+        val tester = DoFnTester.of(fetcherFnDaily)
+        val outputs = tester.processBundle(listOf(input))
+
+        assertThat(outputs).isEmpty()
+    }
+
     private class UrlMatcher(vararg val substrings: String) : ArgumentMatcher<String> {
-        override fun matches(argument: String?): Boolean {
-            return argument != null && substrings.all { argument.contains(it) }
-        }
-        override fun toString(): String = "URL containing $substrings"
-    }
-
-    // Helper for any() with generics and nullability
-    private fun <T> any(): T {
-        Mockito.any<T>()
-        // Provide a non-null default value (or handle null appropriately if needed)
-        // Depending on the type T, this might need adjustment. For Map, emptyMap is safe.
-        @Suppress("UNCHECKED_CAST")
-        return Collections.emptyMap<String, String>() as T
+        override fun matches(argument: String?): Boolean =
+            argument != null && substrings.all { argument.contains(it) }
+        override fun toString(): String = "URL containing ${substrings.joinToString()}"
     }
 }

--- a/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
+++ b/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
@@ -63,9 +63,9 @@ class TiingoCryptoFetcherFnTest {
             .apply(Create.of(KV.of(pair, null as Void?)))
 
         val fetcherTransformDaily: PTransform<in PCollection<KV<String, Void>>, PCollection<KV<String, Candle>>> = ParDo.of(fetcherFnDaily)
-        val output = input.apply("RunFetcherDaily", fetcherTransformDaily)
+        val output: PCollection<KV<String, Candle>> = input.apply("RunFetcherDaily", fetcherTransformDaily)
 
-        PAssert.that(output).satisfies { elements ->
+        PAssert.that(output).satisfies { elements: Iterable<KV<String, Candle>> ->
             val results = elements.toList()
             assertThat(results).hasSize(2)
             assertThat(results[0].key).isEqualTo(pair)
@@ -87,7 +87,7 @@ class TiingoCryptoFetcherFnTest {
             .apply(Create.of(KV.of(pair, null as Void?)))
 
         val fetcherTransformIOException: PTransform<in PCollection<KV<String, Void>>, PCollection<KV<String, Candle>>> = ParDo.of(fetcherFnDaily)
-        val output = input.apply("RunFetcherIOException", fetcherTransformIOException)
+        val output: PCollection<KV<String, Candle>> = input.apply("RunFetcherIOException", fetcherTransformIOException)
 
         PAssert.that(output).empty()
 
@@ -99,9 +99,9 @@ class TiingoCryptoFetcherFnTest {
         val invalidFn = TiingoCryptoFetcherFn(mockHttpClient, Duration.standardDays(1), "")
         val pair = "BTC/USD"
 
-        val input  = pipeline.apply(Create.of(KV.of(pair, null as Void?)))
+        val input = pipeline.apply(Create.of(KV.of(pair, null as Void?)))
         val invalidFetcherTransform: PTransform<in PCollection<KV<String, Void>>, PCollection<KV<String, Candle>>> = ParDo.of(invalidFn)
-        val output = input.apply("RunFetcherInvalidKey", invalidFetcherTransform)
+        val output: PCollection<KV<String, Candle>> = input.apply("RunFetcherInvalidKey", invalidFetcherTransform)
 
         PAssert.that(output).empty()
         pipeline.run().waitUntilFinish()

--- a/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
+++ b/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
@@ -1,9 +1,6 @@
 package com.verlumen.tradestream.marketdata
 
 import com.google.common.truth.Truth.assertThat
-import org.hamcrest.Matchers.* // For Hamcrest matchers in the first test
-import org.mockito.kotlin.* // For any(), argThat(), whenever()
-
 import com.google.protobuf.util.Timestamps
 import com.verlumen.tradestream.http.HttpClient
 import org.apache.beam.sdk.testing.PAssert
@@ -17,9 +14,13 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import org.mockito.ArgumentMatcher // Import standard Mockito matcher
 import org.mockito.Mock
+import org.mockito.Mockito // Import Mockito for verify etc.
 import org.mockito.junit.MockitoJUnit
 import org.mockito.junit.MockitoRule
+import org.mockito.kotlin.any // Still using mockito-kotlin's any() for simplicity, but not essential
+import org.mockito.kotlin.whenever
 import java.io.IOException
 
 @RunWith(JUnit4::class)
@@ -37,25 +38,25 @@ class TiingoCryptoFetcherFnTest {
 
     private val testApiKey = "TEST_API_KEY_123"
 
-    // Sample responses
+    // Sample responses (remain the same)
     private val sampleResponseDaily = """
        [{"ticker": "btcusd", "priceData": [
          {"date": "2023-10-26T00:00:00+00:00", "open": 34500, "high": 34800, "low": 34200, "close": 34650, "volume": 1500},
          {"date": "2023-10-27T00:00:00+00:00", "open": 34650, "high": 35000, "low": 34500, "close": 34950, "volume": 1800}
        ]}]
     """.trimIndent()
-private val sampleResponseMinute = """
+     private val sampleResponseMinute = """
        [{"ticker": "btcusd", "priceData": [
          {"date": "2023-10-27T10:01:00+00:00", "open": 34955, "high": 34970, "low": 34950, "close": 34965, "volume": 8.2}
        ]}]
     """.trimIndent()
-private val emptyResponse = "[]"
+    private val emptyResponse = "[]"
 
     @Before
     fun setUp() {
         // Manually instantiate the DoFn with mocks
         fetcherFnDaily = TiingoCryptoFetcherFn(mockHttpClient, Duration.standardDays(1), testApiKey)
-        fetcherFnMinute = TiingoCryptoFetcherFn(mockHttpClient, Duration.standardMinutes(5), testApiKey) // Example: 5 min granularity
+        fetcherFnMinute = TiingoCryptoFetcherFn(mockHttpClient, Duration.standardMinutes(5), testApiKey)
     }
 
     @Test
@@ -64,28 +65,25 @@ private val emptyResponse = "[]"
         val input = KV.of(currencyPair, null as Void?)
 
         // Mock HTTP client for initial fetch (daily)
-        val expectedStartDate = "2019-01-02" // Should always use default for now
-        // *** Use Hamcrest Matchers.allOf ***
-        val expectedUrl = allOf(
-            containsString("startDate=$expectedStartDate"),
-            containsString("resampleFreq=1day"), // Adjusted to match helper output for daily
-            containsString("tickers=btcusd"),
-            containsString("token=$testApiKey")
-        )
-        whenever(mockHttpClient.get(argThat(expectedUrl), any())).thenReturn(sampleResponseDaily)
+        val expectedStartDate = "2019-01-02"
+        // Use standard Mockito argThat
+        val urlMatcher = argThat(UrlMatcher(
+            "startDate=$expectedStartDate",
+            "resampleFreq=1day",
+            "tickers=btcusd",
+            "token=$testApiKey"
+        ))
+        whenever(mockHttpClient.get(urlMatcher, any())).thenReturn(sampleResponseDaily)
 
-        // Use DoFnTester to test the DoFn in isolation
         val tester = DoFnTester.of(fetcherFnDaily)
-        // *** EXPLICITLY TYPED outputKVs ***
-        val outputKVs: List<KV<String, Candle>> = tester.processBundle(input)
+        val outputKVs = tester.processBundle(input)
 
-        // Assert output
+        // Assert output (remains the same)
         assertThat(outputKVs).hasSize(2)
         assertThat(outputKVs[0].key).isEqualTo(currencyPair)
         assertThat(outputKVs[0].value.close).isEqualTo(34650.0)
         assertThat(outputKVs[1].key).isEqualTo(currencyPair)
         assertThat(outputKVs[1].value.close).isEqualTo(34950.0)
-        // Verify timestamps if needed using Timestamps.toMillis(...)
     }
 
     @Test
@@ -93,22 +91,20 @@ private val emptyResponse = "[]"
         val currencyPair = "BTC/USD"
         val input = KV.of(currencyPair, null as Void?)
 
-        // Mock HTTP client for initial fetch (5 minute)
         val expectedStartDate = "2019-01-02"
-        // *** Use LAMBDA for argThat ***
-        val expectedUrlMatcher: (String) -> Boolean = { url ->
-            url.contains("startDate=$expectedStartDate") &&
-            url.contains("resampleFreq=5min") && // Check correct freq
-            url.contains("tickers=btcusd") &&
-            url.contains("token=$testApiKey")
-        }
-        whenever(mockHttpClient.get(argThat(expectedUrlMatcher), any())).thenReturn(sampleResponseMinute)
+         // Use standard Mockito argThat
+        val urlMatcher = argThat(UrlMatcher(
+             "startDate=$expectedStartDate",
+             "resampleFreq=5min",
+             "tickers=btcusd",
+             "token=$testApiKey"
+        ))
+        whenever(mockHttpClient.get(urlMatcher, any())).thenReturn(sampleResponseMinute)
 
         val tester = DoFnTester.of(fetcherFnMinute) // Use 5-min fetcher
-        // *** EXPLICITLY TYPED outputKVs ***
-        val outputKVs: List<KV<String, Candle>> = tester.processBundle(input)
+        val outputKVs = tester.processBundle(input)
 
-        // Assert output
+        // Assert output (remains the same)
         assertThat(outputKVs).hasSize(1)
         assertThat(outputKVs[0].key).isEqualTo(currencyPair)
         assertThat(outputKVs[0].value.close).isEqualTo(34965.0)
@@ -119,13 +115,11 @@ private val emptyResponse = "[]"
     fun `processElement handles empty api response`() {
         val currencyPair = "BTC/USD"
         val input = KV.of(currencyPair, null as Void?)
-        // *** Use LAMBDA for argThat (simpler) ***
-        val expectedUrlMatcher: (String) -> Boolean = { it.contains("token=$testApiKey") }
-        whenever(mockHttpClient.get(argThat(expectedUrlMatcher), any())).thenReturn(emptyResponse)
+        val urlMatcher = argThat(UrlMatcher("token=$testApiKey")) // Ensure key is still passed
+        whenever(mockHttpClient.get(urlMatcher, any())).thenReturn(emptyResponse)
 
         val tester = DoFnTester.of(fetcherFnDaily)
-        // *** EXPLICITLY TYPED outputKVs ***
-        val outputKVs: List<KV<String, Candle>> = tester.processBundle(input)
+        val outputKVs = tester.processBundle(input)
 
         assertThat(outputKVs).isEmpty()
     }
@@ -134,31 +128,41 @@ private val emptyResponse = "[]"
     fun `processElement skips fetch if api key is invalid`() {
         val currencyPair = "BTC/USD"
         val input = KV.of(currencyPair, null as Void?)
-
-        // Create fetcher with invalid key
         val fetcherFnInvalidKey = TiingoCryptoFetcherFn(mockHttpClient, Duration.standardDays(1), "") // Empty Key
 
         val tester = DoFnTester.of(fetcherFnInvalidKey)
-        // *** EXPLICITLY TYPED outputKVs ***
-        val outputKVs: List<KV<String, Candle>> = tester.processBundle(input)
+        val outputKVs = tester.processBundle(input)
 
         assertThat(outputKVs).isEmpty()
-        // Verify httpClient.get was *not* called (using Mockito.verify if needed, but logic check is sufficient here)
+        // Verify httpClient.get was *not* called
+        Mockito.verify(mockHttpClient, Mockito.never()).get(any(), any())
     }
-
 
     @Test
     fun `processElement handles http error`() {
         val currencyPair = "BTC/USD"
         val input = KV.of(currencyPair, null as Void?)
-        // *** Use LAMBDA for argThat ***
-        val expectedUrlMatcher: (String) -> Boolean = { it.contains("token=$testApiKey") }
-        whenever(mockHttpClient.get(argThat(expectedUrlMatcher), any())).thenThrow(IOException("Network Error"))
+        val urlMatcher = argThat(UrlMatcher("token=$testApiKey"))
+        whenever(mockHttpClient.get(urlMatcher, any())).thenThrow(IOException("Network Error"))
 
         val tester = DoFnTester.of(fetcherFnDaily)
-        // *** EXPLICITLY TYPED outputKVs ***
-        val outputKVs: List<KV<String, Candle>> = tester.processBundle(input)
+        val outputKVs = tester.processBundle(input)
 
         assertThat(outputKVs).isEmpty()
+    }
+
+    // --- Standard Mockito ArgumentMatcher Implementation ---
+    // This replaces the need for mockito-kotlin's argThat helper function syntax
+    // and the separate contains() helper.
+    private class UrlMatcher(vararg val substrings: String) : ArgumentMatcher<String> {
+        override fun matches(argument: String?): Boolean {
+            return argument != null && substrings.all { argument.contains(it) }
+        }
+         override fun toString(): String = "URL containing $substrings"
+    }
+
+    // Helper function to use the standard Mockito matcher
+    private fun argThat(matcher: ArgumentMatcher<String>): String {
+        return Mockito.argThat(matcher) ?: "" // Use Mockito's argThat
     }
 }

--- a/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
+++ b/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
@@ -1,13 +1,18 @@
 package com.verlumen.tradestream.marketdata
 
+import com.google.common.truth.Truth.assertThat // Use Truth for assertions
+import com.google.protobuf.util.Timestamps
 import com.verlumen.tradestream.http.HttpClient
+import org.apache.beam.sdk.testing.PAssert
+import org.apache.beam.sdk.testing.TestPipeline
+import org.apache.beam.sdk.transforms.Create
 import org.apache.beam.sdk.transforms.DoFnTester
 import org.apache.beam.sdk.values.KV
 import org.joda.time.Duration
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.Assert
+import org.junit.Assert // Keep standard Assert for assertTrue/NotNull if preferred
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.mockito.ArgumentMatcher
@@ -15,6 +20,8 @@ import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.junit.MockitoJUnit
 import org.mockito.junit.MockitoRule
+import org.mockito.kotlin.any // Using any() from mockito-kotlin for conciseness
+import org.mockito.kotlin.whenever
 import java.io.IOException
 import java.util.Collections
 
@@ -67,17 +74,21 @@ class TiingoCryptoFetcherFnTest {
             "tickers=btcusd",
             "token=$testApiKey"
         )
-        Mockito.`when`(mockHttpClient.get(Mockito.argThat { arg -> urlMatcher.matches(arg) }, 
-            Mockito.any()))
+        Mockito.`when`(mockHttpClient.get(Mockito.argThat { arg: String? -> urlMatcher.matches(arg) },
+            Mockito.anyMap())) // Use anyMap() for headers
             .thenReturn(sampleResponseDaily)
 
         val tester = DoFnTester.of(fetcherFnDaily)
-        // Use varargs processBundle API with an explicit null-safety casting
-        val outputs = tester.processBundle(input)
+        // Pass input as a list
+        val outputs: List<KV<String, Candle>> = tester.processBundle(listOf(input))
 
-        // For now, we just verify the outputs aren't null or empty
-        Assert.assertNotNull("Expected outputs to not be null", outputs)
-        Assert.assertTrue("Expected outputs to not be empty", outputs != null && !outputs.isEmpty())
+        // Use Truth assertions
+        assertThat(outputs).isNotNull()
+        assertThat(outputs).hasSize(2)
+        assertThat(outputs[0].key).isEqualTo(currencyPair)
+        assertThat(outputs[0].value.close).isEqualTo(34650.0)
+        assertThat(outputs[1].key).isEqualTo(currencyPair)
+        assertThat(outputs[1].value.close).isEqualTo(34950.0)
     }
 
     @Test
@@ -92,46 +103,51 @@ class TiingoCryptoFetcherFnTest {
              "tickers=btcusd",
              "token=$testApiKey"
         )
-        Mockito.`when`(mockHttpClient.get(Mockito.argThat { arg -> urlMatcher.matches(arg) }, 
-            Mockito.any()))
+         Mockito.`when`(mockHttpClient.get(Mockito.argThat { arg: String? -> urlMatcher.matches(arg) },
+            Mockito.anyMap()))
             .thenReturn(sampleResponseMinute)
 
         val tester = DoFnTester.of(fetcherFnMinute)
-        val outputs = tester.processBundle(input)
+        val outputs = tester.processBundle(listOf(input)) // Pass input as a list
 
-        Assert.assertNotNull("Expected outputs to not be null", outputs)
-        Assert.assertTrue("Expected outputs to not be empty", outputs != null && !outputs.isEmpty())
+        assertThat(outputs).isNotNull()
+        assertThat(outputs).hasSize(1)
+        assertThat(outputs[0].key).isEqualTo(currencyPair)
+        assertThat(outputs[0].value.close).isEqualTo(34965.0)
     }
 
     @Test
     fun `processElement handles empty api response`() {
         val currencyPair = "BTC/USD"
         val input: KV<String, Void?> = KV.of(currencyPair, null)
-        
+
         val urlMatcher = UrlMatcher("token=$testApiKey")
-        Mockito.`when`(mockHttpClient.get(Mockito.argThat { arg -> urlMatcher.matches(arg) }, 
-            Mockito.any()))
+         Mockito.`when`(mockHttpClient.get(Mockito.argThat { arg: String? -> urlMatcher.matches(arg) },
+            Mockito.anyMap()))
             .thenReturn(emptyResponse)
 
         val tester = DoFnTester.of(fetcherFnDaily)
-        val outputs = tester.processBundle(input)
+        val outputs = tester.processBundle(listOf(input)) // Pass input as a list
 
-        Assert.assertTrue("Expected empty outputs", outputs == null || outputs.isEmpty())
+        assertThat(outputs).isNotNull()
+        assertThat(outputs).isEmpty() // Use Truth's isEmpty
     }
 
     @Test
     fun `processElement skips fetch if api key is invalid`() {
         val currencyPair = "BTC/USD"
         val input: KV<String, Void?> = KV.of(currencyPair, null)
-        val fetcherFnInvalidKey = TiingoCryptoFetcherFn(mockHttpClient, Duration.standardDays(1), "")
+        val fetcherFnInvalidKey = TiingoCryptoFetcherFn(mockHttpClient, Duration.standardDays(1), "") // Empty Key
 
         val tester = DoFnTester.of(fetcherFnInvalidKey)
-        val outputs = tester.processBundle(input)
+        val outputs = tester.processBundle(listOf(input)) // Pass input as a list
 
-        Assert.assertTrue("Expected empty outputs", outputs == null || outputs.isEmpty())
+        assertThat(outputs).isNotNull()
+        assertThat(outputs).isEmpty()
+        // Verify httpClient.get was *not* called
         Mockito.verify(mockHttpClient, Mockito.never()).get(
             Mockito.anyString(),
-            Mockito.any()
+            Mockito.anyMap() // Use anyMap()
         )
     }
 
@@ -139,16 +155,17 @@ class TiingoCryptoFetcherFnTest {
     fun `processElement handles http error`() {
         val currencyPair = "BTC/USD"
         val input: KV<String, Void?> = KV.of(currencyPair, null)
-        
+
         val urlMatcher = UrlMatcher("token=$testApiKey")
-        Mockito.`when`(mockHttpClient.get(Mockito.argThat { arg -> urlMatcher.matches(arg) }, 
-            Mockito.any()))
+         Mockito.`when`(mockHttpClient.get(Mockito.argThat { arg: String? -> urlMatcher.matches(arg) },
+            Mockito.anyMap()))
             .thenThrow(IOException("Network Error"))
 
         val tester = DoFnTester.of(fetcherFnDaily)
-        val outputs = tester.processBundle(input)
+        val outputs = tester.processBundle(listOf(input)) // Pass input as a list
 
-        Assert.assertTrue("Expected empty outputs", outputs == null || outputs.isEmpty())
+        assertThat(outputs).isNotNull()
+        assertThat(outputs).isEmpty()
     }
 
     // --- Mockito ArgumentMatcher Implementation ---
@@ -157,5 +174,14 @@ class TiingoCryptoFetcherFnTest {
             return argument != null && substrings.all { argument.contains(it) }
         }
         override fun toString(): String = "URL containing $substrings"
+    }
+
+    // Helper for any() with generics and nullability
+    private fun <T> any(): T {
+        Mockito.any<T>()
+        // Provide a non-null default value (or handle null appropriately if needed)
+        // Depending on the type T, this might need adjustment. For Map, emptyMap is safe.
+        @Suppress("UNCHECKED_CAST")
+        return Collections.emptyMap<String, String>() as T
     }
 }

--- a/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
+++ b/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
@@ -1,0 +1,156 @@
+package com.verlumen.tradestream.marketdata
+
+import com.google.common.truth.Truth.assertThat
+import com.google.protobuf.util.Timestamps
+import com.verlumen.tradestream.http.HttpClient
+import org.apache.beam.sdk.testing.PAssert
+import org.apache.beam.sdk.testing.TestPipeline
+import org.apache.beam.sdk.transforms.Create
+import org.apache.beam.sdk.transforms.DoFnTester
+import org.apache.beam.sdk.values.KV
+import org.joda.time.Duration
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnit
+import org.mockito.junit.MockitoRule
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.whenever
+import java.io.IOException
+
+@RunWith(JUnit4::class)
+class TiingoCryptoFetcherFnTest {
+
+    @get:Rule
+    val mockitoRule: MockitoRule = MockitoJUnit.rule()
+
+    @Mock
+    lateinit var mockHttpClient: HttpClient
+
+    // Test instances - Manually create with mocks for now
+    lateinit var fetcherFnDaily: TiingoCryptoFetcherFn
+    lateinit var fetcherFnMinute: TiingoCryptoFetcherFn
+
+    private val testApiKey = "TEST_API_KEY_123"
+
+    // Sample responses
+    private val sampleResponseDaily = """
+       [{"ticker": "btcusd", "priceData": [
+         {"date": "2023-10-26T00:00:00+00:00", "open": 34500, "high": 34800, "low": 34200, "close": 34650, "volume": 1500},
+         {"date": "2023-10-27T00:00:00+00:00", "open": 34650, "high": 35000, "low": 34500, "close": 34950, "volume": 1800}
+       ]}]
+    """.trimIndent()
+     private val sampleResponseMinute = """
+       [{"ticker": "btcusd", "priceData": [
+         {"date": "2023-10-27T10:01:00+00:00", "open": 34955, "high": 34970, "low": 34950, "close": 34965, "volume": 8.2}
+       ]}]
+    """.trimIndent()
+    private val emptyResponse = "[]"
+
+    @Before
+    fun setUp() {
+        // Manually instantiate the DoFn with mocks
+        fetcherFnDaily = TiingoCryptoFetcherFn(mockHttpClient, Duration.standardDays(1), testApiKey)
+        fetcherFnMinute = TiingoCryptoFetcherFn(mockHttpClient, Duration.standardMinutes(5), testApiKey) // Example: 5 min granularity
+    }
+
+    @Test
+    fun `processElement daily fetch uses default start date and outputs KVs`() {
+        val currencyPair = "BTC/USD"
+        val input = KV.of(currencyPair, null as Void?)
+
+        // Mock HTTP client for initial fetch (daily)
+        val expectedStartDate = "2019-01-02" // Should always use default for now
+        val expectedUrl = contains("startDate=$expectedStartDate") and
+                          contains("resampleFreq=1day") and
+                          contains("tickers=btcusd") and
+                          contains("token=$testApiKey")
+        whenever(mockHttpClient.get(argThat(expectedUrl), any())).thenReturn(sampleResponseDaily)
+
+        // Use DoFnTester to test the DoFn in isolation
+        val tester = DoFnTester.of(fetcherFnDaily)
+        val outputKVs = tester.processBundle(input)
+
+        // Assert output
+        assertThat(outputKVs).hasSize(2)
+        assertThat(outputKVs[0].key).isEqualTo(currencyPair)
+        assertThat(outputKVs[0].value.close).isEqualTo(34650.0)
+        assertThat(outputKVs[1].key).isEqualTo(currencyPair)
+        assertThat(outputKVs[1].value.close).isEqualTo(34950.0)
+        // Verify timestamps if needed using Timestamps.toMillis(...)
+    }
+
+    @Test
+    fun `processElement minute fetch uses default start date and correct freq`() {
+        val currencyPair = "BTC/USD"
+        val input = KV.of(currencyPair, null as Void?)
+
+        // Mock HTTP client for initial fetch (5 minute)
+        val expectedStartDate = "2019-01-02"
+        val expectedUrl = contains("startDate=$expectedStartDate") and
+                          contains("resampleFreq=5min") and // Check correct freq
+                          contains("tickers=btcusd") and
+                          contains("token=$testApiKey")
+        whenever(mockHttpClient.get(argThat(expectedUrl), any())).thenReturn(sampleResponseMinute)
+
+        val tester = DoFnTester.of(fetcherFnMinute) // Use 5-min fetcher
+        val outputKVs = tester.processBundle(input)
+
+        // Assert output
+        assertThat(outputKVs).hasSize(1)
+        assertThat(outputKVs[0].key).isEqualTo(currencyPair)
+        assertThat(outputKVs[0].value.close).isEqualTo(34965.0)
+    }
+
+
+    @Test
+    fun `processElement handles empty api response`() {
+        val currencyPair = "BTC/USD"
+        val input = KV.of(currencyPair, null as Void?)
+        val expectedUrl = contains("token=$testApiKey") // Ensure key is still passed
+        whenever(mockHttpClient.get(argThat(expectedUrl), any())).thenReturn(emptyResponse)
+
+        val tester = DoFnTester.of(fetcherFnDaily)
+        val outputKVs = tester.processBundle(input)
+
+        assertThat(outputKVs).isEmpty()
+    }
+
+     @Test
+    fun `processElement skips fetch if api key is invalid`() {
+        val currencyPair = "BTC/USD"
+        val input = KV.of(currencyPair, null as Void?)
+
+        // Create fetcher with invalid key
+         val fetcherFnInvalidKey = TiingoCryptoFetcherFn(mockHttpClient, Duration.standardDays(1), "") // Empty Key
+
+        val tester = DoFnTester.of(fetcherFnInvalidKey)
+        val outputKVs = tester.processBundle(input)
+
+        assertThat(outputKVs).isEmpty()
+        // Verify httpClient.get was *not* called (using Mockito.verify if needed, but logic check is sufficient here)
+    }
+
+
+    @Test
+    fun `processElement handles http error`() {
+        val currencyPair = "BTC/USD"
+        val input = KV.of(currencyPair, null as Void?)
+        val expectedUrl = contains("token=$testApiKey")
+        whenever(mockHttpClient.get(argThat(expectedUrl), any())).thenThrow(IOException("Network Error"))
+
+        val tester = DoFnTester.of(fetcherFnDaily)
+        val outputKVs = tester.processBundle(input)
+
+        assertThat(outputKVs).isEmpty()
+    }
+
+    // Helper for URL matching
+    private fun contains(substring: String): (String) -> Boolean = { it.contains(substring) }
+    private fun <T> argThat(matcher: (T) -> Boolean): T = org.mockito.kotlin.argThat(matcher)
+
+}

--- a/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
+++ b/src/test/java/com/verlumen/tradestream/marketdata/TiingoCryptoFetcherFnTest.kt
@@ -65,10 +65,12 @@ class TiingoCryptoFetcherFnTest {
 
         // Mock HTTP client for initial fetch (daily)
         val expectedStartDate = "2019-01-02" // Should always use default for now
-        val expectedUrl = contains("startDate=$expectedStartDate") and
-                          contains("resampleFreq=1day") and
-                          contains("tickers=btcusd") and
-                          contains("token=$testApiKey")
+        val expectedUrl = org.hamcrest.Matchers.allOf(
+            org.hamcrest.Matchers.containsString("startDate=$expectedStartDate"),
+            org.hamcrest.Matchers.containsString("resampleFreq=daily"),
+            org.hamcrest.Matchers.containsString("tickers=btcusd"),
+            org.hamcrest.Matchers.containsString("token=$testApiKey")
+        )
         whenever(mockHttpClient.get(argThat(expectedUrl), any())).thenReturn(sampleResponseDaily)
 
         // Use DoFnTester to test the DoFn in isolation


### PR DESCRIPTION
This change introduces a new Beam `DoFn`, `TiingoCryptoFetcherFn`, which retrieves historical cryptocurrency candle data from the Tiingo API. It accepts currency pairs as input and emits parsed `Candle` objects downstream.

### Summary of Changes:

* **New Kotlin Transform:**

  * Implemented `TiingoCryptoFetcherFn`, a Beam `DoFn` that:

    * Accepts `KV<String, Void?>` input for currency pairs.
    * Constructs Tiingo API requests based on configurable granularity and API key.
    * Parses the API response using existing `TiingoResponseParser`.
    * Emits `KV<String, Candle>` for each parsed candle.
    * Handles invalid API keys and I/O exceptions gracefully with proper logging.
* **Build File Updates:**

  * Added new Bazel targets for `tiingo_crypto_fetcher_fn` and its corresponding test.
* **Unit Tests:**

  * Added `TiingoCryptoFetcherFnTest.kt` with test coverage for:

    * Successful candle fetch and output verification.
    * Handling of I/O exceptions.
    * Behavior with missing/invalid API keys.
