### PR TITLE
Add deployment and release pipeline support for strategy-discovery-request-factory service (MINOR)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,6 +81,12 @@ jobs:
             --repository localhost:5000/top-crypto-updater \
             --tag "latest"
 
+          # Build and push strategy-discovery-request-factory image
+          bazel run //services/strategy_discovery_request_factory:push_strategy_discovery_request_factory_image \
+            -- \
+            --repository localhost:5000/strategy-discovery-request-factory \
+            --tag "latest"
+
           # Load images into minikube
           docker pull localhost:5000/tradestream-data-pipeline:latest
           docker tag localhost:5000/tradestream-data-pipeline:latest tradestream-data-pipeline:latest
@@ -91,6 +97,9 @@ jobs:
           docker pull localhost:5000/top-crypto-updater:latest
           docker tag localhost:5000/top-crypto-updater:latest top-crypto-updater:latest
           minikube image load top-crypto-updater:latest
+          docker pull localhost:5000/strategy-discovery-request-factory:latest
+          docker tag localhost:5000/strategy-discovery-request-factory:latest strategy-discovery-request-factory:latest
+          minikube image load strategy-discovery-request-factory:latest
 
       - name: Install Cert Manager
         run: |
@@ -112,9 +121,12 @@ jobs:
             --set candleIngestor.image.tag=latest \
             --set topCryptoUpdaterCronjob.image.repository=top-crypto-updater \
             --set topCryptoUpdaterCronjob.image.tag=latest \
+            --set strategyDiscoveryRequestFactory.image.repository=strategy-discovery-request-factory \
+            --set strategyDiscoveryRequestFactory.image.tag=latest \
             --set pipeline.runMode=dry \
             --set redis.enabled=true \
-            --set topCryptoUpdaterCronjob.enabled=true
+            --set topCryptoUpdaterCronjob.enabled=true \
+            --set strategyDiscoveryRequestFactory.enabled=true
 
       - name: Monitor Deployment
         run: |
@@ -122,15 +134,23 @@ jobs:
           # Verify CronJob was created successfully (CronJobs don't have Ready/Established conditions)
           echo "Checking if CronJob exists..."
           kubectl get cronjob my-tradestream-top-crypto-updater -n tradestream-namespace
+          kubectl get cronjob my-tradestream-strategy-discovery-request-factory -n tradestream-namespace
           # Check CronJob status and configuration
           echo "CronJob details:"
           kubectl describe cronjob my-tradestream-top-crypto-updater -n tradestream-namespace
+          kubectl describe cronjob my-tradestream-strategy-discovery-request-factory -n tradestream-namespace
           # Verify CronJob is not suspended
           if kubectl get cronjob my-tradestream-top-crypto-updater -n tradestream-namespace -o jsonpath='{.spec.suspend}' | grep -q true; then
-            echo "ERROR: CronJob is suspended"
+            echo "ERROR: CronJob my-tradestream-top-crypto-updater is suspended"
             exit 1
           else
-            echo "CronJob is active and ready to run on schedule"
+            echo "CronJob my-tradestream-top-crypto-updater is active and ready to run on schedule"
+          fi
+          if kubectl get cronjob my-tradestream-strategy-discovery-request-factory -n tradestream-namespace -o jsonpath='{.spec.suspend}' | grep -q true; then
+            echo "ERROR: CronJob my-tradestream-strategy-discovery-request-factory is suspended"
+            exit 1
+          else
+            echo "CronJob my-tradestream-strategy-discovery-request-factory is active and ready to run on schedule"
           fi
 
       - name: Diagnostics

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,9 +11,11 @@ jobs:
       PIPELINE_REPO: tradestreamhq/tradestream-data-pipeline
       CANDLE_INGESTOR_REPO: tradestreamhq/candle-ingestor
       TOP_CRYPTO_UPDATER_REPO: tradestreamhq/top-crypto-updater
