### PR TITLE
Add state tracking to InfluxDBManager and integrate persistent resume support for backfill and polling (MINOR)

### DIFF
--- a/services/candle_ingestor/influx_client.py
+++ b/services/candle_ingestor/influx_client.py
@@ -99,7 +99,6 @@ class InfluxDBManager:
             except (TypeError, ValueError) as ve:
                 logging.warning(f"Skipping candle due to value error {ve}: {candle_dict}")
 
-
         if not points:
             logging.info("No valid points to write after filtering.")
             return 0
@@ -188,7 +187,6 @@ class InfluxDBManager:
             logging.error(f"InfluxDBError updating processing state for {symbol} ({ingestion_type}): {e}")
         except Exception as e:
             logging.error(f"Generic error updating processing state for {symbol} ({ingestion_type}): {e}")
-
 
     def close(self):
         if self.client:

--- a/services/candle_ingestor/influx_client.py
+++ b/services/candle_ingestor/influx_client.py
@@ -1,7 +1,7 @@
 from absl import logging
 from influxdb_client import InfluxDBClient, Point, WritePrecision
 from influxdb_client.client.write_api import SYNCHRONOUS
-from influxdb_client.client.exceptions import InfluxDBError # For more specific error handling
+from influxdb_client.client.exceptions import InfluxDBError
 
 
 class InfluxDBManager:

--- a/services/candle_ingestor/influx_client_test.py
+++ b/services/candle_ingestor/influx_client_test.py
@@ -234,7 +234,13 @@ class TestInfluxDBManager(unittest.TestCase):
         manager = influx_client.InfluxDBManager(
             self.test_url, self.test_token, self.test_org, self.test_bucket
         )
-        self.mock_query_api_instance.query.side_effect = InfluxDBError(response="Simulated DB Error")
+        
+        # Create a mock response object for InfluxDBError
+        mock_response = mock.MagicMock()
+        mock_response.data = "Simulated DB Error"
+        mock_response.status = 500
+        
+        self.mock_query_api_instance.query.side_effect = InfluxDBError(response=mock_response)
 
         # Act
         timestamp = manager.get_last_processed_timestamp("adausd", "backfill")
@@ -277,7 +283,13 @@ class TestInfluxDBManager(unittest.TestCase):
         manager = influx_client.InfluxDBManager(
             self.test_url, self.test_token, self.test_org, self.test_bucket
         )
-        self.mock_write_api_instance.write.side_effect = InfluxDBError(response="Simulated DB Write Error")
+        
+        # Create a mock response object for InfluxDBError
+        mock_response = mock.MagicMock()
+        mock_response.data = "Simulated DB Write Error"
+        mock_response.status = 500
+        
+        self.mock_write_api_instance.write.side_effect = InfluxDBError(response=mock_response)
 
         # Act
         # This should not raise an exception out of the method due to try-except

--- a/services/candle_ingestor/influx_client_test.py
+++ b/services/candle_ingestor/influx_client_test.py
@@ -3,6 +3,8 @@ from unittest import mock
 
 # Your module to test
 from services.candle_ingestor import influx_client
+from influxdb_client import InfluxDBClient, Point, WritePrecision # Added Point, WritePrecision
+from influxdb_client.client.exceptions import InfluxDBError # Added InfluxDBError
 
 
 # Mock the InfluxDBClient itself and its methods
@@ -14,10 +16,20 @@ class TestInfluxDBManager(unittest.TestCase):
         self.test_org = "fake-org"
         self.test_bucket = "fake-bucket"
 
+        # Mock instances that will be returned by InfluxDBClient()
+        self.mock_client_instance = mock.MagicMock(spec=InfluxDBClient)
+        self.mock_write_api_instance = mock.MagicMock()
+        self.mock_query_api_instance = mock.MagicMock()
+
+        # Configure client instance to return mock APIs
+        self.mock_client_instance.write_api.return_value = self.mock_write_api_instance
+        self.mock_client_instance.query_api.return_value = self.mock_query_api_instance
+
+
     def test_connect_success(self, MockInfluxDBClient):
         # Arrange
