### PR TITLE
Add retry logic using Tenacity for robust InfluxDB and Tiingo API interactions (MINOR)

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,4 @@
 absl-py==2.2.2
 influxdb-client==1.48.0
 requests==2.32.3
+tenacity==9.1.2

--- a/requirements_lock.txt
+++ b/requirements_lock.txt
@@ -132,6 +132,10 @@ six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
     # via python-dateutil
+tenacity==9.1.2 \
+    --hash=sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb \
+    --hash=sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138
+    # via -r requirements.in
 typing-extensions==4.13.2 \
     --hash=sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c \
     --hash=sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef

--- a/services/candle_ingestor/BUILD
+++ b/services/candle_ingestor/BUILD
@@ -16,6 +16,7 @@ py_library(
     deps = [
         "//third_party:absl_py",
         "//third_party:requests",
+        "//third_party:tenacity",  # Added
     ],
 )
 
@@ -25,6 +26,7 @@ py_library(
     deps = [
         "//third_party:absl_py",
         "//third_party:requests",
+        "//third_party:tenacity",  # Added
     ],
 )
 
@@ -34,6 +36,7 @@ py_library(
     deps = [
         "//third_party:absl_py",
         "//third_party:influxdb_client",
+        "//third_party:tenacity",  # Added
     ],
 )
 
@@ -100,7 +103,7 @@ py_test(
     deps = [
         ":main_app",
         ":ingestion_helpers_lib",
-        ":influx_client_lib", 
+        ":influx_client_lib",
         ":tiingo_client_lib",
         "//third_party:absl_py",
     ],

--- a/services/candle_ingestor/influx_client.py
+++ b/services/candle_ingestor/influx_client.py
@@ -40,7 +40,7 @@ class InfluxDBManager:
                     f"Failed to ping InfluxDB at {self.url}. Check connection and configuration."
                 )
                 self.client = None
-                raise InfluxDBError("Ping failed") # Raise to trigger retry
+                raise InfluxDBError(message="Ping failed") # Raise to trigger retry
         except Exception as e:
             logging.error(
                 f"Error connecting to InfluxDB at {self.url}: {e}"

--- a/services/candle_ingestor/influx_client_test.py
+++ b/services/candle_ingestor/influx_client_test.py
@@ -296,7 +296,7 @@ class TestInfluxDBManager(unittest.TestCase):
         manager.update_last_processed_timestamp("ethusd", "polling", 1678886400000)
 
         # Assert
-        self.mock_write_api_instance.write.assert_called_once() # Still called
+        self.assertEqual(self.mock_write_api_instance.write.call_count, 5) # Still called 5 times due to retry
 
 
 if __name__ == "__main__":

--- a/services/candle_ingestor/main_test.py
+++ b/services/candle_ingestor/main_test.py
@@ -16,6 +16,7 @@ FLAGS = flags.FLAGS
 class BaseIngestorTest(absltest.TestCase):
     def setUp(self):
         super().setUp()
+        candle_ingestor_main.shutdown_requested = False # Reset global flag
         self.mock_influx_manager = mock.MagicMock(
             spec=influx_client_module.InfluxDBManager
         )

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -337,3 +337,11 @@ py_library(
         requirement("requests"),
     ],
 )
+
+py_library(
+    name = "tenacity",
+    visibility = ["//visibility:public"],
+    deps = [
+        requirement("tenacity"),
+    ],
+)


### PR DESCRIPTION
This PR introduces robust retry handling across the `candle_ingestor` service by integrating the `tenacity` library. It enhances the system’s resilience to transient failures in external dependencies such as InfluxDB and Tiingo.

**Key Changes:**

* **Dependency Additions:**

  * Added `tenacity==9.1.2` to `requirements.in` and `BUILD` files.

* **Retry Integration:**

  * Wrapped InfluxDB operations (`connect`, `write_candles_batch`, `get_last_processed_timestamp`, `update_last_processed_timestamp`) in retry decorators with exponential backoff and exception filtering.
  * Added retry logic to Tiingo API requests with custom handling of HTTP 429 (rate limiting), including support for `Retry-After` headers.
  * Introduced retry-wrapped data fetcher for CMC in `cmc_client.py`.

* **Graceful Shutdown Support:**

  * Introduced `shutdown_requested` global flag and signal handlers for SIGINT/SIGTERM.
  * Ensured all long-running loops (backfill, polling) and sleep intervals are interruptible.

* **Testing Improvements:**

  * Adjusted InfluxDB client tests to reflect retry logic (e.g., expecting multiple calls on failure).

* **Code Structure Enhancements:**

  * Refactored retryable logic into internal helper methods to maintain separation of concerns.
  * Improved logging for visibility into retry attempts and shutdown behavior.

**Version Note:**
(MINOR) This change introduces new functionality (resilience and shutdown handling) while preserving backward compatibility and existing behavior under normal conditions.
