### PR TITLE
Add Bazel targets for `kafka-python` and `protobuf` third-party dependencies

### DIFF
--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -18,6 +18,22 @@ py_library(
 )
 
 py_library(
+    name = "kafka_python",
+    visibility = ["//visibility:public"],
+    deps = [
+        requirement("kafka-python"),
+    ],
+)
+
+py_library(
+    name = "protobuf",
+    visibility = ["//visibility:public"],
+    deps = [
+        requirement("protobuf"),
+    ],
+)
+
+py_library(
     name = "redis",
     visibility = ["//visibility:public"],
     deps = [


### PR DESCRIPTION
This change introduces new `py_library` targets in the `third_party/python/BUILD` file to support the following dependencies:

* `kafka-python`
* `protobuf`

Both libraries are now exposed with `//visibility:public`, enabling use in other Bazel targets throughout the project. This setup facilitates dependency management and consistent builds for components relying on Kafka and Protocol Buffers.

No functional changes to application logic are introduced in this patch.
