### PR TITLE
Add InfluxDB Java and Kotlin client dependencies to Bazel build (MINOR)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -79,6 +79,8 @@ maven.install(
         "com.google.mug:mug-protobuf:8.2",
         "com.google.protobuf:protobuf-java:4.29.2",
         "com.google.protobuf:protobuf-java-util:4.29.2",
+        "com.influxdb:influxdb-client-java:7.3.0",
+        "com.influxdb:influxdb-client-kotlin:7.3.0",
         "com.ryanharter.auto.value:auto-value-gson:1.3.1",
         "com.ryanharter.auto.value:auto-value-gson-annotations:0.8.0",
         "com.ryanharter.auto.value:auto-value-gson-factory:1.3.1",

--- a/third_party/java/BUILD
+++ b/third_party/java/BUILD
@@ -200,7 +200,7 @@ java_library(
     name = "influxdb_client_java",
     visibility = ["//visibility:public"],
     exports = [
-        "@tradestream_maven//:com_influxdb_client_java",
+        "@tradestream_maven//:com_influxdb_influxdb_client_java",
     ],
 )
 
@@ -208,7 +208,7 @@ java_library(
     name = "influxdb_client_kotlin",
     visibility = ["//visibility:public"],
     exports = [
-        "@tradestream_maven//:com_influxdb_client_kotlin",
+        "@tradestream_maven//:com_influxdb_influxdb_client_kotlin",
     ],
 )
 

--- a/third_party/java/BUILD
+++ b/third_party/java/BUILD
@@ -197,6 +197,22 @@ java_library(
 )
 
 java_library(
+    name = "influxdb_client_java",
+    visibility = ["//visibility:public"],
+    exports = [
+        "@tradestream_maven//:com_influxdb_client_java",
+    ],
+)
+
+java_library(
+    name = "influxdb_client_kotlin",
+    visibility = ["//visibility:public"],
+    exports = [
+        "@tradestream_maven//:com_influxdb_client_kotlin",
+    ],
+)
+
+java_library(
     name = "jenetics",
     visibility = ["//visibility:public"],
     exports = [


### PR DESCRIPTION
Added InfluxDB Java and Kotlin clients to MODULE.bazel and exposed them via new `java_library` targets.