### PR TITLE
Add Crypto.com and Gemini to candle ingestor exchange list

### DIFF
--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -99,6 +99,8 @@ candleIngestor:
       - "kraken" # High volume, U.S. friendly
       - "binanceus" # U.S. specific, good U.S. volume
       - "bitstamp" # Good volume, U.S. accessible
+      - "cryptocom" # Decent volume, U.S. regulated
+      - "gemini" # Decent volume, U.S. regulated
     minExchangesRequired: 2
     # minExchangesRequired: 0 # 0 = auto-detect
     candleGranularityMinutes: 1


### PR DESCRIPTION
Expanded the default exchange list for the candle ingestor to include Crypto.com and Gemini.