### PR TITLE
Add Python dependencies for `absl-py`, `influxdb-client`, and `requests`; remove Windows-specific requirements file

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -45,7 +45,6 @@ pip.parse(
     # We need to use the same version here as in the `python.toolchain` call.
     python_version = "3.9.13",
     requirements_lock = "//:requirements_lock.txt",
-    requirements_windows = "//:requirements_windows.txt",
 )
 use_repo(pip, "pypi")
 

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -1,3 +1,6 @@
+load("@pip//:requirements.bzl", "requirement")
+load("@rules_python//python:py_library.bzl", "py_library")
+
 java_library(
     name = "argparse4j",
     visibility = ["//visibility:public"],
@@ -308,5 +311,13 @@ java_library(
     visibility = ["//visibility:public"],
     exports = [
         "@tradestream_maven//:org_knowm_xchange_xchange_stream_core",
+    ],
+)
+
+py_library(
+    name = "requests",
+    visibility = ["//visibility:public"],
+    deps = [
+        requirement("requests"),
     ],
 )

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -1,4 +1,4 @@
-load("@pip//:requirements.bzl", "requirement")
+load("@pypi//:requirements.bzl", "requirement")
 load("@rules_python//python:py_library.bzl", "py_library")
 
 java_library(

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -315,6 +315,14 @@ java_library(
 )
 
 py_library(
+    name = "absl_py",
+    visibility = ["//visibility:public"],
+    deps = [
+        requirement("absl-py"),
+    ],
+)
+
+py_library(
     name = "requests",
     visibility = ["//visibility:public"],
     deps = [

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -323,6 +323,14 @@ py_library(
 )
 
 py_library(
+    name = "influxdb_client",
+    visibility = ["//visibility:public"],
+    deps = [
+        requirement("influxdb-client"),
+    ],
+)
+
+py_library(
     name = "requests",
     visibility = ["//visibility:public"],
     deps = [


### PR DESCRIPTION
This PR introduces several updates to the Bazel build configuration:

#### Changes:

1. **MODULE.bazel**:

   * Removed the `requirements_windows` dependency, streamlining the dependency configuration for cross-platform compatibility.

2. **third\_party/BUILD**:

   * Added `py_library` targets for:

     * `absl_py` → Maps to the `absl-py` PyPI package.
     * `influxdb_client` → Maps to the `influxdb-client` PyPI package.
     * `requests` → Maps to the `requests` PyPI package.
   * Included necessary Bazel `load` statements to support `py_library` targets.

#### Rationale:

The added Python dependencies are necessary for upcoming features that require integration with `absl-py`, `influxdb-client`, and `requests`. The removal of the Windows-specific requirements file is part of a broader effort to simplify dependency management and eliminate unused configurations.

No functional logic was altered—this change is strictly dependency and build-related.