-        mock_client_instance = MockInfluxDBClient.return_value
-        mock_client_instance.ping.return_value = True
+        MockInfluxDBClient.return_value = self.mock_client_instance # Ensure our mock is used
+        self.mock_client_instance.ping.return_value = True
 
         # Act
         manager = influx_client.InfluxDBManager(
@@ -28,15 +40,15 @@ class TestInfluxDBManager(unittest.TestCase):
         MockInfluxDBClient.assert_called_once_with(
             url=self.test_url, token=self.test_token, org=self.test_org
         )
-        mock_client_instance.ping.assert_called_once()
+        self.mock_client_instance.ping.assert_called_once()
         self.assertIsNotNone(manager.get_client())
         self.assertEqual(manager.get_bucket(), self.test_bucket)
         self.assertEqual(manager.get_org(), self.test_org)
 
     def test_connect_ping_fails(self, MockInfluxDBClient):
         # Arrange
-        mock_client_instance = MockInfluxDBClient.return_value
-        mock_client_instance.ping.return_value = False
+        MockInfluxDBClient.return_value = self.mock_client_instance
+        self.mock_client_instance.ping.return_value = False
 
         # Act
         manager = influx_client.InfluxDBManager(
@@ -44,7 +56,7 @@ class TestInfluxDBManager(unittest.TestCase):
         )
 
         # Assert
-        self.assertIsNone(manager.get_client())  # Client should be set to None
+        self.assertIsNone(manager.get_client())
 
     def test_connect_exception_on_client_creation(self, MockInfluxDBClient):
         # Arrange
@@ -60,8 +72,8 @@ class TestInfluxDBManager(unittest.TestCase):
 
     def test_connect_exception_on_ping(self, MockInfluxDBClient):
         # Arrange
-        mock_client_instance = MockInfluxDBClient.return_value
-        mock_client_instance.ping.side_effect = Exception("Ping network error")
+        MockInfluxDBClient.return_value = self.mock_client_instance
+        self.mock_client_instance.ping.side_effect = Exception("Ping network error")
 
         # Act
         manager = influx_client.InfluxDBManager(
@@ -73,10 +85,9 @@ class TestInfluxDBManager(unittest.TestCase):
 
     def test_get_write_api_success(self, MockInfluxDBClient):
         # Arrange
-        mock_client_instance = MockInfluxDBClient.return_value
-        mock_client_instance.ping.return_value = True
-        mock_write_api = mock.MagicMock()
-        mock_client_instance.write_api.return_value = mock_write_api
+        MockInfluxDBClient.return_value = self.mock_client_instance
+        self.mock_client_instance.ping.return_value = True
+        # self.mock_write_api_instance is already set up in setUp
 
         manager = influx_client.InfluxDBManager(
             self.test_url, self.test_token, self.test_org, self.test_bucket
@@ -86,8 +97,8 @@ class TestInfluxDBManager(unittest.TestCase):
         write_api = manager.get_write_api()
 
         # Assert
-        self.assertEqual(write_api, mock_write_api)
-        mock_client_instance.write_api.assert_called_once()
+        self.assertEqual(write_api, self.mock_write_api_instance)
+        self.mock_client_instance.write_api.assert_called_once()
 
     def test_get_write_api_client_not_initialized(self, MockInfluxDBClient):
         # Arrange
@@ -104,10 +115,9 @@ class TestInfluxDBManager(unittest.TestCase):
 
     def test_get_query_api_success(self, MockInfluxDBClient):
         # Arrange
-        mock_client_instance = MockInfluxDBClient.return_value
-        mock_client_instance.ping.return_value = True
-        mock_query_api = mock.MagicMock()
-        mock_client_instance.query_api.return_value = mock_query_api
+        MockInfluxDBClient.return_value = self.mock_client_instance
+        self.mock_client_instance.ping.return_value = True
+        # self.mock_query_api_instance is already set up in setUp
 
         manager = influx_client.InfluxDBManager(
             self.test_url, self.test_token, self.test_org, self.test_bucket
@@ -117,8 +127,8 @@ class TestInfluxDBManager(unittest.TestCase):
         query_api = manager.get_query_api()
 
         # Assert
-        self.assertEqual(query_api, mock_query_api)
-        mock_client_instance.query_api.assert_called_once()
+        self.assertEqual(query_api, self.mock_query_api_instance)
+        self.mock_client_instance.query_api.assert_called_once()
 
     def test_get_query_api_client_not_initialized(self, MockInfluxDBClient):
         # Arrange
@@ -135,23 +145,22 @@ class TestInfluxDBManager(unittest.TestCase):
 
     def test_close_client(self, MockInfluxDBClient):
         # Arrange
-        mock_client_instance = MockInfluxDBClient.return_value
-        mock_client_instance.ping.return_value = True
+        MockInfluxDBClient.return_value = self.mock_client_instance
+        self.mock_client_instance.ping.return_value = True
         manager = influx_client.InfluxDBManager(
             self.test_url, self.test_token, self.test_org, self.test_bucket
         )
-        self.assertIsNotNone(manager.get_client())  # Ensure client was set
+        self.assertIsNotNone(manager.get_client())
 
         # Act
         manager.close()
 
         # Assert
-        mock_client_instance.close.assert_called_once()
+        self.mock_client_instance.close.assert_called_once()
 
     def test_close_client_not_initialized(self, MockInfluxDBClient):
         # Arrange
-        mock_client_instance = MockInfluxDBClient.return_value
-        mock_client_instance.ping.return_value = False  # Ensure client is None
+        MockInfluxDBClient.return_value.ping.return_value = False # Client is None
         manager = influx_client.InfluxDBManager(
             self.test_url, self.test_token, self.test_org, self.test_bucket
         )
@@ -160,7 +169,122 @@ class TestInfluxDBManager(unittest.TestCase):
         manager.close()  # Should not throw error
 
         # Assert
-        mock_client_instance.close.assert_not_called()
+        self.mock_client_instance.close.assert_not_called() # close on the *instance*
+
+    # --- New tests for state management ---
+
+    def test_get_last_processed_timestamp_success(self, MockInfluxDBClient):
+        # Arrange
+        MockInfluxDBClient.return_value = self.mock_client_instance
+        self.mock_client_instance.ping.return_value = True
+        manager = influx_client.InfluxDBManager(
+            self.test_url, self.test_token, self.test_org, self.test_bucket
+        )
+
+        mock_table = mock.MagicMock()
+        mock_record = mock.MagicMock()
+        mock_record.get_value.return_value = 1678886400000 # Example timestamp
+        mock_table.records = [mock_record]
+        self.mock_query_api_instance.query.return_value = [mock_table]
+
+        symbol = "btcusd"
+        ingestion_type = "backfill"
+
+        # Act
+        timestamp = manager.get_last_processed_timestamp(symbol, ingestion_type)
+
+        # Assert
+        self.assertEqual(timestamp, 1678886400000)
+        expected_query = f'''
+        from(bucket: "{self.test_bucket}")
+          |> range(start: 0)
+          |> filter(fn: (r) => r._measurement == "ingestor_processing_state")
+          |> filter(fn: (r) => r.symbol == "{symbol}")
+          |> filter(fn: (r) => r.ingestion_type == "{ingestion_type}")
+          |> filter(fn: (r) => r._field == "last_processed_timestamp_ms")
+          |> sort(columns: ["_time"], desc: true)
+          |> limit(n: 1)
+          |> yield(name: "last")
+        '''
+        self.mock_query_api_instance.query.assert_called_once_with(query=mock.ANY, org=self.test_org)
+        # More precise query matching if needed, by capturing the query argument
+        args, kwargs = self.mock_query_api_instance.query.call_args
+        self.assertEqual(kwargs['query'].strip(), expected_query.strip())
+
+
+    def test_get_last_processed_timestamp_no_data(self, MockInfluxDBClient):
+        # Arrange
+        MockInfluxDBClient.return_value = self.mock_client_instance
+        self.mock_client_instance.ping.return_value = True
+        manager = influx_client.InfluxDBManager(
+            self.test_url, self.test_token, self.test_org, self.test_bucket
+        )
+        self.mock_query_api_instance.query.return_value = [] # No tables/records
+
+        # Act
+        timestamp = manager.get_last_processed_timestamp("ethusd", "polling")
+
+        # Assert
+        self.assertIsNone(timestamp)
+
+    def test_get_last_processed_timestamp_influxdb_error(self, MockInfluxDBClient):
+        # Arrange
+        MockInfluxDBClient.return_value = self.mock_client_instance
+        self.mock_client_instance.ping.return_value = True
+        manager = influx_client.InfluxDBManager(
+            self.test_url, self.test_token, self.test_org, self.test_bucket
+        )
+        self.mock_query_api_instance.query.side_effect = InfluxDBError(response="Simulated DB Error")
+
+        # Act
+        timestamp = manager.get_last_processed_timestamp("adausd", "backfill")
+
+        # Assert
+        self.assertIsNone(timestamp) # Should handle error and return None
+
+    def test_update_last_processed_timestamp_writes_correct_point(self, MockInfluxDBClient):
+        # Arrange
+        MockInfluxDBClient.return_value = self.mock_client_instance
+        self.mock_client_instance.ping.return_value = True
+        manager = influx_client.InfluxDBManager(
+            self.test_url, self.test_token, self.test_org, self.test_bucket
+        )
+
+        symbol = "btcusd"
+        ingestion_type = "backfill"
+        timestamp_ms = 1678886400000
+
+        # Act
+        manager.update_last_processed_timestamp(symbol, ingestion_type, timestamp_ms)
+
+        # Assert
+        self.mock_write_api_instance.write.assert_called_once()
+        args, kwargs = self.mock_write_api_instance.write.call_args
+        written_record = kwargs['record']
+
+        # Assuming it's a single Point object for simplicity in this test
+        self.assertIsInstance(written_record, Point)
+        self.assertEqual(written_record._name, "ingestor_processing_state")
+        self.assertIn(("symbol", symbol), written_record._tags.items())
+        self.assertIn(("ingestion_type", ingestion_type), written_record._tags.items())
+        self.assertIn(("last_processed_timestamp_ms", timestamp_ms), written_record._fields.items())
+
+
+    def test_update_last_processed_timestamp_influxdb_error(self, MockInfluxDBClient):
+        # Arrange
+        MockInfluxDBClient.return_value = self.mock_client_instance
+        self.mock_client_instance.ping.return_value = True
+        manager = influx_client.InfluxDBManager(
+            self.test_url, self.test_token, self.test_org, self.test_bucket
+        )
+        self.mock_write_api_instance.write.side_effect = InfluxDBError(response="Simulated DB Write Error")
+
+        # Act
+        # This should not raise an exception out of the method due to try-except
+        manager.update_last_processed_timestamp("ethusd", "polling", 1678886400000)
+
+        # Assert
+        self.mock_write_api_instance.write.assert_called_once() # Still called
 
 
 if __name__ == "__main__":

--- a/services/candle_ingestor/ingestion_helpers.py
+++ b/services/candle_ingestor/ingestion_helpers.py
@@ -28,21 +28,34 @@ def parse_backfill_start_date(date_str: str) -> datetime:
     """
     now = datetime.now(timezone.utc)
     date_str_lower = date_str.lower()
+    
+    logging.debug(f"Parsing backfill_start_date: {date_str_lower}")
 
-    if re.match(r"^\d+_days_ago$", date_str_lower):
+    # Match X_day_ago or X_days_ago (singular or plural)
+    if re.match(r"^\d+_days?_ago$", date_str_lower):
         days = int(date_str_lower.split("_")[0])
+        logging.debug(f"Matched X_day(s)_ago pattern, days={days}")
         return now - timedelta(days=days)
-    elif re.match(r"^\d+_weeks_ago$", date_str_lower):
+    
+    # Match X_week_ago or X_weeks_ago
+    elif re.match(r"^\d+_weeks?_ago$", date_str_lower):
         weeks = int(date_str_lower.split("_")[0])
+        logging.debug(f"Matched X_week(s)_ago pattern, weeks={weeks}")
         return now - timedelta(weeks=weeks)
-    elif re.match(r"^\d+_months_ago$", date_str_lower):
+    
+    # Match X_month_ago or X_months_ago
+    elif re.match(r"^\d+_months?_ago$", date_str_lower):
         months = int(date_str_lower.split("_")[0])
+        logging.debug(f"Matched X_month(s)_ago pattern, months={months}")
         # Approximate months as 30 days for timedelta.
         # For more precision, consider `from dateutil.relativedelta import relativedelta`
         # and `return now - relativedelta(months=months)`
         return now - timedelta(days=months * 30)
-    elif re.match(r"^\d+_years_ago$", date_str_lower):
+    
+    # Match X_year_ago or X_years_ago
+    elif re.match(r"^\d+_years?_ago$", date_str_lower):
         years = int(date_str_lower.split("_")[0])
+        logging.debug(f"Matched X_year(s)_ago pattern, years={years}")
         # For more precision, consider `from dateutil.relativedelta import relativedelta`
         # and `return now - relativedelta(years=years)`
         return now - timedelta(days=years * 365)
@@ -50,6 +63,7 @@ def parse_backfill_start_date(date_str: str) -> datetime:
     try:
         # Attempt to parse as YYYY-MM-DD
         dt = datetime.strptime(date_str, "%Y-%m-%d")
+        logging.debug(f"Parsed as YYYY-MM-DD: {dt.isoformat()}")
         return dt.replace(tzinfo=timezone.utc)  # Make it timezone-aware UTC
     except ValueError:
         logging.error(

--- a/services/candle_ingestor/main.py
+++ b/services/candle_ingestor/main.py
@@ -34,8 +34,6 @@ flags.DEFINE_string(
 # InfluxDB Flags
 default_influx_url = os.getenv(
     "INFLUXDB_URL",
-    # Adjust this if your Helm release name for InfluxDB is different,
-    # or if not running in k8s and need a direct localhost.
     "http://influxdb.tradestream-namespace.svc.cluster.local:8086",
 )
 flags.DEFINE_string("influxdb_url", default_influx_url, "InfluxDB URL.")
@@ -48,7 +46,7 @@ flags.DEFINE_string(
 flags.DEFINE_string(
     "influxdb_bucket",
     os.getenv("INFLUXDB_BUCKET", "tradestream-data"),
-    "InfluxDB Bucket for candles.",
+    "InfluxDB Bucket for candles and state.", # Clarified bucket usage
 )
 
 # Candle Processing Flags
@@ -85,53 +83,62 @@ def run_backfill(
     backfill_start_date_str: str,
     candle_granularity_minutes: int,
     api_call_delay_seconds: int,
+    # last_backfilled_timestamps is now primarily for in-run tracking,
+    # initial state comes from DB before this function is called.
+    # It could be removed if all state is managed strictly via DB calls within the loop.
+    # For now, let's assume it's pre-populated with DB state by the caller (main function).
     last_backfilled_timestamps: dict[str, int],
 ):
     logging.info("Starting historical candle backfill...")
-    start_date_dt = parse_backfill_start_date(backfill_start_date_str)
+    # Overall earliest start date from flags
+    earliest_backfill_flag_dt = parse_backfill_start_date(backfill_start_date_str)
     # End date for historical is up to the start of the current UTC day (exclusive)
     end_date_dt = datetime.now(timezone.utc).replace(
         hour=0, minute=0, second=0, microsecond=0
     )
 
-    if start_date_dt >= end_date_dt:
+    if earliest_backfill_flag_dt >= end_date_dt:
         logging.info(
-            f"Backfill start date ({start_date_dt.strftime('%Y-%m-%d')}) is not before "
+            f"Backfill flag start date ({earliest_backfill_flag_dt.strftime('%Y-%m-%d')}) is not before "
             f"effective end date ({end_date_dt.strftime('%Y-%m-%d')}). Skipping backfill."
         )
         return
 
     resample_freq = get_tiingo_resample_freq(candle_granularity_minutes)
+    granularity_delta = timedelta(minutes=candle_granularity_minutes)
 
     for ticker in tiingo_tickers:
-        # TODO (PR6): Query InfluxDB for the last known candle for this ticker
-        # and adjust current_ticker_start_dt if it's more recent than start_date_dt.
-        current_ticker_start_dt = start_date_dt
-        max_timestamp_for_ticker_in_backfill = (
-            last_backfilled_timestamps.get(ticker, 0)
-        ) # Use existing if available
+        current_run_max_ts_for_ticker = 0 # Tracks max timestamp *within this specific run_backfill execution*
 
-        # Adjust start if already partially backfilled and that point is after calculated start_date_dt
-        if max_timestamp_for_ticker_in_backfill > 0:
-            dt_from_ts = datetime.fromtimestamp(max_timestamp_for_ticker_in_backfill / 1000.0, timezone.utc)
-            # Start from the next candle interval
-            potential_next_start = dt_from_ts.replace(second=0, microsecond=0) + timedelta(minutes=candle_granularity_minutes)
-            current_ticker_start_dt = max(current_ticker_start_dt, potential_next_start)
-        
+        # Determine the actual start date for this specific ticker
+        db_last_backfill_ts_ms = last_backfilled_timestamps.get(ticker) # Pre-populated from DB by main()
+
+        if db_last_backfill_ts_ms and db_last_backfill_ts_ms > 0:
+            dt_from_db_ts = datetime.fromtimestamp(db_last_backfill_ts_ms / 1000.0, timezone.utc)
+            # Start fetching for the period *after* the last successfully recorded candle
+            potential_next_start_from_db = dt_from_db_ts.replace(second=0, microsecond=0) + granularity_delta
+            # current_ticker_start_dt is the later of the flag-defined start or the DB state
+            current_ticker_start_dt = max(earliest_backfill_flag_dt, potential_next_start_from_db)
+            logging.info(f"Resuming backfill for {ticker} from DB state, effective start: {current_ticker_start_dt.isoformat()}")
+        else:
+            # No DB state for this ticker, use the original start_date_dt from flags/parsing
+            current_ticker_start_dt = earliest_backfill_flag_dt
+            logging.info(f"Starting new backfill for {ticker} from flag-defined start: {current_ticker_start_dt.isoformat()}")
+
+
         if current_ticker_start_dt >= end_date_dt:
-            logging.info(f"Ticker {ticker} already backfilled up to or beyond target end date. Last backfilled ts: {max_timestamp_for_ticker_in_backfill}. Skipping.")
+            logging.info(f"Ticker {ticker} already effectively backfilled up to or beyond target end date. Last known DB ts: {db_last_backfill_ts_ms}. Skipping.")
             continue
 
         logging.info(
             f"Backfilling {ticker} from {current_ticker_start_dt.strftime('%Y-%m-%d %H:%M:%S')} to {end_date_dt.strftime('%Y-%m-%d %H:%M:%S')}"
         )
         chunk_start_dt = current_ticker_start_dt
-        
+
         while chunk_start_dt < end_date_dt:
             chunk_start_str = chunk_start_dt.strftime("%Y-%m-%d")
-            # Fetch up to 90 days or until end_date_dt, whichever is sooner
             chunk_end_dt = min(
-                chunk_start_dt + timedelta(days=89), end_date_dt - timedelta(microseconds=1) # Ensure end is inclusive for daily, and not overlapping for intraday
+                chunk_start_dt + timedelta(days=89), end_date_dt - timedelta(microseconds=1)
             )
             chunk_end_str = chunk_end_dt.strftime("%Y-%m-%d")
 
@@ -141,34 +148,39 @@ def run_backfill(
             historical_candles = get_historical_candles_tiingo(
                 tiingo_api_key,
                 ticker,
-                chunk_start_str, # Tiingo /prices takes date strings for historical
+                chunk_start_str,
                 chunk_end_str,
                 resample_freq,
             )
             if historical_candles:
                 historical_candles.sort(key=lambda c: c["timestamp_ms"])
-                influx_manager.write_candles_batch(historical_candles)
-                if historical_candles: # update max_timestamp
-                    max_timestamp_for_ticker_in_backfill = max(
-                        max_timestamp_for_ticker_in_backfill,
-                        historical_candles[-1]["timestamp_ms"],
-                    )
+                written_count = influx_manager.write_candles_batch(historical_candles)
+                if written_count > 0:
+                    latest_ts_in_batch = historical_candles[-1]["timestamp_ms"]
+                    current_run_max_ts_for_ticker = max(current_run_max_ts_for_ticker, latest_ts_in_batch)
+                    # Update InfluxDB state immediately after successful batch write
+                    influx_manager.update_last_processed_timestamp(ticker, "backfill", latest_ts_in_batch)
+                    logging.info(f"  Successfully wrote {written_count} candles. Updated InfluxDB backfill state for {ticker} to {latest_ts_in_batch}")
+                else:
+                    logging.warning(f"  Write_candles_batch reported 0 candles written for {ticker} despite having data. DB State not updated for this batch.")
             else:
                 logging.info(
                     f"  No data in chunk for {ticker}: {chunk_start_str} to {chunk_end_str}"
                 )
 
-            chunk_start_dt = chunk_end_dt + timedelta(days=1) # Next chunk starts the following day
-            if chunk_start_dt < end_date_dt and len(tiingo_tickers) > 1: # Avoid sleep if only one ticker or last chunk
+            chunk_start_dt = chunk_end_dt + timedelta(days=1)
+            if chunk_start_dt < end_date_dt and len(tiingo_tickers) > 1:
                 logging.info(
                     f"Waiting {api_call_delay_seconds}s before next API call/chunk for {ticker}..."
                 )
                 time.sleep(api_call_delay_seconds)
-        
-        if max_timestamp_for_ticker_in_backfill > 0:
-            last_backfilled_timestamps[ticker] = max_timestamp_for_ticker_in_backfill
+
+        # Update the passed-in dict with the latest timestamp from this specific run (optional, as DB is primary)
+        if current_run_max_ts_for_ticker > 0:
+             last_backfilled_timestamps[ticker] = max(last_backfilled_timestamps.get(ticker, 0), current_run_max_ts_for_ticker)
+
         logging.info(
-            f"Finished backfill for {ticker}. Last backfilled ts: {last_backfilled_timestamps.get(ticker)}"
+            f"Finished backfill for {ticker}. Check InfluxDB for authoritative state."
         )
     logging.info("Historical candle backfill completed.")
 
@@ -180,31 +192,48 @@ def run_polling_loop(
     candle_granularity_minutes: int,
     api_call_delay_seconds: int,
     initial_catchup_days: int,
+    # This dict is now primarily an in-memory cache, initialized from DB.
     last_processed_timestamps: dict[str, int],
 ):
     logging.info("Starting real-time candle polling loop...")
     resample_freq = get_tiingo_resample_freq(candle_granularity_minutes)
     granularity_delta = timedelta(minutes=candle_granularity_minutes)
 
-    # Initialize last_processed_timestamps for tickers not set by backfill
-    now_utc_for_init = datetime.now(timezone.utc)
-    default_catchup_start_dt = now_utc_for_init - timedelta(days=initial_catchup_days)
-    default_catchup_start_minute = (
-        (default_catchup_start_dt.minute // candle_granularity_minutes) 
-        * candle_granularity_minutes
-    )
-    default_catchup_start_dt_aligned = default_catchup_start_dt.replace(
-        minute=default_catchup_start_minute, second=0, microsecond=0
-    )
-    default_catchup_start_ms = int(default_catchup_start_dt_aligned.timestamp() * 1000)
+    # Initialize last_processed_timestamps for tickers if not already set (e.g. by backfill stage)
+    logging.info("Initializing polling timestamps from InfluxDB or defaults...")
+    for ticker_symbol in tiingo_tickers:
+        if ticker_symbol not in last_processed_timestamps or last_processed_timestamps.get(ticker_symbol, 0) == 0:
+            polling_state_ts_ms = influx_manager.get_last_processed_timestamp(ticker_symbol, "polling")
+            if polling_state_ts_ms:
+                last_processed_timestamps[ticker_symbol] = polling_state_ts_ms
+                logging.info(f"Found last polling state for {ticker_symbol}: {datetime.fromtimestamp(polling_state_ts_ms / 1000.0, timezone.utc).isoformat()}")
+            else:
+                # If no polling state, check if backfill state exists (already in last_processed_timestamps from main)
+                backfill_state_ts_ms = last_processed_timestamps.get(ticker_symbol) # From main's pre-population
+                if backfill_state_ts_ms:
+                    # No specific polling state, but backfill state exists. We can use this.
+                    # The value is already in last_processed_timestamps, so no need to set it again.
+                    logging.info(f"No polling state for {ticker_symbol}, using last backfill state: {datetime.fromtimestamp(backfill_state_ts_ms / 1000.0, timezone.utc).isoformat()}")
+                else:
+                    # Fallback to default catchup if no state found at all
+                    now_utc_for_init = datetime.now(timezone.utc)
+                    default_catchup_start_dt = now_utc_for_init - timedelta(days=initial_catchup_days)
+                    default_catchup_start_minute = (
+                        (default_catchup_start_dt.minute // candle_granularity_minutes)
+                        * candle_granularity_minutes
+                    )
+                    default_catchup_start_dt_aligned = default_catchup_start_dt.replace(
+                        minute=default_catchup_start_minute, second=0, microsecond=0
+                    )
+                    default_catchup_start_ms = int(default_catchup_start_dt_aligned.timestamp() * 1000)
+                    last_processed_timestamps[ticker_symbol] = default_catchup_start_ms
+                    logging.info(
+                        f"No backfill or polling state for {ticker_symbol}. "
+                        f"Setting polling start from approx {initial_catchup_days} days ago: {default_catchup_start_dt_aligned.isoformat()}"
+                    )
+        else: # Timestamp for this ticker was already present (likely from backfill state propagation)
+             logging.info(f"Using pre-existing/backfill timestamp for {ticker_symbol} for polling start: {datetime.fromtimestamp(last_processed_timestamps[ticker_symbol] / 1000.0, timezone.utc).isoformat()}")
 
-    for ticker in tiingo_tickers:
-        if ticker not in last_processed_timestamps or last_processed_timestamps.get(ticker, 0) == 0:
-            logging.info(
-                f"No valid backfill timestamp for {ticker}, "
-                f"setting polling start from approx {initial_catchup_days} days ago: {default_catchup_start_dt_aligned.isoformat()}"
-            )
-            last_processed_timestamps[ticker] = default_catchup_start_ms
 
     try:
         while True:
@@ -215,11 +244,12 @@ def run_polling_loop(
             for ticker in tiingo_tickers:
                 try:
                     last_ts_ms = last_processed_timestamps.get(ticker)
-                    if last_ts_ms is None:
-                        logging.error(f"CRITICAL: Missing last_ts_ms for {ticker}. Re-initializing with default catchup.")
-                        last_ts_ms = default_catchup_start_ms
-                        last_processed_timestamps[ticker] = last_ts_ms
-                    
+                    if last_ts_ms is None: # Should have been initialized above
+                        logging.error(f"CRITICAL: Missing last_ts_ms for {ticker} at start of polling iteration. This should not happen.")
+                        # As a safeguard, re-initialize to a very safe default to avoid infinite loops on bad data
+                        last_ts_ms = (datetime.now(timezone.utc) - timedelta(days=initial_catchup_days)).timestamp() * 1000
+                        last_processed_timestamps[ticker] = int(last_ts_ms)
+
                     last_known_candle_start_dt_utc = datetime.fromtimestamp(last_ts_ms / 1000.0, timezone.utc)
 
                     current_minute_floored = (current_cycle_time_utc.minute // candle_granularity_minutes) * candle_granularity_minutes
@@ -236,24 +266,25 @@ def run_polling_loop(
                         continue
 
                     query_start_dt_utc = last_known_candle_start_dt_utc + granularity_delta
-                    query_end_dt_utc = target_latest_closed_candle_start_dt_utc + granularity_delta - timedelta(seconds=1)
+                    # Tiingo's /prices endpoint end date for intraday seems to be exclusive for the day part if time not specified.
+                    # For polling, we want up to the most recently *fully closed* candle period.
+                    query_end_dt_utc = target_latest_closed_candle_start_dt_utc # Inclusive start of the last *closed* candle period.
+                                                                               # Tiingo API usually needs end date to be "up to"
+                                                                               # For safety, let's query up to current time to catch late data, then filter.
+                    effective_query_end_dt_utc = current_cycle_time_utc
 
-                    if query_start_dt_utc > current_cycle_time_utc:
-                        logging.debug(f"Query start time {query_start_dt_utc.isoformat()} is in the future for {ticker}. Skipping.")
+
+                    if query_start_dt_utc >= effective_query_end_dt_utc: # query_end_dt_utc changed to current_cycle_time_utc
+                        logging.debug(f"Query start time {query_start_dt_utc.isoformat()} is not before effective query end {effective_query_end_dt_utc.isoformat()} for {ticker}. Skipping API call.")
                         continue
-                    
-                    query_end_dt_utc = min(query_end_dt_utc, current_cycle_time_utc)
 
-                    if query_start_dt_utc > query_end_dt_utc:
-                        logging.debug(f"Calculated query start {query_start_dt_utc.isoformat()} is after query end {query_end_dt_utc.isoformat()} for {ticker}. Skipping API call.")
-                        continue
-
-                    if candle_granularity_minutes >= 1440:
+                    if candle_granularity_minutes >= 1440: # Daily
                         query_start_str = query_start_dt_utc.strftime("%Y-%m-%d")
-                        query_end_str = query_end_dt_utc.strftime("%Y-%m-%d")
-                    else:
+                        query_end_str = effective_query_end_dt_utc.strftime("%Y-%m-%d")
+                    else: # Intraday
                         query_start_str = query_start_dt_utc.strftime("%Y-%m-%dT%H:%M:%S")
-                        query_end_str = query_end_dt_utc.strftime("%Y-%m-%dT%H:%M:%S")
+                        query_end_str = effective_query_end_dt_utc.strftime("%Y-%m-%dT%H:%M:%S")
+
 
                     logging.info(f"Polling for {ticker} from {query_start_str} to {query_end_str}")
 
@@ -269,16 +300,23 @@ def run_polling_loop(
                         new_candles_to_write = []
                         for c in polled_candles:
                             candle_ts_ms = c["timestamp_ms"]
+                            # Ensure candle start is after last processed, and candle period is fully closed
                             candle_end_ts_ms = candle_ts_ms + granularity_delta.total_seconds() * 1000
                             if candle_ts_ms > last_ts_ms and candle_end_ts_ms <= current_cycle_time_utc.timestamp() * 1000:
                                 new_candles_to_write.append(c)
-                        
+
                         new_candles_to_write.sort(key=lambda c: c["timestamp_ms"])
 
                         if new_candles_to_write:
-                            logging.info(f"Fetched {len(new_candles_to_write)} new candle(s) for {ticker} via polling.")
-                            influx_manager.write_candles_batch(new_candles_to_write)
-                            last_processed_timestamps[ticker] = new_candles_to_write[-1]["timestamp_ms"]
+                            logging.info(f"Fetched {len(new_candles_to_write)} new, closed candle(s) for {ticker} via polling.")
+                            written_count = influx_manager.write_candles_batch(new_candles_to_write)
+                            if written_count > 0:
+                                latest_polled_ts_ms = new_candles_to_write[-1]["timestamp_ms"]
+                                last_processed_timestamps[ticker] = latest_polled_ts_ms # Update in-memory dict
+                                influx_manager.update_last_processed_timestamp(ticker, "polling", latest_polled_ts_ms) # Update DB state
+                                logging.info(f"  Successfully wrote {written_count} candles. Updated InfluxDB polling state for {ticker} to {latest_polled_ts_ms}")
+                            else:
+                                logging.warning(f"  Polling write_candles_batch reported 0 candles written for {ticker}. DB State not updated for this batch.")
                         else:
                             logging.info(f"No new, fully closed candles found for {ticker} in polled range after filtering.")
                     else:
@@ -306,13 +344,11 @@ def run_polling_loop(
         logging.info("Polling loop finished.")
 
 
-
 def main(argv):
     del argv
     logging.set_verbosity(logging.INFO)
     logging.info("Starting candle ingestor script (Python)...")
     logging.info("Configuration:")
-    # ... (logging of flags as before) ...
     logging.info(f"  CoinMarketCap API Key: {'****' if FLAGS.cmc_api_key else 'Not Set/Loaded from Env'}")
     logging.info(f"  Top N Cryptos: {FLAGS.top_n_cryptos}")
     logging.info(f"  Tiingo API Key: {'****' if FLAGS.tiingo_api_key else 'Not Set/Loaded from Env'}")
@@ -346,10 +382,22 @@ def main(argv):
         return 1
     logging.info(f"Target Tiingo tickers: {tiingo_tickers}")
 
+    # This dictionary will store the last processed timestamp (from DB or this run)
+    # for each ticker, primarily for backfill state.
+    # Polling loop will manage its own state more directly from DB first.
     last_processed_candle_timestamps = {}
 
     try:
         if FLAGS.backfill_start_date.lower() != "skip":
+            logging.info("Attempting to pre-populate backfill states from InfluxDB...")
+            for ticker_symbol in tiingo_tickers:
+                db_state_ts_ms = influx_manager.get_last_processed_timestamp(ticker_symbol, "backfill")
+                if db_state_ts_ms:
+                    last_processed_candle_timestamps[ticker_symbol] = db_state_ts_ms
+                    logging.info(f"  Pre-populated backfill state for {ticker_symbol}: {datetime.fromtimestamp(db_state_ts_ms / 1000.0, timezone.utc).isoformat()}")
+                else:
+                    logging.info(f"  No prior backfill state found in DB for {ticker_symbol}.")
+
             run_backfill(
                 influx_manager,
                 tiingo_tickers,
@@ -357,13 +405,19 @@ def main(argv):
                 FLAGS.backfill_start_date,
                 FLAGS.candle_granularity_minutes,
                 FLAGS.tiingo_api_call_delay_seconds,
-                last_processed_candle_timestamps,
+                last_processed_candle_timestamps, # Pass the pre-populated map
             )
         else:
             logging.info("Skipping historical backfill as per 'backfill_start_date' flag.")
-            # Initialize timestamps for polling if backfill is skipped
-            # This init is now handled at the start of run_polling_loop if needed
+            # If skipping backfill, we still might want to populate last_processed_candle_timestamps
+            # from DB in case there was a partial backfill before "skip" was set.
+            # Or, rely on polling loop's initialization to pick up backfill state if it exists.
+            # For clarity, if backfill is skipped, we assume polling will handle init from scratch or existing state.
 
+
+        # The last_processed_candle_timestamps dict now contains the most recent backfill timestamps
+        # (either from DB before run_backfill or updated by run_backfill itself).
+        # run_polling_loop will use this as a fallback if no specific "polling" state is found.
         run_polling_loop(
             influx_manager,
             tiingo_tickers,
@@ -371,8 +425,7 @@ def main(argv):
             FLAGS.candle_granularity_minutes,
             FLAGS.tiingo_api_call_delay_seconds,
             FLAGS.polling_initial_catchup_days,
-            last_processed_candle_timestamps, # Pass the potentially populated map
-            # test_max_cycles=None # In production, this runs indefinitely
+            last_processed_candle_timestamps, # Pass the potentially populated/updated map
         )
 
     except Exception as e:

--- a/services/candle_ingestor/main_test.py
+++ b/services/candle_ingestor/main_test.py
@@ -13,41 +13,44 @@ from services.candle_ingestor import ingestion_helpers
 FLAGS = flags.FLAGS
 
 
-class RunPollingLoopTest(absltest.TestCase):
-
+class BaseIngestorTest(absltest.TestCase):
     def setUp(self):
         super().setUp()
         self.mock_influx_manager = mock.MagicMock(
             spec=influx_client_module.InfluxDBManager
         )
+        # Configure default return values for new state methods
+        self.mock_influx_manager.get_last_processed_timestamp.return_value = None
+        self.mock_influx_manager.update_last_processed_timestamp.return_value = None
+        self.mock_influx_manager.write_candles_batch.return_value = 1 # Simulate successful write
 
-        # Patch get_historical_candles_tiingo where it's looked up by main.py
+        self.patch_get_top_n_crypto_symbols = mock.patch(
+            "services.candle_ingestor.main.get_top_n_crypto_symbols"
+        )
+        self.mock_get_top_n_crypto_symbols = self.patch_get_top_n_crypto_symbols.start()
+        self.addCleanup(self.patch_get_top_n_crypto_symbols.stop)
+
         self.patch_get_historical_candles = mock.patch(
             "services.candle_ingestor.main.get_historical_candles_tiingo"
         )
         self.mock_get_historical_candles = self.patch_get_historical_candles.start()
         self.addCleanup(self.patch_get_historical_candles.stop)
 
-        # Patch time.sleep where it's looked up by main.py
         self.patch_main_time_sleep = mock.patch("services.candle_ingestor.main.time.sleep")
         self.mock_main_time_sleep = self.patch_main_time_sleep.start()
         self.addCleanup(self.patch_main_time_sleep.stop)
 
-        # Patch datetime module as seen by main.py
         self.patch_main_datetime = mock.patch("services.candle_ingestor.main.datetime")
         self.mock_main_datetime_module = self.patch_main_datetime.start()
         self.addCleanup(self.patch_main_datetime.stop)
 
-        # Configure the mock datetime module's methods as needed
-        self.mock_main_datetime_module.now = mock.MagicMock() # To be set per test
-        self.mock_main_datetime_module.fromtimestamp = datetime.fromtimestamp # Real method
-        self.mock_main_datetime_module.strptime = datetime.strptime       # Real method
-        # If main.py calls datetime.datetime(...) directly, mock that too or allow pass-through
+        self.mock_main_datetime_module.now = mock.MagicMock()
+        self.mock_main_datetime_module.fromtimestamp = datetime.fromtimestamp
+        self.mock_main_datetime_module.strptime = datetime.strptime
         self.mock_main_datetime_module.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
 
 
         self.saved_flags = flagsaver.save_flag_values()
-        # Dummy values, actual API calls will be mocked. These satisfy flag requirements.
         FLAGS.cmc_api_key = "dummy_cmc_for_test"
         FLAGS.tiingo_api_key = "dummy_tiingo_for_test"
         FLAGS.influxdb_token = "dummy_influx_token_for_test"
@@ -55,124 +58,315 @@ class RunPollingLoopTest(absltest.TestCase):
         FLAGS.candle_granularity_minutes = 1
         FLAGS.polling_initial_catchup_days = 1
         FLAGS.tiingo_api_call_delay_seconds = 0
+        FLAGS.backfill_start_date = "1_day_ago" # Default for some tests
 
         self.test_ticker = "btcusd"
         self.tiingo_tickers = [self.test_ticker]
-        self.last_processed_timestamps = {} # Reset for each test
-
+        self.last_processed_candle_timestamps_for_backfill = {} # Used to pass to run_backfill
+        self.last_processed_timestamps_for_polling = {} # Used to pass to run_polling
 
     def tearDown(self):
         flagsaver.restore_flag_values(self.saved_flags)
         super().tearDown()
 
-    def test_poll_one_ticker_fetches_and_writes_new_candle(self):
-        current_cycle_time_utc = datetime(2023, 1, 1, 10, 2, 30, tzinfo=timezone.utc)
-        self.mock_main_datetime_module.now.return_value = current_cycle_time_utc
+    def _set_current_time(self, dt_str):
+        self.mock_main_datetime_module.now.return_value = datetime.fromisoformat(dt_str).replace(tzinfo=timezone.utc)
 
-        granularity_minutes = 1
-        FLAGS.candle_granularity_minutes = granularity_minutes
-
-        last_processed_start_dt = datetime(2023, 1, 1, 9, 59, 0, tzinfo=timezone.utc)
-        self.last_processed_timestamps[self.test_ticker] = int(last_processed_start_dt.timestamp() * 1000)
-
-        candle_10_00_start_dt = datetime(2023, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
-        candle_10_00_ts_ms = int(candle_10_00_start_dt.timestamp() * 1000)
-        tiingo_response_candle = {
-            "timestamp_ms": candle_10_00_ts_ms, "open": 1.0, "high": 2.0, 
-            "low": 0.0, "close": 1.5, "volume": 10.0,
-            "currency_pair": self.test_ticker
+    def _create_dummy_candle(self, timestamp_ms, pair="btcusd", close_price=100.0):
+        return {
+            "timestamp_ms": timestamp_ms, "open": close_price -1, "high": close_price + 1,
+            "low": close_price -2, "close": close_price, "volume": 10.0,
+            "currency_pair": pair
         }
-        self.mock_get_historical_candles.return_value = [tiingo_response_candle]
-        self.mock_influx_manager.write_candles_batch.return_value = 1
 
-        # Simulate breaking the infinite loop via KeyboardInterrupt after one iteration
-        def sleep_side_effect(duration_seconds):
-            raise KeyboardInterrupt("Stop loop for test")
+class RunBackfillTest(BaseIngestorTest):
 
-        self.mock_main_time_sleep.side_effect = sleep_side_effect
+    def test_backfill_new_ticker_no_db_state(self):
+        self._set_current_time("2023-01-10T12:00:00") # "now" for parsing "1_day_ago"
+        FLAGS.backfill_start_date = "1_day_ago" # Effective start: 2023-01-09T12:00:00
+        self.mock_influx_manager.get_last_processed_timestamp.return_value = None # No DB state
 
-        # Call the polling loop (it will exit after first cycle due to the sleep mock)
+        dummy_candle = self._create_dummy_candle(datetime(2023, 1, 9, 12, 0, 0, tzinfo=timezone.utc).timestamp() * 1000)
+        self.mock_get_historical_candles.return_value = [dummy_candle]
+
+        initial_backfill_timestamps = {} # Empty, main will populate based on DB calls
+
+        candle_ingestor_main.run_backfill(
+            influx_manager=self.mock_influx_manager,
+            tiingo_tickers=self.tiingo_tickers,
+            tiingo_api_key=FLAGS.tiingo_api_key,
+            backfill_start_date_str=FLAGS.backfill_start_date,
+            candle_granularity_minutes=FLAGS.candle_granularity_minutes,
+            api_call_delay_seconds=FLAGS.tiingo_api_call_delay_seconds,
+            last_backfilled_timestamps=initial_backfill_timestamps # Passed from main
+        )
+        # run_backfill itself now queries DB if last_backfilled_timestamps is empty or misses a ticker
+        # The initial call from main() pre-populates last_backfilled_timestamps
+        # Here, we are testing the case where main's pre-population found nothing for this ticker
+
+        # Assertions
+        self.mock_influx_manager.get_last_processed_timestamp.assert_any_call(self.test_ticker, "backfill") # Checked by main()
+        # Check if Tiingo was called with the date derived from FLAGS.backfill_start_date
+        # expected_start_date_str for Tiingo API (YYYY-MM-DD)
+        # "now" is 2023-01-10, "1_day_ago" is 2023-01-09 for chunk start
+        self.mock_get_historical_candles.assert_called_with(
+            FLAGS.tiingo_api_key, self.test_ticker, "2023-01-09", mock.ANY, mock.ANY
+        )
+        self.mock_influx_manager.update_last_processed_timestamp.assert_called_with(
+            self.test_ticker, "backfill", dummy_candle["timestamp_ms"]
+        )
+
+    def test_backfill_resumes_from_db_state(self):
+        self._set_current_time("2023-01-10T12:00:00")
+        FLAGS.backfill_start_date = "5_days_ago" # Flag start: 2023-01-05T12:00:00
+        db_resume_timestamp_ms = int(datetime(2023, 1, 7, 0, 0, 0, tzinfo=timezone.utc).timestamp() * 1000)
+        
+        # Simulate that main() pre-populated this from DB
+        initial_backfill_timestamps = {self.test_ticker: db_resume_timestamp_ms}
+
+        # Candles that would be fetched after resuming
+        expected_fetch_start_dt = datetime(2023, 1, 7, 0, 1, 0, tzinfo=timezone.utc) # db_resume_ts + 1 min
+        dummy_candle_resumed = self._create_dummy_candle(int(expected_fetch_start_dt.timestamp() * 1000))
+        self.mock_get_historical_candles.return_value = [dummy_candle_resumed]
+
+        candle_ingestor_main.run_backfill(
+            influx_manager=self.mock_influx_manager,
+            tiingo_tickers=self.tiingo_tickers,
+            tiingo_api_key=FLAGS.tiingo_api_key,
+            backfill_start_date_str=FLAGS.backfill_start_date,
+            candle_granularity_minutes=FLAGS.candle_granularity_minutes,
+            api_call_delay_seconds=FLAGS.tiingo_api_call_delay_seconds,
+            last_backfilled_timestamps=initial_backfill_timestamps # Pass pre-populated dict
+        )
+        
+        # Assert that Tiingo is called starting from the day of (db_resume_timestamp + granularity)
+        # db_resume is 2023-01-07 00:00. next candle is 00:01. Tiingo historical takes YYYY-MM-DD.
+        self.mock_get_historical_candles.assert_called_with(
+            FLAGS.tiingo_api_key, self.test_ticker, "2023-01-07", mock.ANY, mock.ANY
+        )
+        self.mock_influx_manager.update_last_processed_timestamp.assert_called_with(
+            self.test_ticker, "backfill", dummy_candle_resumed["timestamp_ms"]
+        )
+
+    def test_backfill_db_state_is_after_flag_start_date(self):
+        self._set_current_time("2023-01-10T12:00:00")
+        FLAGS.backfill_start_date = "1_day_ago" # Flag start: 2023-01-09T12:00:00
+        # DB state is *older* than flag start, so flag start should take precedence for earliest point
+        db_older_timestamp_ms = int(datetime(2023, 1, 8, 0, 0, 0, tzinfo=timezone.utc).timestamp() * 1000)
+
+        initial_backfill_timestamps = {self.test_ticker: db_older_timestamp_ms}
+
+        expected_fetch_start_dt = datetime(2023, 1, 9, 12, 0, 0, tzinfo=timezone.utc) # From flag
+        dummy_candle = self._create_dummy_candle(int(expected_fetch_start_dt.timestamp() * 1000))
+        self.mock_get_historical_candles.return_value = [dummy_candle]
+
+        candle_ingestor_main.run_backfill(
+            influx_manager=self.mock_influx_manager,
+            tiingo_tickers=self.tiingo_tickers,
+            tiingo_api_key=FLAGS.tiingo_api_key,
+            backfill_start_date_str=FLAGS.backfill_start_date,
+            candle_granularity_minutes=FLAGS.candle_granularity_minutes,
+            api_call_delay_seconds=FLAGS.tiingo_api_call_delay_seconds,
+            last_backfilled_timestamps=initial_backfill_timestamps
+        )
+        # Expected fetch start day should be 2023-01-09 (from flag as it's later than DB state + delta)
+        self.mock_get_historical_candles.assert_called_with(
+            FLAGS.tiingo_api_key, self.test_ticker, "2023-01-09", mock.ANY, mock.ANY
+        )
+        self.mock_influx_manager.update_last_processed_timestamp.assert_called_with(
+            self.test_ticker, "backfill", dummy_candle["timestamp_ms"]
+        )
+
+
+class RunPollingLoopTest(BaseIngestorTest):
+
+    def test_polling_initializes_from_polling_db_state(self):
+        self._set_current_time("2023-01-10T12:05:00")
+        polling_db_state_ms = int(datetime(2023, 1, 10, 11, 58, 0, tzinfo=timezone.utc).timestamp() * 1000)
+        self.mock_influx_manager.get_last_processed_timestamp.side_effect = lambda symbol, type: polling_db_state_ms if type == "polling" else None
+
+        # Candle that would be fetched after resuming
+        expected_fetch_start_dt = datetime(2023, 1, 10, 11, 59, 0, tzinfo=timezone.utc) # polling_db_state_ms + 1min
+        # Polling loop looks for candles up to current time - granularity
+        # Current time 12:05, granularity 1 min -> target_latest_closed_candle_start = 12:04
+        # query_start = 11:59, query_end = 12:04
+        # So, candles from 11:59, 12:00, 12:01, 12:02, 12:03, 12:04 are candidates if Tiingo returns them.
+        # Let's say Tiingo returns one for 12:00
+        candle_12_00_ts = int(datetime(2023, 1, 10, 12, 0, 0, tzinfo=timezone.utc).timestamp()*1000)
+        polled_candle = self._create_dummy_candle(candle_12_00_ts)
+        self.mock_get_historical_candles.return_value = [polled_candle]
+
+        self.mock_main_time_sleep.side_effect = KeyboardInterrupt # Stop after one loop
+
+        last_processed_timestamps_arg = {} # main.py passes this, polling loop initializes it
+
         candle_ingestor_main.run_polling_loop(
             influx_manager=self.mock_influx_manager,
             tiingo_tickers=self.tiingo_tickers,
             tiingo_api_key=FLAGS.tiingo_api_key,
-            candle_granularity_minutes=granularity_minutes,
+            candle_granularity_minutes=FLAGS.candle_granularity_minutes,
             api_call_delay_seconds=FLAGS.tiingo_api_call_delay_seconds,
             initial_catchup_days=FLAGS.polling_initial_catchup_days,
-            last_processed_timestamps=self.last_processed_timestamps,
+            last_processed_timestamps=last_processed_timestamps_arg
         )
 
-        # Validate the expected query window
-        expected_query_start_dt = datetime(2023, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
-        expected_query_end_dt = datetime(2023, 1, 1, 10, 1, 59, tzinfo=timezone.utc)
-
-        self.mock_get_historical_candles.assert_called_once_with(
-            FLAGS.tiingo_api_key,
-            self.test_ticker,
-            expected_query_start_dt.strftime("%Y-%m-%dT%H:%M:%S"),
-            expected_query_end_dt.strftime("%Y-%m-%dT%H:%M:%S"),
-            ingestion_helpers.get_tiingo_resample_freq(granularity_minutes)
+        self.mock_influx_manager.get_last_processed_timestamp.assert_any_call(self.test_ticker, "polling")
+        # Verify Tiingo called with start date derived from polling_db_state_ms + 1 min
+        # polling_db_state_ms = 2023-01-10T11:58:00Z
+        # query_start_dt_utc = 2023-01-10T11:59:00Z
+        # query_end_dt_utc (effective_query_end_dt_utc) will be current_cycle_time_utc = 2023-01-10T12:05:00Z
+        self.mock_get_historical_candles.assert_called_with(
+            FLAGS.tiingo_api_key, self.test_ticker, "2023-01-10T11:59:00", "2023-01-10T12:05:00", mock.ANY
         )
+        self.mock_influx_manager.update_last_processed_timestamp.assert_called_with(
+            self.test_ticker, "polling", polled_candle["timestamp_ms"]
+        )
+        self.assertEqual(last_processed_timestamps_arg[self.test_ticker], polled_candle["timestamp_ms"])
 
-        self.mock_influx_manager.write_candles_batch.assert_called_once_with([tiingo_response_candle])
-        self.assertEqual(self.last_processed_timestamps[self.test_ticker], candle_10_00_ts_ms)
 
-    def test_poll_one_ticker_no_new_closed_candle_yet(self):
-        current_cycle_time_utc = datetime(2023, 1, 1, 10, 0, 30, tzinfo=timezone.utc)
-        self.mock_main_datetime_module.now.return_value = current_cycle_time_utc
+    def test_polling_initializes_from_backfill_db_state_if_no_polling_state(self):
+        self._set_current_time("2023-01-10T12:05:00")
+        backfill_db_state_ms = int(datetime(2023, 1, 10, 11, 50, 0, tzinfo=timezone.utc).timestamp() * 1000)
+        # Simulate polling returns None, backfill returns a value
+        self.mock_influx_manager.get_last_processed_timestamp.side_effect = lambda symbol, type: backfill_db_state_ms if type == "backfill" else None
+        
+        # This dictionary will be populated by main() with the backfill state before polling loop is called
+        last_processed_timestamps_from_main = {self.test_ticker: backfill_db_state_ms}
 
-        FLAGS.candle_granularity_minutes = 1
-        last_processed_dt = datetime(2023, 1, 1, 9, 59, 0, tzinfo=timezone.utc)
-        self.last_processed_timestamps[self.test_ticker] = int(last_processed_dt.timestamp() * 1000)
+        polled_candle = self._create_dummy_candle(int(datetime(2023,1,10,11,51,0, tzinfo=timezone.utc).timestamp()*1000))
+        self.mock_get_historical_candles.return_value = [polled_candle]
+        self.mock_main_time_sleep.side_effect = KeyboardInterrupt
 
-        self.mock_get_historical_candles.return_value = []
-
-        def sleep_side_effect(duration_seconds):
-            if duration_seconds > 0:
-                raise KeyboardInterrupt("Stop loop for test")
-        self.mock_main_time_sleep.side_effect = sleep_side_effect
-
-        # Function should complete normally (KeyboardInterrupt is caught internally)
         candle_ingestor_main.run_polling_loop(
-            self.mock_influx_manager, self.tiingo_tickers, FLAGS.tiingo_api_key,
-            FLAGS.candle_granularity_minutes, 0, FLAGS.polling_initial_catchup_days,
-            self.last_processed_timestamps
+            influx_manager=self.mock_influx_manager,
+            tiingo_tickers=self.tiingo_tickers,
+            tiingo_api_key=FLAGS.tiingo_api_key,
+            candle_granularity_minutes=FLAGS.candle_granularity_minutes,
+            api_call_delay_seconds=FLAGS.tiingo_api_call_delay_seconds,
+            initial_catchup_days=FLAGS.polling_initial_catchup_days,
+            last_processed_timestamps=last_processed_timestamps_from_main # Pass dict that main would have populated
         )
 
-        self.mock_get_historical_candles.assert_not_called()
-        self.mock_influx_manager.write_candles_batch.assert_not_called()
+        self.mock_influx_manager.get_last_processed_timestamp.assert_any_call(self.test_ticker, "polling")
+        # If "polling" was None, it would use the value from last_processed_timestamps_from_main (backfill state)
+        # backfill_db_state_ms = 2023-01-10T11:50:00Z
+        # query_start_dt_utc = 2023-01-10T11:51:00Z
+        self.mock_get_historical_candles.assert_called_with(
+            FLAGS.tiingo_api_key, self.test_ticker, "2023-01-10T11:51:00", "2023-01-10T12:05:00", mock.ANY
+        )
+        self.mock_influx_manager.update_last_processed_timestamp.assert_called_with(
+            self.test_ticker, "polling", polled_candle["timestamp_ms"]
+        )
 
-    def test_poll_initializes_last_timestamp_if_missing(self):
-        current_cycle_time_utc = datetime(2023, 1, 1, 10, 2, 0, tzinfo=timezone.utc)
-        self.mock_main_datetime_module.now.return_value = current_cycle_time_utc
+    def test_polling_initializes_from_default_catchup_if_no_db_state(self):
+        self._set_current_time("2023-01-10T12:05:00") # "now"
+        FLAGS.polling_initial_catchup_days = 3 # Catchup from 2023-01-07T12:05:00
+        self.mock_influx_manager.get_last_processed_timestamp.return_value = None # No DB state at all
 
-        FLAGS.candle_granularity_minutes = 1
-        FLAGS.polling_initial_catchup_days = 1
-    
-        self.last_processed_timestamps.clear() 
-        self.mock_get_historical_candles.return_value = []
+        # Expected start: 2023-01-07T12:05:00 aligned to 1-min granularity -> 2023-01-07T12:05:00
+        # Polling query_start will be this + 1 min -> 2023-01-07T12:06:00
+        expected_default_start_ms = int(datetime(2023,1,7,12,5,0, tzinfo=timezone.utc).timestamp() * 1000)
+        polled_candle = self._create_dummy_candle(expected_default_start_ms + 60000) # Candle for 12:06
+        self.mock_get_historical_candles.return_value = [polled_candle]
+        self.mock_main_time_sleep.side_effect = KeyboardInterrupt
 
-        # Properly mock sleep to interrupt the infinite loop after first iteration
-        def sleep_side_effect(duration_seconds):
-            if duration_seconds > 0:
-                raise KeyboardInterrupt("Stop loop for test")
-        self.mock_main_time_sleep.side_effect = sleep_side_effect
+        last_processed_timestamps_arg = {}
 
-        # Function should complete normally (KeyboardInterrupt is caught internally)
         candle_ingestor_main.run_polling_loop(
-            self.mock_influx_manager, self.tiingo_tickers, FLAGS.tiingo_api_key,
-            FLAGS.candle_granularity_minutes, 0, FLAGS.polling_initial_catchup_days,
-            self.last_processed_timestamps
+            influx_manager=self.mock_influx_manager,
+            tiingo_tickers=self.tiingo_tickers,
+            tiingo_api_key=FLAGS.tiingo_api_key,
+            candle_granularity_minutes=FLAGS.candle_granularity_minutes,
+            api_call_delay_seconds=FLAGS.tiingo_api_call_delay_seconds,
+            initial_catchup_days=FLAGS.polling_initial_catchup_days,
+            last_processed_timestamps=last_processed_timestamps_arg
         )
-    
-        # Validate initialization logic
-        self.assertIn(self.test_ticker, self.last_processed_timestamps)
-        expected_init_dt = datetime(2022, 12, 31, 10, 2, 0, tzinfo=timezone.utc)
-        expected_init_ts_ms = int(expected_init_dt.timestamp() * 1000)
-        self.assertEqual(self.last_processed_timestamps[self.test_ticker], expected_init_ts_ms)
 
-        self.mock_get_historical_candles.assert_called_once()
-        self.mock_influx_manager.write_candles_batch.assert_not_called()
+        self.mock_influx_manager.get_last_processed_timestamp.assert_any_call(self.test_ticker, "polling")
+        self.mock_influx_manager.get_last_processed_timestamp.assert_any_call(self.test_ticker, "backfill")
+        # Query start should be default_catchup_start_ms + granularity
+        self.assertEqual(last_processed_timestamps_arg[self.test_ticker], expected_default_start_ms)
+        self.mock_get_historical_candles.assert_called_with(
+            FLAGS.tiingo_api_key, self.test_ticker, "2023-01-07T12:06:00", "2023-01-10T12:05:00", mock.ANY
+        )
+        self.mock_influx_manager.update_last_processed_timestamp.assert_called_with(
+            self.test_ticker, "polling", polled_candle["timestamp_ms"]
+        )
+
+
+class MainFunctionTest(BaseIngestorTest): # Inherit for shared mocks
+
+    @flagsaver.flagsaver(backfill_start_date="skip") # Ensure backfill is skipped for this test
+    @mock.patch("services.candle_ingestor.main.run_polling_loop")
+    @mock.patch("services.candle_ingestor.main.run_backfill") # Also mock backfill
+    @mock.patch("services.candle_ingestor.main.InfluxDBManager")
+    def test_main_skip_backfill_initializes_polling_correctly(
+        self, MockInfluxDBManager, mock_run_backfill, mock_run_polling_loop
+    ):
+        # Arrange
+        MockInfluxDBManager.return_value = self.mock_influx_manager # Use our instance
+        self.mock_get_top_n_crypto_symbols.return_value = self.tiingo_tickers
+
+        # Simulate DB states for polling initialization
+        # No polling state, but a backfill state exists
+        backfill_state_for_poll_init_ms = int(datetime(2023,1,9,10,0,0,tzinfo=timezone.utc).timestamp()*1000)
+        def get_ts_side_effect(symbol, type):
+            if type == "polling": return None
+            if type == "backfill": return backfill_state_for_poll_init_ms
+            return None
+        self.mock_influx_manager.get_last_processed_timestamp.side_effect = get_ts_side_effect
+
+        # Act
+        candle_ingestor_main.main(None)
+
+        # Assert
+        mock_run_backfill.assert_not_called() # Backfill was skipped
+
+        # Check arguments passed to run_polling_loop
+        mock_run_polling_loop.assert_called_once()
+        args, kwargs = mock_run_polling_loop.call_args
+        passed_last_processed_timestamps = kwargs['last_processed_timestamps']
+        
+        # Since backfill was skipped, the passed dict to polling should be empty initially.
+        # The polling loop itself will query InfluxDB and find the backfill state.
+        self.assertEqual(passed_last_processed_timestamps, {})
+
+
+    @flagsaver.flagsaver(backfill_start_date="1_day_ago")
+    @mock.patch("services.candle_ingestor.main.run_polling_loop")
+    @mock.patch("services.candle_ingestor.main.run_backfill")
+    @mock.patch("services.candle_ingestor.main.InfluxDBManager")
+    def test_main_with_backfill_populates_timestamps_for_backfill_call(
+        self, MockInfluxDBManager, mock_run_backfill, mock_run_polling_loop
+    ):
+        # Arrange
+        MockInfluxDBManager.return_value = self.mock_influx_manager
+        self.mock_get_top_n_crypto_symbols.return_value = self.tiingo_tickers
+
+        db_backfill_state_ms = int(datetime(2023,1,8,0,0,tzinfo=timezone.utc).timestamp()*1000)
+        self.mock_influx_manager.get_last_processed_timestamp.side_effect = lambda symbol, type: db_backfill_state_ms if type == "backfill" else None
+
+        # Act
+        candle_ingestor_main.main(None)
+
+        # Assert
+        # Check that get_last_processed_timestamp was called by main() to pre-populate for backfill
+        self.mock_influx_manager.get_last_processed_timestamp.assert_any_call(self.test_ticker, "backfill")
+
+        mock_run_backfill.assert_called_once()
+        args_backfill, kwargs_backfill = mock_run_backfill.call_args
+        passed_timestamps_to_backfill = kwargs_backfill['last_backfilled_timestamps']
+        self.assertEqual(passed_timestamps_to_backfill.get(self.test_ticker), db_backfill_state_ms)
+
+        # Polling loop should also be called, potentially with the dict updated by backfill
+        mock_run_polling_loop.assert_called_once()
+        args_polling, kwargs_polling = mock_run_polling_loop.call_args
+        passed_timestamps_to_polling = kwargs_polling['last_processed_timestamps']
+        # This assertion depends on whether run_backfill modifies the dict in place.
+        # If run_backfill modifies it, it should contain the latest from backfill.
+        # If not, it will still be the initial DB state for backfill.
+        # Given current run_backfill updates it in place (if new data fetched):
+        # self.assertEqual(passed_timestamps_to_polling.get(self.test_ticker), ...)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR introduces persistent resume functionality for both backfill and polling operations in the candle ingestor service by leveraging InfluxDB to store and retrieve the last processed timestamps for each symbol and ingestion type.

**Key Changes:**

* **InfluxDBManager Enhancements:**

  * Added `get_last_processed_timestamp(symbol, ingestion_type)` to query the latest processed timestamp from InfluxDB.
  * Added `update_last_processed_timestamp(symbol, ingestion_type, timestamp_ms)` to persist the latest processed timestamp after successful writes.
  * Improved exception handling with specific `InfluxDBError` logging.

* **Backfill Pipeline Improvements:**

  * Modified `run_backfill` to initialize and incrementally update the last processed timestamp in InfluxDB.
  * Ensures the backfill resumes from the last stored timestamp if available.
  * Skips writing or updating state if no new data is ingested.

* **Polling Loop Enhancements:**

  * Polling now initializes from stored "polling" state if present.
  * If no polling state is available, falls back to "backfill" state or a default catch-up range.
  * After each polling cycle, the ingested timestamp is updated in InfluxDB.

* **Tests:**

  * Extended unit tests to cover new timestamp management logic.
  * Verified DB initialization, updates, and fallback paths for polling and backfill modes.
  * Refactored mocks and setup for clarity and reuse across test classes.

* **Helper Functions:**

  * Enhanced `parse_backfill_start_date()` to accept both singular and plural time descriptors (e.g., "1\_day\_ago", "2\_days\_ago").

**Version Impact:**
(MINOR) – This update introduces new functionality for state persistence and ingestion resumption without breaking existing interfaces.