+      STRATEGY_DISCOVERY_REQUEST_FACTORY_REPO: tradestreamhq/strategy-discovery-request-factory
       PIPELINE_SECTION_KEY: pipeline
       CANDLE_INGESTOR_SECTION_KEY: candleIngestor
       TOP_CRYPTO_UPDATER_SECTION_KEY: topCryptoUpdaterCronjob
+      STRATEGY_DISCOVERY_REQUEST_FACTORY_SECTION_KEY: strategyDiscoveryRequestFactory
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -80,6 +82,11 @@ jobs:
           bazel run //services/top_crypto_updater:push_top_crypto_updater_image \
             -- \
             --tag ${{ steps.version.outputs.version_tag }}
+      - name: Push the Strategy Discovery Request Factory image
+        run: |
+          bazel run //services/strategy_discovery_request_factory:push_strategy_discovery_request_factory_image \
+            -- \
+            --tag ${{ steps.version.outputs.version_tag }}
 
       - name: Install yq
         run: |
@@ -95,7 +102,9 @@ jobs:
             .["${{ env.CANDLE_INGESTOR_SECTION_KEY }}"].image.repository = "${{ env.CANDLE_INGESTOR_REPO }}" |
             .["${{ env.CANDLE_INGESTOR_SECTION_KEY }}"].image.tag = "${{ steps.version.outputs.version_tag }}" |
             .["${{ env.TOP_CRYPTO_UPDATER_SECTION_KEY }}"].image.repository = "${{ env.TOP_CRYPTO_UPDATER_REPO }}" |
-            .["${{ env.TOP_CRYPTO_UPDATER_SECTION_KEY }}"].image.tag = "${{ steps.version.outputs.version_tag }}"
+            .["${{ env.TOP_CRYPTO_UPDATER_SECTION_KEY }}"].image.tag = "${{ steps.version.outputs.version_tag }}" |
+            .["${{ env.STRATEGY_DISCOVERY_REQUEST_FACTORY_SECTION_KEY }}"].image.repository = "${{ env.STRATEGY_DISCOVERY_REQUEST_FACTORY_REPO }}" |
+            .["${{ env.STRATEGY_DISCOVERY_REQUEST_FACTORY_SECTION_KEY }}"].image.tag = "${{ steps.version.outputs.version_tag }}"
           ' charts/tradestream/values.yaml > charts/tradestream/values.yaml.tmp
           mv charts/tradestream/values.yaml.tmp charts/tradestream/values.yaml
 

