### PR TITLE
Switch default normalized symbol format from USDT to USD

### DIFF
--- a/services/candle_ingestor/ccxt_client.py
+++ b/services/candle_ingestor/ccxt_client.py
@@ -200,4 +200,3 @@ class MultiExchangeCandleClient:
             "exchange": "averaged",
             "source_exchanges": [c["exchange"] for c in candles],
         }
-        

--- a/services/candle_ingestor/ccxt_client.py
+++ b/services/candle_ingestor/ccxt_client.py
@@ -57,13 +57,13 @@ class CCXTCandleClient:
             raise
 
     def _normalize_symbol(self, symbol: str) -> str:
-        """Convert symbol format (e.g., 'btcusd' -> 'BTC/USDT')"""
+        """Convert symbol format (e.g., 'btcusd' -> 'BTC/USD')"""
         if "/" in symbol:
             return symbol.upper()
 
         if symbol.lower().endswith("usd"):
             base = symbol[:-3].upper()
-            return f"{base}/USDT"
+            return f"{base}/USD"
         elif symbol.lower().endswith("btc"):
             base = symbol[:-3].upper()
             return f"{base}/BTC"
@@ -93,7 +93,6 @@ class CCXTCandleClient:
                     "exchange": self.exchange_name,
                 }
             )
-
         return candles
 
 
@@ -126,7 +125,7 @@ class MultiExchangeCandleClient:
                 candles = client.get_historical_candles(symbol, timeframe, since, limit)
                 if candles:
                     exchange_candles[name] = candles
-                    logging.info(f"Fetched {len(candles)} candles from {name}")
+                logging.info(f"Fetched {len(candles)} candles from {name}")
             except Exception as e:
                 logging.warning(f"Failed to fetch from {name}: {e}")
                 continue
@@ -201,3 +200,4 @@ class MultiExchangeCandleClient:
             "exchange": "averaged",
             "source_exchanges": [c["exchange"] for c in candles],
         }
+        

--- a/services/candle_ingestor/ccxt_client_test.py
+++ b/services/candle_ingestor/ccxt_client_test.py
@@ -281,4 +281,3 @@ class TestMultiExchangeCandleClient(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-    

--- a/services/candle_ingestor/ccxt_client_test.py
+++ b/services/candle_ingestor/ccxt_client_test.py
@@ -31,8 +31,8 @@ class TestCCXTCandleClient(unittest.TestCase):
         client = CCXTCandleClient.__new__(CCXTCandleClient)  # Skip __init__
 
         # Test various formats
-        self.assertEqual(client._normalize_symbol("btcusd"), "BTC/USDT")
-        self.assertEqual(client._normalize_symbol("ethusd"), "ETH/USDT")
+        self.assertEqual(client._normalize_symbol("btcusd"), "BTC/USD")
+        self.assertEqual(client._normalize_symbol("ethusd"), "ETH/USD")
         self.assertEqual(client._normalize_symbol("BTC/USD"), "BTC/USD")
         self.assertEqual(client._normalize_symbol("ethbtc"), "ETH/BTC")
 
@@ -76,11 +76,11 @@ class TestCCXTCandleClient(unittest.TestCase):
             [
                 1640995260000,
                 50500.0,
-                50200.0,
+                50200.0,  # Invalid: high < low
                 50800.0,
                 50600.0,
                 85.2,
-            ],  # Invalid: high < low
+            ],
             [1640995320000, 0, 0, 0, 0, 0],  # Invalid: all zeros
         ]
         mock_exchange.fetch_ohlcv.return_value = mock_ohlcv
