### PR TITLE
Add Discovery Proto for Strategy Optimization Requests and Results

### DIFF
--- a/protos/BUILD
+++ b/protos/BUILD
@@ -28,6 +28,7 @@ proto_library(
     deps = [
         ":marketdata_proto",
         ":strategies_proto",
+        "@com_google_protobuf//:timestamp_proto",
     ],
 )
 

--- a/protos/BUILD
+++ b/protos/BUILD
@@ -26,7 +26,6 @@ proto_library(
     name = "discovery_proto",
     srcs = ["discovery.proto"],
     deps = [
-        ":marketdata_proto",
         ":strategies_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],

--- a/protos/BUILD
+++ b/protos/BUILD
@@ -23,6 +23,21 @@ py_proto_library(
 )
 
 proto_library(
+    name = "discovery_proto",
+    srcs = ["discovery.proto"],
+    deps = [
+        ":marketdata_proto",
+        ":strategies_proto",
+    ],
+)
+
+py_proto_library(
+    name = "discovery_py_proto",
+    visibility = ["//visibility:public"],
+    deps = [":discovery_proto"],
+)
+
+proto_library(
     name = "marketdata_proto",
     srcs = ["marketdata.proto"],
     deps = [

--- a/protos/discovery.proto
+++ b/protos/discovery.proto
@@ -5,8 +5,8 @@ package discovery;
 import "google/protobuf/any.proto";
 import "google/protobuf/timestamp.proto";
 
-import "marketdata.proto"; // Still needed if marketdata.Candle is used internally by the service
-import "strategies.proto"; // Contains strategies.Strategy, strategies.StrategyType
+import "protos/marketdata.proto";
+import "protos/strategies.proto";
 
 // =======================================
 //   Strategy Discovery Service Messages

--- a/protos/discovery.proto
+++ b/protos/discovery.proto
@@ -1,0 +1,70 @@
+syntax = "proto3";
+
+package discovery;
+
+// Standard Google Protobuf imports
+import "google/protobuf/any.proto";
+
+// Imports for types defined in other .proto files within your project.
+// Please adjust the paths if your .proto files are organized differently
+// or if the package names for Candle and StrategyType are different.
+
+// Assuming 'Candle' is defined in a 'marketdata.proto' file,
+// and that file declares 'package marketdata;'.
+import "marketdata.proto"; // Contains marketdata.Candle
+
+// Assuming 'StrategyType' is defined in a 'strategies.proto' file,
+// and that file declares 'package strategies;'.
+import "strategies.proto"; // Contains strategies.StrategyType
+
+
+// =======================================
+//   Strategy Discovery Service Messages
+// =======================================
+
+// Strategy Definition
+// Note: If 'Strategy' is a common type used in multiple services/protos,
+// it might be better placed in a shared proto file (e.g., common_types.proto or strategies.proto)
+// and imported here. If so, remove this definition and add the appropriate import.
+message Strategy {
+  google.protobuf.Any strategy_parameters = 1; // Specific parameters for this strategy instance
+  strategies.StrategyType strategy_type = 2;   // The type of the strategy (e.g., MOVING_AVERAGE_CROSSOVER)
+}
+
+// Configuration for Genetic Algorithm based optimization
+message GAConfig {
+  int32 max_generations = 1;
+  int32 population_size = 2;
+}
+
+// Request for discovering top N strategies
+message StrategyDiscoveryRequest {
+  repeated marketdata.Candle candles = 1;      // Market data for the discovery process
+  strategies.StrategyType strategy_type = 2;   // Specifies the primary type of strategy to discover
+  int32 top_n = 3;                             // Number of top strategies to return
+
+  // Configuration for the optimization algorithm.
+  // This allows for future expansion to other optimization methods.
+  oneof optimization_config {
+    GAConfig ga_config = 4; // Configuration if using Genetic Algorithm
+    // Example: OtherOptimizerConfig another_optimizer_config = 5;
+  }
+}
+
+// Represents a discovered strategy, including its full definition and achieved score
+message DiscoveredStrategy {
+  Strategy strategy = 1; // The actual strategy (type and parameters)
+  double score = 2;      // The score achieved by this strategy instance
+}
+
+// Response from the strategy discovery service: a list of top N discovered strategies
+message StrategyDiscoveryResponse {
+  repeated DiscoveredStrategy top_strategies = 1; // List of discovered strategies, typically ordered by score
+}
+
+// Optional: Define the service itself if you're using gRPC
+/*
+service StrategyDiscoveryService {
+  rpc DiscoverStrategies(StrategyDiscoveryRequest) returns (StrategyDiscoveryResponse);
+}
+*/

--- a/protos/discovery.proto
+++ b/protos/discovery.proto
@@ -2,34 +2,15 @@ syntax = "proto3";
 
 package discovery;
 
-// Standard Google Protobuf imports
 import "google/protobuf/any.proto";
 
-// Imports for types defined in other .proto files within your project.
-// Please adjust the paths if your .proto files are organized differently
-// or if the package names for Candle and StrategyType are different.
-
-// Assuming 'Candle' is defined in a 'marketdata.proto' file,
-// and that file declares 'package marketdata;'.
 import "marketdata.proto"; // Contains marketdata.Candle
-
-// Assuming 'StrategyType' is defined in a 'strategies.proto' file,
-// and that file declares 'package strategies;'.
-import "strategies.proto"; // Contains strategies.StrategyType
+import "strategies.proto"; // Contains strategies.Strategy
 
 
 // =======================================
 //   Strategy Discovery Service Messages
 // =======================================
-
-// Strategy Definition
-// Note: If 'Strategy' is a common type used in multiple services/protos,
-// it might be better placed in a shared proto file (e.g., common_types.proto or strategies.proto)
-// and imported here. If so, remove this definition and add the appropriate import.
-message Strategy {
-  google.protobuf.Any strategy_parameters = 1; // Specific parameters for this strategy instance
-  strategies.StrategyType strategy_type = 2;   // The type of the strategy (e.g., MOVING_AVERAGE_CROSSOVER)
-}
 
 // Configuration for Genetic Algorithm based optimization
 message GAConfig {
@@ -57,8 +38,8 @@ message DiscoveredStrategy {
   double score = 2;      // The score achieved by this strategy instance
 }
 
-// Response from the strategy discovery service: a list of top N discovered strategies
-message StrategyDiscoveryResponse {
+// Result from the strategy discovery service: a list of top N discovered strategies
+message StrategyDiscoveryResult {
   repeated DiscoveredStrategy top_strategies = 1; // List of discovered strategies, typically ordered by score
 }
 
@@ -67,4 +48,3 @@ message StrategyDiscoveryResponse {
 service StrategyDiscoveryService {
   rpc DiscoverStrategies(StrategyDiscoveryRequest) returns (StrategyDiscoveryResponse);
 }
-*/

--- a/protos/discovery.proto
+++ b/protos/discovery.proto
@@ -5,7 +5,6 @@ package discovery;
 import "google/protobuf/any.proto";
 import "google/protobuf/timestamp.proto";
 
-import "protos/marketdata.proto";
 import "protos/strategies.proto";
 
 // Configuration for Genetic Algorithm based optimization

--- a/protos/discovery.proto
+++ b/protos/discovery.proto
@@ -34,7 +34,7 @@ message StrategyDiscoveryRequest {
 
 // Represents a discovered strategy, including its full definition and achieved score
 message DiscoveredStrategy {
-  Strategy strategy = 1; // The actual strategy (type and parameters)
+  strategies.Strategy strategy = 1; // The actual strategy (type and parameters)
   double score = 2;      // The score achieved by this strategy instance
 }
 

--- a/protos/discovery.proto
+++ b/protos/discovery.proto
@@ -42,9 +42,3 @@ message DiscoveredStrategy {
 message StrategyDiscoveryResult {
   repeated DiscoveredStrategy top_strategies = 1; // List of discovered strategies, typically ordered by score
 }
-
-// Optional: Define the service itself if you're using gRPC
-/*
-service StrategyDiscoveryService {
-  rpc DiscoverStrategies(StrategyDiscoveryRequest) returns (StrategyDiscoveryResponse);
-}

--- a/protos/discovery.proto
+++ b/protos/discovery.proto
@@ -3,10 +3,10 @@ syntax = "proto3";
 package discovery;
 
 import "google/protobuf/any.proto";
+import "google/protobuf/timestamp.proto";
 
-import "marketdata.proto"; // Contains marketdata.Candle
-import "strategies.proto"; // Contains strategies.Strategy
-
+import "marketdata.proto"; // Still needed if marketdata.Candle is used internally by the service
+import "strategies.proto"; // Contains strategies.Strategy, strategies.StrategyType
 
 // =======================================
 //   Strategy Discovery Service Messages
@@ -20,25 +20,30 @@ message GAConfig {
 
 // Request for discovering top N strategies
 message StrategyDiscoveryRequest {
-  repeated marketdata.Candle candles = 1;      // Market data for the discovery process
-  strategies.StrategyType strategy_type = 2;   // Specifies the primary type of strategy to discover
-  int32 top_n = 3;                             // Number of top strategies to return
+  string symbol = 1;                            // Trading symbol (e.g., "BTCUSDT", "AAPL")
+  google.protobuf.Timestamp start_time = 2;     // Inclusive start time for market data
+  google.protobuf.Timestamp end_time = 3;       // Exclusive end time for market data
+  strategies.StrategyType strategy_type = 4;    // Specifies the primary type of strategy to discover
+  int32 top_n = 5;                              // Number of top strategies to return
 
   // Configuration for the optimization algorithm.
-  // This allows for future expansion to other optimization methods.
   oneof optimization_config {
-    GAConfig ga_config = 4; // Configuration if using Genetic Algorithm
-    // Example: OtherOptimizerConfig another_optimizer_config = 5;
+    GAConfig ga_config = 6; // Configuration if using Genetic Algorithm
+    // Example: OtherOptimizerConfig another_optimizer_config = 7;
   }
 }
 
-// Represents a discovered strategy, including its full definition and achieved score
+// Represents a discovered strategy, including its full definition, achieved score,
+// and the context of its discovery.
 message DiscoveredStrategy {
-  strategies.Strategy strategy = 1; // The actual strategy (type and parameters)
-  double score = 2;      // The score achieved by this strategy instance
+  strategies.Strategy strategy = 1;          // The actual strategy (type and parameters)
+  double score = 2;                           // The score achieved by this strategy instance
+  string symbol = 3;                          // Symbol used for this discovery/evaluation
+  google.protobuf.Timestamp start_time = 4;   // Inclusive start time of data used
+  google.protobuf.Timestamp end_time = 5;     // Exclusive end time of data used
 }
 
 // Result from the strategy discovery service: a list of top N discovered strategies
 message StrategyDiscoveryResult {
-  repeated DiscoveredStrategy top_strategies = 1; // List of discovered strategies, typically ordered by score
+  repeated DiscoveredStrategy top_strategies = 1; // List of discovered strategies
 }

--- a/protos/discovery.proto
+++ b/protos/discovery.proto
@@ -8,10 +8,6 @@ import "google/protobuf/timestamp.proto";
 import "protos/marketdata.proto";
 import "protos/strategies.proto";
 
-// =======================================
-//   Strategy Discovery Service Messages
-// =======================================
-
 // Configuration for Genetic Algorithm based optimization
 message GAConfig {
   int32 max_generations = 1;

--- a/protos/discovery.proto
+++ b/protos/discovery.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package discovery;
 
-import "google/protobuf/any.proto";
 import "google/protobuf/timestamp.proto";
 
 import "protos/strategies.proto";


### PR DESCRIPTION
This PR introduces a new `discovery.proto` definition along with associated Bazel build targets to support strategy discovery via optimization algorithms. Key changes include:

* **New Proto Definitions:**

  * `GAConfig`: Configuration message for Genetic Algorithm-based strategy optimization.
  * `StrategyDiscoveryRequest`: Request structure to initiate strategy discovery, including time range, strategy type, and optimization configuration.
  * `DiscoveredStrategy`: Captures a discovered strategy instance, including score and metadata.
  * `StrategyDiscoveryResult`: Response containing the list of top discovered strategies.

* **BUILD File Updates:**

  * Added `discovery_proto` and `discovery_py_proto` targets.
  * Declared dependencies on `strategies_proto` and the Protobuf timestamp library.

These additions enable downstream services to request and consume optimized strategy discovery results programmatically.