--- a/charts/tradestream/templates/strategy-discovery-request-factory.yaml
+++ b/charts/tradestream/templates/strategy-discovery-request-factory.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.strategyDiscoveryRequestFactory.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "tradestream.fullname" . }}-strategy-discovery-request-factory
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "tradestream.name" . }}
+    component: strategy-discovery-request-factory
+    release: {{ .Release.Name }}
+spec:
+  schedule: "{{ .Values.strategyDiscoveryRequestFactory.schedule }}"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: strategy-discovery-request-factory
+              image: "{{ .Values.strategyDiscoveryRequestFactory.image.repository }}:{{ .Values.strategyDiscoveryRequestFactory.image.tag | default .Chart.AppVersion }}"
+              imagePullPolicy: {{ .Values.strategyDiscoveryRequestFactory.image.pullPolicy }}
+              env:
+                - name: INFLUXDB_URL
+                  value: "http://{{ include "tradestream.fullname" . }}-influxdb:8086"
+                - name: INFLUXDB_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ .Values.influxdb.adminUser.existingSecret | default (printf "%s-influxdb-admin-secret" (include "tradestream.fullname" .)) }}"
+                      key: admin-token # Assuming admin-token is the correct key in the secret
+                - name: INFLUXDB_ORG
+                  value: "{{ .Values.influxdb.adminUser.organization }}"
+                - name: INFLUXDB_BUCKET_TRACKER
+                  value: "{{ .Values.strategyDiscoveryRequestFactory.config.influxDbBucketTracker | default .Values.influxdb.adminUser.bucket }}"
+                - name: KAFKA_BOOTSTRAP_SERVERS
+                  value: "{{ include "tradestream.fullname" . }}-kafka.{{ .Release.Namespace }}.svc.cluster.local:9092"
+                - name: KAFKA_TOPIC
+                  value: "{{ .Values.strategyDiscoveryRequestFactory.config.kafkaTopic }}"
+                - name: TRACKER_SERVICE_NAME
+                  value: "{{ .Values.strategyDiscoveryRequestFactory.config.trackerServiceName }}"
+                - name: GLOBAL_STATUS_TRACKER_SERVICE_NAME
+                  value: "{{ .Values.strategyDiscoveryRequestFactory.config.globalStatusTrackerServiceName }}"
+                - name: MIN_PROCESSING_ADVANCE_MINUTES
+                  value: "{{ .Values.strategyDiscoveryRequestFactory.config.minProcessingAdvanceMinutes }}"
+                - name: CURRENCY_PAIRS
+                  value: "{{ join "," .Values.strategyDiscoveryRequestFactory.config.currencyPairs }}"
+                - name: FIBONACCI_WINDOWS_MINUTES
+                  value: "{{ join "," .Values.strategyDiscoveryRequestFactory.config.fibonacciWindowsMinutes }}"
+                - name: DEFAULT_TOP_N
+                  value: "{{ .Values.strategyDiscoveryRequestFactory.config.defaultTopN }}"
+                - name: DEFAULT_MAX_GENERATIONS
+                  value: "{{ .Values.strategyDiscoveryRequestFactory.config.defaultMaxGenerations }}"
+                - name: DEFAULT_POPULATION_SIZE
+                  value: "{{ .Values.strategyDiscoveryRequestFactory.config.defaultPopulationSize }}"
+              resources:
+                requests:
+                  cpu: "{{ .Values.strategyDiscoveryRequestFactory.resources.requests.cpu }}"
+                  memory: "{{ .Values.strategyDiscoveryRequestFactory.resources.requests.memory }}"
+                limits:
+                  cpu: "{{ .Values.strategyDiscoveryRequestFactory.resources.limits.cpu }}"
+                  memory: "{{ .Values.strategyDiscoveryRequestFactory.resources.limits.memory }}"
+  concurrencyPolicy: "{{ .Values.strategyDiscoveryRequestFactory.concurrencyPolicy }}"
+  failedJobsHistoryLimit: {{ .Values.strategyDiscoveryRequestFactory.failedJobsHistoryLimit }}
+  successfulJobsHistoryLimit: {{ .Values.strategyDiscoveryRequestFactory.successfulJobsHistoryLimit }}
+{{- end }}

--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -145,3 +145,48 @@ topCryptoUpdaterCronjob:
   redis:
     host: '{{ include "tradestream.fullname" . }}-redis-master' # Dynamically set Redis host
     port: 6379
