### PR TITLE
Update CCXT exchange list and raise minimum required exchanges to 3 (MINOR)

### DIFF
--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -95,11 +95,13 @@ candleIngestor:
   config:
     # CCXT Exchange Configuration
     exchanges:
-      - "binance" # Primary exchange (first in priority order)
-      - "coinbasepro" # Secondary exchange
-      - "kraken" # Tertiary exchange
-    minExchangesRequired: 0 # 0 = auto-detect (will require all 3 exchanges by default)
-    # Candle Processing Configuration
+      - "coinbase"   # High volume, U.S. based
+      - "kraken"     # High volume, U.S. friendly
+      - "binanceus"  # U.S. specific, good U.S. volume
+      - "bitstamp"   # Good volume, U.S. accessible
+      - "gemini"     # Decent volume, U.S. regulated
+    minExchangesRequired: 3
+    # minExchangesRequired: 0 # 0 = auto-detect
     candleGranularityMinutes: 1
     backfillStartDate: "1_year_ago" # Configurable backfill start
     catchUpInitialDays: 7 # Configurable initial catch-up

--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -95,12 +95,12 @@ candleIngestor:
   config:
     # CCXT Exchange Configuration
     exchanges:
-      - "coinbase"   # High volume, U.S. based
-      - "kraken"     # High volume, U.S. friendly
-      - "binanceus"  # U.S. specific, good U.S. volume
-      - "bitstamp"   # Good volume, U.S. accessible
-      - "cryptocom"  # Decent volume, U.S. regulated
-      - "gemini"     # Decent volume, U.S. regulated
+      - "coinbase" # High volume, U.S. based
+      - "kraken" # High volume, U.S. friendly
+      - "binanceus" # U.S. specific, good U.S. volume
+      - "bitstamp" # Good volume, U.S. accessible
+      - "cryptocom" # Decent volume, U.S. regulated
+      - "gemini" # Decent volume, U.S. regulated
     minExchangesRequired: 3
     # minExchangesRequired: 0 # 0 = auto-detect
     candleGranularityMinutes: 1

--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -99,6 +99,7 @@ candleIngestor:
       - "kraken"     # High volume, U.S. friendly
       - "binanceus"  # U.S. specific, good U.S. volume
       - "bitstamp"   # Good volume, U.S. accessible
+      - "cryptocom"  # Decent volume, U.S. regulated
       - "gemini"     # Decent volume, U.S. regulated
     minExchangesRequired: 3
     # minExchangesRequired: 0 # 0 = auto-detect


### PR DESCRIPTION
Expanded the default exchange list and set a fixed minimum exchange requirement for the candle ingestor.