### PR TITLE
Add CandleSource Abstract Class and Bazel Build Target

### DIFF
--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -30,6 +30,14 @@ kt_jvm_library(
     ],
 )
 
+java_library(
+    name = "candle_source",
+    srcs = ["CandleSource.java"],
+    deps = [
+        "//protos:marketdata_java_proto",
+        "//third_party:beam_sdks_java_core",    ],
+)
+
 # Coinbase specific streaming client
 java_library(
     name = "coinbase_streaming_client",

--- a/src/main/java/com/verlumen/tradestream/marketdata/CandleSource.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/CandleSource.java
@@ -1,0 +1,8 @@
+package com.verlumen.tradestream.marketdata;
+
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.KV
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+
+public abstract class CandleSource extends PTransform<PBegin,PCollection<KV<String, Candle>>> {}

--- a/src/main/java/com/verlumen/tradestream/marketdata/CandleSource.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/CandleSource.java
@@ -1,7 +1,7 @@
 package com.verlumen.tradestream.marketdata;
 
 import org.apache.beam.sdk.transforms.PTransform;
-import org.apache.beam.sdk.values.KV
+import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 


### PR DESCRIPTION
This PR introduces the `CandleSource` abstract class to the `marketdata` module and defines its corresponding Bazel build target.

### Summary of Changes:

* Created `CandleSource.java` in `src/main/java/com/verlumen/tradestream/marketdata/`.

  * It extends `PTransform` to represent a Beam transform for producing `PCollection` of key-value pairs of `String` and `Candle`.
  * Serves as a base class for different candle data sources.
* Updated the Bazel `BUILD` file:

  * Added a new `java_library` target named `candle_source`.
  * Included necessary dependencies: `marketdata_java_proto` and `beam_sdks_java_core`.

These changes lay the groundwork for integrating various streaming candle sources into the processing pipeline.
