### PR TITLE
Switch InfluxDB write API to use SYNCHRONOUS option

### DIFF
--- a/shared/persistence/influxdb_last_processed_tracker.py
+++ b/shared/persistence/influxdb_last_processed_tracker.py
@@ -165,7 +165,7 @@ class InfluxDBLastProcessedTracker:
                 return
 
         write_api = self.client.write_api(
-            write_options=WritePrecision.MS
+            write_options=SYNCHRONOUS
         )  # Using MS precision
         if not write_api:  # Should not happen if client is valid
             logging.error(

--- a/shared/persistence/influxdb_last_processed_tracker.py
+++ b/shared/persistence/influxdb_last_processed_tracker.py
@@ -1,7 +1,7 @@
 from absl import logging
 from influxdb_client import InfluxDBClient, Point, WritePrecision
 from influxdb_client.client.exceptions import InfluxDBError
-from influxdb_client.client.write_api import SYNCHRONOUS 
+from influxdb_client.client.write_api import SYNCHRONOUS
 from tenacity import (
     retry,
     stop_after_attempt,

--- a/shared/persistence/influxdb_last_processed_tracker.py
+++ b/shared/persistence/influxdb_last_processed_tracker.py
@@ -1,6 +1,7 @@
 from absl import logging
 from influxdb_client import InfluxDBClient, Point, WritePrecision
 from influxdb_client.client.exceptions import InfluxDBError
+from influxdb_client.client.write_api import SYNCHRONOUS 
 from tenacity import (
     retry,
     stop_after_attempt,

--- a/shared/persistence/influxdb_last_processed_tracker_test.py
+++ b/shared/persistence/influxdb_last_processed_tracker_test.py
@@ -251,8 +251,10 @@ class TestInfluxDBLastProcessedTracker(unittest.TestCase):
             "test_service", "test_key", 1234567890123
         )
 
-        # Verify write_api was called
-        self.mock_client_instance.write_api.assert_called_once()
+        # Verify write_api was called with correct options
+        self.mock_client_instance.write_api.assert_called_once_with(
+            write_options=SYNCHRONOUS
+        )
         mock_write_api.write.assert_called_once()
 
         # Verify the write call parameters


### PR DESCRIPTION
Replaced the incorrect use of `WritePrecision.MS` with `SYNCHRONOUS` in the InfluxDB write API and updated related test coverage.