### PR TITLE
Integrate candle ingestor into Helm chart

### DIFF
--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -87,7 +87,7 @@ candleIngestor:
   enabled: false
   replicaCount: 1
   image:
-    repository: "your-docker-repo/candle-ingestor" # TODO: Replace with actual image repo
+    repository: "tradestreamhq//candle-ingestor"
     pullPolicy: IfNotPresent
     # tag: "" # Defaults to .Chart.AppVersion, will be overridden by CI/CD
   serviceAccount:

--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -82,3 +82,66 @@ pipeline:
     jarURI: local:///src/main/java/com/verlumen/tradestream/pipeline/app_deploy.jar
     parallelism: 1
     upgradeMode: stateless
+
+candleIngestor:
+  enabled: false
+  replicaCount: 1
+  image:
+    repository: "your-docker-repo/candle-ingestor" # TODO: Replace with actual image repo
+    pullPolicy: IfNotPresent
+    # tag: "" # Defaults to .Chart.AppVersion, will be overridden by CI/CD
+  serviceAccount:
+    create: true
+    # name: "" # Defaults to <helm-release-name>-candle-ingestor, uncomment to override
+    annotations: {}
+  config:
+    topNCryptos: 100
+    candleGranularityMinutes: 1
+    influxDbUrl: "http://{{ include "tradestream.fullname" . }}-influxdb:8086" # Assumes InfluxDB is deployed by the same chart
+    influxDbBucket: "tradestream-data" # Should match the bucket created by the InfluxDB sub-chart
+    dataSources: "coinmarketcap,tiingo" # Comma-separated list of data sources
+    # Add other script-specific flags here
+    # exampleFlag: "exampleValue"
+  secrets:
+    # Secrets for API keys
+    cmcApiKey:
+      name: "coinmarketcap" # Name of the existing K8s secret for CoinMarketCap
+      key: "apiKey"        # Key within the secret that holds the API key
+    tiingoApiKey:
+      name: "tiingo"       # Name of the existing K8s secret for Tiingo
+      key: "apiKey"        # Key within the secret that holds the API key
+    # New secret for InfluxDB application token specific to the candle ingestor
+    influxDb:
+      name: "influxdb-candle-ingestor-credentials" # Name of the new K8s secret to be created
+      tokenKey: "INFLUXDB_TOKEN" # Key for the InfluxDB token
+      orgKey: "INFLUXDB_ORG"     # Key for the InfluxDB organization
+  # Resource requests and limits
+  resources: {}
+  #   requests:
+  #     cpu: 100m
+  #     memory: 128Mi
+  #   limits:
+  #     cpu: 500m
+  #     memory: 512Mi
+
+  # Liveness probe configuration
+  livenessProbe:
+    exec:
+      command:
+      - /bin/true # Placeholder: Replace with actual health check command if available
+    initialDelaySeconds: 30 # How long to wait after the container starts before performing the first probe
+    periodSeconds: 15       # How often to perform the probe
+    timeoutSeconds: 5       # When the probe times out
+    failureThreshold: 3     # Number of times Kubernetes will try when a Pod fails a Liveness Probe
+    successThreshold: 1     # Minimum consecutive successes for the probe to be considered successful after having failed
+
+  # Readiness probe configuration
+  readinessProbe:
+    exec:
+      command:
+      - /bin/true # Placeholder: Replace with actual health check command if available
+    initialDelaySeconds: 30 # How long to wait after the container starts before performing the first probe
+    periodSeconds: 15       # How often to perform the probe
+    timeoutSeconds: 5       # When the probe times out
+    failureThreshold: 3     # Number of times Kubernetes will try when a Pod fails a Readiness Probe
+    successThreshold: 1     # Minimum consecutive successes for the probe to be considered successful after having failed

--- a/influxdb-candle-ingestor-credentials-secret.yaml
+++ b/influxdb-candle-ingestor-credentials-secret.yaml
@@ -1,0 +1,16 @@
+# IMPORTANT: The placeholder values for INFLUXDB_TOKEN and INFLUXDB_ORG in this file
+# must be replaced with actual base64 encoded secrets before applying this manifest to a Kubernetes cluster.
+# You can generate the base64 encoded values using a command like:
+# echo -n "your-actual-token-or-org" | base64
+apiVersion: v1
+kind: Secret
+metadata:
+  name: influxdb-candle-ingestor-credentials
+  namespace: default # Or specify the namespace where your tradestream application will be deployed
+type: Opaque
+data:
+  # IMPORTANT: Replace these placeholder values with actual base64 encoded secrets before applying to the cluster.
+  # Example: echo -n "your-influxdb-token" | base64
+  INFLUXDB_TOKEN: "REPLACE_WITH_BASE64_ENCODED_INFLUXDB_TOKEN"
+  # Example: echo -n "your-influxdb-org" | base64
+  INFLUXDB_ORG: "REPLACE_WITH_BASE64_ENCODED_INFLUXDB_ORG"


### PR DESCRIPTION
This commit introduces the necessary Helm chart configurations to deploy the candle ingestor.

Key changes:
- Added `charts/tradestream/templates/candle-ingestor-deployment.yaml` to define the Kubernetes Deployment for the ingestor. This includes conditional deployment, configurable image, environment variables sourced from `values.yaml` and secrets, and probes.
- Added `charts/tradestream/templates/candle-ingestor-serviceaccount.yaml` to define an optional, dedicated ServiceAccount for the ingestor.
- Updated `charts/tradestream/values.yaml` with a new `candleIngestor` section. This section includes configurations for enabling the ingestor, replica count, image details, service account, script-specific parameters (e.g., `topNCryptos`, `influxDbUrl`), secret names for API keys and InfluxDB credentials, resources, and probes.
- Created `influxdb-candle-ingestor-credentials-secret.yaml` (in the repository root) as a template for the Kubernetes Secret required for InfluxDB. This secret will store `INFLUXDB_TOKEN` and `INFLUXDB_ORG` and needs to be populated with actual base64 encoded values and applied to the cluster manually or via a setup script.

The ingestor deployment is conditional via `.Values.candleIngestor.enabled` (defaulted to `false`). Probes are currently set to simple `/bin/true` commands and can be enhanced later if the ingestor script provides an HTTP health endpoint.