### PR TITLE
Add `mockito-kotlin` dependency for Kotlin-based testing

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -77,6 +77,7 @@ maven.install(
         "com.google.truth:truth:1.4.4",
         "junit:junit:4.13.2",
         "org.mockito:mockito-core:4.3.1",
+        "org.mockito.kotlin:mockito-kotlin:5.4.0",
     ],
     fetch_sources = True,
     repositories = [

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -237,6 +237,15 @@ java_library(
 )
 
 java_library(
+    name = "mockito_kotlin",
+    visibility = ["//visibility:public"],
+    exports = [
+        "@tradestream_maven//:org_mockito_kotlin_mockito_kotlin",
+    ],
+    testonly = True,
+)
+
+java_library(
     name = "mug",
     visibility = ["//visibility:public"],
     exports = [


### PR DESCRIPTION
This change introduces support for Kotlin-based unit testing by adding the `org.mockito.kotlin:mockito-kotlin:5.4.0` dependency to the Bazel build configuration:

* Updated `MODULE.bazel` to include the `mockito-kotlin` artifact in the Maven install list.
* Added a new `java_library` target for `mockito_kotlin` in `third_party/BUILD`, exposing the dependency for use in tests.

This prepares the codebase for future Kotlin test development or migration and ensures compatibility with Mockito in Kotlin contexts.

No (MAJOR) or (MINOR) version tag is required as this is a patch-level change.