+
+# Strategy Discovery Request Factory CronJob configuration
+strategyDiscoveryRequestFactory:
+  enabled: true
+  schedule: "0 * * * *" # Run at the start of every hour
+  image:
+    repository: "tradestreamhq/strategy-discovery-request-factory"
+    pullPolicy: IfNotPresent
+    tag: "v1.35.3-develop"
+  concurrencyPolicy: "Forbid" # Prevents multiple jobs from running concurrently
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  config:
+    influxDbBucketTracker: "tradestream-data" # Bucket for tracker state
+    kafkaTopic: "strategy-discovery-requests"
+    trackerServiceName: "strategy_discovery_processor" # Name for this service's own state
+    globalStatusTrackerServiceName: "global_candle_status" # Name of the service that reports latest candle data
+    minProcessingAdvanceMinutes: 5 # Min minutes new data must be ahead to trigger
+    currencyPairs:
+      - "BTC/USD"
+      - "ETH/USD"
+      - "ADA/USD"
+      - "SOL/USD"
+      - "DOGE/USD"
+    fibonacciWindowsMinutes: # Fibonacci sequence windows in minutes
+      - "1597" # ~1.1 days
+      - "2584" # ~1.8 days
+      - "4181" # ~2.9 days
+      - "6765" # ~4.7 days
+      - "10946" # ~7.6 days
+      - "17711" # ~12.3 days
+      - "28657" # ~19.9 days
+      - "46368" # ~32.2 days
+      - "75025" # ~52.1 days
+      - "121393" # ~84.3 days
+    defaultTopN: 5
+    defaultMaxGenerations: 30
+    defaultPopulationSize: 50
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "256Mi"
+    limits:
+      cpu: "200m"
+      memory: "512Mi"

--- a/services/strategy_discovery_request_factory/BUILD
+++ b/services/strategy_discovery_request_factory/BUILD
@@ -110,3 +110,40 @@ py_test(
         "//third_party/python:protobuf",
     ],
 )
+
+# --- OCI Image Rules ---
+load("@aspect_rules_py//py:defs.bzl", "py_image_layer")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index", "oci_push")
+load("@container_structure_test//:defs.bzl", "container_structure_test")
+
+py_image_layer(
+    name = "layers",
+    binary = ":app",
+)
+
+oci_image(
+    name = "image",
+    base = "@python_3_13_slim",
+    entrypoint = ["/services/strategy_discovery_request_factory/app"],
+    tars = [":layers"],
+)
+
+oci_image_index(
+    name = "images",
+    images = [
+        ":image",
+    ],
+)
+
+oci_push(
+    name = "push_strategy_discovery_request_factory_image",
+    image = ":images",
+    repository = "tradestreamhq/strategy-discovery-request-factory",
+)
+
+container_structure_test(
+    name = "container_test",
+    configs = ["container-structure-test.yaml"],
+    image = ":image",
+    tags = ["requires-docker"],
+)

--- a/services/strategy_discovery_request_factory/container-structure-test.yaml
+++ b/services/strategy_discovery_request_factory/container-structure-test.yaml
@@ -1,0 +1,11 @@
+schemaVersion: "2.0.0"
+commandTests:
+  - name: "Strategy Discovery Request Factory Help Test"
+    command: "/services/strategy_discovery_request_factory/app"
+    args: ["--help"]
+    exitCode: 1 # Help usually exits with non-zero
+    expectedOutput:
+      - "Strategy Discovery Request Factory - Stateless Orchestration Service" # From main.py docstring
+      - "influxdb_url"
+      - "kafka_bootstrap_servers"
+      - "currency_pairs"


### PR DESCRIPTION
This PR integrates the `strategy-discovery-request-factory` service into the CI/CD pipeline and Helm deployment for the `tradestream` project. Key updates include:

* **CI Workflow (`ci.yaml`):**

  * Added Bazel target to build and push the service's container image.
  * Pulled and tagged the image for Minikube and loaded it into the cluster.
  * Verified the associated CronJob is created and not suspended.

* **Release Workflow (`release.yaml`):**

  * Defined environment variables for repository and config section keys.
  * Built and pushed the version-tagged image for the service.
  * Updated Helm values file with the new image tag and repository.

* **Helm Chart:**

  * Added a new CronJob template (`strategy-discovery-request-factory.yaml`) under `charts/tradestream/templates`.
  * Enabled configuration for image, schedule, Kafka, InfluxDB, and operational parameters in `values.yaml`.

* **Bazel Build Rules:**

  * Introduced OCI image build and push targets.
  * Added a container structure test for the image with a `--help` command check.

This change introduces a new deployable CronJob-based service and requires new configuration values, making it a **(MINOR)** version update.