@@ -281,3 +281,4 @@ class TestMultiExchangeCandleClient(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+    

--- a/services/candle_ingestor/main.py
+++ b/services/candle_ingestor/main.py
@@ -1115,4 +1115,3 @@ def main(argv):
 
 if __name__ == "__main__":
     app.run(main)
-    

--- a/services/candle_ingestor/main.py
+++ b/services/candle_ingestor/main.py
@@ -203,7 +203,6 @@ def _validate_symbols_single_exchange(ccxt_client, symbols: list[str]) -> list[s
                 logging.warning(
                     f"Symbol {symbol} ({ccxt_symbol}) not available on {exchange_name}, skipping"
                 )
-
     except Exception as e:
         logging.error(f"Error loading markets from {exchange_name}: {e}")
         logging.warning(
@@ -271,7 +270,6 @@ def _validate_symbols_multi_exchange(
             f"Symbol validation: {len(valid_symbols)}/{len(symbols)} symbols meet "
             f"minimum {min_exchanges_required} exchange requirement"
         )
-
     return valid_symbols
 
 
@@ -354,13 +352,13 @@ def get_ccxt_timeframe(granularity_minutes: int) -> str:
 
 def convert_tiingo_symbol_to_ccxt(tiingo_symbol: str) -> str:
     """Convert Tiingo-style symbol to CCXT format."""
-    # Handle common patterns from Tiingo format (e.g., 'btcusd' -> 'BTC/USDT')
+    # Handle common patterns from Tiingo format (e.g., 'btcusd' -> 'BTC/USD')
     if "/" in tiingo_symbol:
         return tiingo_symbol.upper()
 
     if tiingo_symbol.lower().endswith("usd"):
         base = tiingo_symbol[:-3].upper()
-        return f"{base}/USDT"  # Most exchanges use USDT instead of USD
+        return f"{base}/USD"
     elif tiingo_symbol.lower().endswith("btc"):
         base = tiingo_symbol[:-3].upper()
         return f"{base}/BTC"
@@ -399,7 +397,6 @@ def get_historical_candles_ccxt(
             start_dt = datetime.strptime(start_date_str, "%Y-%m-%d").replace(
                 tzinfo=timezone.utc
             )
-
         start_timestamp_ms = int(start_dt.timestamp() * 1000)
 
         # Calculate limit based on timeframe and date range
@@ -409,7 +406,6 @@ def get_historical_candles_ccxt(
             end_dt = datetime.strptime(end_date_str, "%Y-%m-%d").replace(
                 tzinfo=timezone.utc
             )
-
         time_diff_hours = (end_dt - start_dt).total_seconds() / 3600
 
         # Estimate reasonable limit based on timeframe
@@ -1119,3 +1115,4 @@ def main(argv):
 
 if __name__ == "__main__":
     app.run(main)
+    

--- a/services/candle_ingestor/symbol_validation_test.py
+++ b/services/candle_ingestor/symbol_validation_test.py
@@ -22,16 +22,16 @@ class TestSymbolValidation(unittest.TestCase):
         def normalize_symbol(symbol):
             if symbol.lower().endswith("usd"):
                 base = symbol[:-3].upper()
-                return f"{base}/USDT"
+                return f"{base}/USD"
             return symbol.upper()
 
         mock_client._normalize_symbol.side_effect = normalize_symbol
 
         # Mock exchange markets
         mock_client.exchange.load_markets.return_value = {
-            "BTC/USDT": {"symbol": "BTC/USDT"},
-            "ETH/USDT": {"symbol": "ETH/USDT"},
-            "ADA/USDT": {"symbol": "ADA/USDT"},
+            "BTC/USD": {"symbol": "BTC/USD"},
+            "ETH/USD": {"symbol": "ETH/USD"},
+            "ADA/USD": {"symbol": "ADA/USD"},
         }
 
         symbols = ["btcusd", "ethusd", "xrpusd"]  # XRP not available
@@ -55,14 +55,14 @@ class TestSymbolValidation(unittest.TestCase):
         def normalize_symbol_binance(symbol):
             if symbol.lower().endswith("usd"):
                 base = symbol[:-3].upper()
-                return f"{base}/USDT"
+                return f"{base}/USD"
             return symbol.upper()
 
         mock_binance._normalize_symbol.side_effect = normalize_symbol_binance
         mock_binance.exchange.load_markets.return_value = {
-            "BTC/USDT": {},
-            "ETH/USDT": {},
-            "ADA/USDT": {},
+            "BTC/USD": {},
+            "ETH/USD": {},
+            "ADA/USD": {},
         }
 
         mock_coinbase = mock.MagicMock()
@@ -108,13 +108,13 @@ class TestSymbolValidation(unittest.TestCase):
         def normalize_symbol(symbol):
             if symbol.lower().endswith("usd"):
                 base = symbol[:-3].upper()
-                return f"{base}/USDT"
+                return f"{base}/USD"
             return symbol.upper()
 
         mock_binance._normalize_symbol.side_effect = normalize_symbol
         mock_binance.exchange.load_markets.return_value = {
-            "BTC/USDT": {},
-            "ETH/USDT": {},
+            "BTC/USD": {},
+            "ETH/USD": {},
         }
 
         mock_client.exchanges = {
@@ -137,13 +137,13 @@ class TestSymbolValidation(unittest.TestCase):
         def normalize_symbol(symbol):
             if symbol.lower().endswith("usd"):
                 base = symbol[:-3].upper()
-                return f"{base}/USDT"
+                return f"{base}/USD"
             return symbol.upper()
 
         mock_client._normalize_symbol.side_effect = normalize_symbol
         mock_client.exchange.load_markets.return_value = {
-            "BTC/USDT": {},
-            "ETH/USDT": {},
+            "BTC/USD": {},
+            "ETH/USD": {},
         }
 
         symbols = ["btcusd", "ethusd", "adausd"]
@@ -164,7 +164,7 @@ class TestSymbolValidation(unittest.TestCase):
         def normalize_symbol(symbol):
             if symbol.lower().endswith("usd"):
                 base = symbol[:-3].upper()
-                return f"{base}/USDT"
+                return f"{base}/USD"
             return symbol.upper()
 
         # Set up both exchange clients identically for this test
@@ -172,8 +172,8 @@ class TestSymbolValidation(unittest.TestCase):
             exchange_client.exchange_name = name
             exchange_client._normalize_symbol.side_effect = normalize_symbol
             exchange_client.exchange.load_markets.return_value = {
-                "BTC/USDT": {},
-                "ETH/USDT": {},
+                "BTC/USD": {},
+                "ETH/USD": {},
             }
 
         symbols = ["btcusd", "ethusd"]
@@ -207,14 +207,13 @@ class TestSymbolValidation(unittest.TestCase):
                 return symbol.upper()
             if symbol.lower().endswith("usd"):
                 base = symbol[:-3].upper()
-                return f"{base}/USDT"
+                return f"{base}/USD"
             return symbol.upper()
 
         mock_client._normalize_symbol.side_effect = normalize_symbol
         mock_client.exchange.load_markets.return_value = {
-            "BTC/USDT": {},
-            "ETH/USDT": {},
-            "BTC/USD": {},
+            "BTC/USD": {}, # Matches btcusd and BTC/USD
+            "ETH/USD": {}, # Matches ethusd
         }
 
         symbols = ["btcusd", "BTC/USD", "ethusd", "INVALID"]
@@ -248,7 +247,7 @@ class TestSymbolValidationIntegration(unittest.TestCase):
         ]
 
         # Mock Binance markets (comprehensive)
-        binance_markets = {f"{pair[:-3].upper()}/USDT": {} for pair in common_pairs}
+        binance_markets = {f"{pair[:-3].upper()}/USD": {} for pair in common_pairs}
 
         # Mock Coinbase markets (more limited)
         coinbase_limited = ["btcusd", "ethusd", "adausd", "solusd", "ltcusd", "linkusd"]
@@ -263,7 +262,7 @@ class TestSymbolValidationIntegration(unittest.TestCase):
         def normalize_symbol_binance(symbol):
             if symbol.lower().endswith("usd"):
                 base = symbol[:-3].upper()
-                return f"{base}/USDT"
+                return f"{base}/USD"
             return symbol.upper()
 
         mock_binance._normalize_symbol.side_effect = normalize_symbol_binance
@@ -299,3 +298,4 @@ class TestSymbolValidationIntegration(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+    

--- a/services/candle_ingestor/symbol_validation_test.py
+++ b/services/candle_ingestor/symbol_validation_test.py
@@ -212,8 +212,8 @@ class TestSymbolValidation(unittest.TestCase):
 
         mock_client._normalize_symbol.side_effect = normalize_symbol
         mock_client.exchange.load_markets.return_value = {
-            "BTC/USD": {}, # Matches btcusd and BTC/USD
-            "ETH/USD": {}, # Matches ethusd
+            "BTC/USD": {},  # Matches btcusd and BTC/USD
+            "ETH/USD": {},  # Matches ethusd
         }
 
         symbols = ["btcusd", "BTC/USD", "ethusd", "INVALID"]

--- a/services/candle_ingestor/symbol_validation_test.py
+++ b/services/candle_ingestor/symbol_validation_test.py
@@ -298,4 +298,3 @@ class TestSymbolValidationIntegration(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-    


### PR DESCRIPTION
Standardized the normalized output for USD-based trading pairs to use "USD" instead of "USDT".