### PR TITLE
Refactor GAEngineFactory to Use GAEngineParams Instead of GAOptimizationRequest (MINOR)

### DIFF
--- a/src/main/java/com/verlumen/tradestream/discovery/BUILD
+++ b/src/main/java/com/verlumen/tradestream/discovery/BUILD
@@ -62,7 +62,7 @@ kt_jvm_library(
         "//src/test/java/com/verlumen/tradestream/discovery:__pkg__",
     ],
     deps = [
-        "//protos:backtesting_java_proto", # GAOptimizationRequest is still used by some callers, even if GAEngineFactory is decoupled
+        "//protos:backtesting_java_proto",  # GAOptimizationRequest is still used by some callers, even if GAEngineFactory is decoupled
         "//protos:marketdata_java_proto",
         "//protos:strategies_java_proto",
         "//third_party/java:jenetics",

--- a/src/main/java/com/verlumen/tradestream/discovery/BUILD
+++ b/src/main/java/com/verlumen/tradestream/discovery/BUILD
@@ -95,8 +95,8 @@ kt_jvm_library(
     name = "ga_engine_params",
     srcs = ["GAEngineParams.kt"],
     deps = [
-        "//protos:marketdata_java_proto", # For Candle
-        "//protos:strategies_java_proto", # For StrategyType
+        "//protos:marketdata_java_proto",  # For Candle
+        "//protos:strategies_java_proto",  # For StrategyType
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/discovery/BUILD
+++ b/src/main/java/com/verlumen/tradestream/discovery/BUILD
@@ -120,8 +120,8 @@ java_library(
         ":ga_engine_params",
         ":param_config",
         ":param_config_manager",
-        "//protos:marketdata_java_proto", # For Candle in GAEngineParams
-        "//protos:strategies_java_proto", # For StrategyType in GAEngineParams
+        "//protos:marketdata_java_proto",  # For Candle in GAEngineParams
+        "//protos:strategies_java_proto",  # For StrategyType in GAEngineParams
         "//third_party/java:guava",
         "//third_party/java:guice",
         "//third_party/java:jenetics",

--- a/src/main/java/com/verlumen/tradestream/discovery/BUILD
+++ b/src/main/java/com/verlumen/tradestream/discovery/BUILD
@@ -62,7 +62,8 @@ kt_jvm_library(
         "//src/test/java/com/verlumen/tradestream/discovery:__pkg__",
     ],
     deps = [
-        "//protos:backtesting_java_proto",
+        "//protos:backtesting_java_proto", # GAOptimizationRequest is still used by some callers, even if GAEngineFactory is decoupled
+        "//protos:marketdata_java_proto",
         "//protos:strategies_java_proto",
         "//third_party/java:jenetics",
     ],
@@ -75,6 +76,7 @@ kt_jvm_library(
         ":fitness_function_factory",
         ":genotype_converter",
         "//protos:backtesting_java_proto",
+        "//protos:marketdata_java_proto",
         "//protos:strategies_java_proto",
         "//src/main/java/com/verlumen/tradestream/backtesting:backtest_request_factory",
         "//src/main/java/com/verlumen/tradestream/backtesting:backtest_runner",
@@ -90,10 +92,19 @@ java_library(
 )
 
 kt_jvm_library(
+    name = "ga_engine_params",
+    srcs = ["GAEngineParams.kt"],
+    deps = [
+        "//protos:marketdata_java_proto", # For Candle
+        "//protos:strategies_java_proto", # For StrategyType
+    ],
+)
+
+kt_jvm_library(
     name = "ga_engine_factory",
     srcs = ["GAEngineFactory.kt"],
     deps = [
-        "//protos:backtesting_java_proto",
+        ":ga_engine_params",
         "//third_party/java:jenetics",
     ],
 )
@@ -106,11 +117,11 @@ java_library(
         ":fitness_function_factory",
         ":ga_constants",
         ":ga_engine_factory",
+        ":ga_engine_params",
         ":param_config",
         ":param_config_manager",
-        "//protos:backtesting_java_proto",
-        "//protos:marketdata_java_proto",
-        "//protos:strategies_java_proto",
+        "//protos:marketdata_java_proto", # For Candle in GAEngineParams
+        "//protos:strategies_java_proto", # For StrategyType in GAEngineParams
         "//third_party/java:guava",
         "//third_party/java:guice",
         "//third_party/java:jenetics",

--- a/src/main/java/com/verlumen/tradestream/discovery/GAEngineFactory.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/GAEngineFactory.kt
@@ -1,6 +1,5 @@
 package com.verlumen.tradestream.discovery
 
-import com.verlumen.tradestream.backtesting.GAOptimizationRequest
 import io.jenetics.engine.Engine
 import java.io.Serializable
 
@@ -9,8 +8,8 @@ interface GAEngineFactory : Serializable {
     /**
      * Creates a genetic algorithm engine configured for the given request.
      *
-     * @param request the GA optimization request
+     * @param params The parameters for configuring the GA engine.
      * @return a configured GA engine
      */
-    fun createEngine(request: GAOptimizationRequest): Engine<*, Double>
+    fun createEngine(params: GAEngineParams): Engine<*, Double>
 }

--- a/src/main/java/com/verlumen/tradestream/discovery/GAEngineParams.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/GAEngineParams.kt
@@ -7,7 +7,7 @@ import java.io.Serializable
 data class GAEngineParams(
     val strategyType: StrategyType,
     val candlesList: List<Candle>,
-    val populationSize: Int
+    val populationSize: Int,
 ) : Serializable {
     companion object {
         private const val serialVersionUID = 1L

--- a/src/main/java/com/verlumen/tradestream/discovery/GAEngineParams.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/GAEngineParams.kt
@@ -1,0 +1,15 @@
+package com.verlumen.tradestream.discovery
+
+import com.verlumen.tradestream.marketdata.Candle
+import com.verlumen.tradestream.strategies.StrategyType
+import java.io.Serializable
+
+data class GAEngineParams(
+    val strategyType: StrategyType,
+    val candlesList: List<Candle>,
+    val populationSize: Int
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/src/test/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/test/java/com/verlumen/tradestream/backtesting/BUILD
@@ -35,7 +35,7 @@ java_test(
         "//src/main/java/com/verlumen/tradestream/discovery:fitness_function_factory",
         "//src/main/java/com/verlumen/tradestream/discovery:ga_engine_factory",
         "//src/main/java/com/verlumen/tradestream/discovery:ga_engine_factory_impl",
-        "//src/main/java/com/verlumen/tradestream/discovery:ga_engine_params", # Added
+        "//src/main/java/com/verlumen/tradestream/discovery:ga_engine_params",  # Added
         "//src/main/java/com/verlumen/tradestream/discovery:param_config",
         "//src/main/java/com/verlumen/tradestream/discovery:param_config_manager",
         "//third_party/java:guava",

--- a/src/test/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/test/java/com/verlumen/tradestream/backtesting/BUILD
@@ -30,12 +30,12 @@ java_test(
     srcs = ["GAEngineFactoryImplTest.java"],
     deps = [
         "//protos:backtesting_java_proto",
-        "//protos:marketdata_java_proto",  # Added for Candle
+        "//protos:marketdata_java_proto",
         "//protos:strategies_java_proto",
         "//src/main/java/com/verlumen/tradestream/discovery:fitness_function_factory",
         "//src/main/java/com/verlumen/tradestream/discovery:ga_engine_factory",
         "//src/main/java/com/verlumen/tradestream/discovery:ga_engine_factory_impl",
-        "//src/main/java/com/verlumen/tradestream/discovery:ga_engine_params",  # Added
+        "//src/main/java/com/verlumen/tradestream/discovery:ga_engine_params",
         "//src/main/java/com/verlumen/tradestream/discovery:param_config",
         "//src/main/java/com/verlumen/tradestream/discovery:param_config_manager",
         "//third_party/java:guava",
@@ -66,21 +66,6 @@ java_test(
         "//third_party/java:junit",
         "//third_party/java:mockito_core",
         "//third_party/java:protobuf_java",
-        "//third_party/java:truth",
-    ],
-)
-
-java_test(
-    name = "ParamConfigsTest",
-    srcs = ["ParamConfigsTest.java"],
-    deps = [
-        "//protos:strategies_java_proto",
-        "//src/main/java/com/verlumen/tradestream/discovery:param_config",
-        "//src/main/java/com/verlumen/tradestream/discovery:param_configs",
-        "//src/main/java/com/verlumen/tradestream/strategies:strategy_constants",
-        "//third_party/java:guava",
-        "//third_party/java:junit",
-        "//third_party/java:test_parameter_injector",
         "//third_party/java:truth",
     ],
 )

--- a/src/test/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/test/java/com/verlumen/tradestream/backtesting/BUILD
@@ -1,77 +1,86 @@
 load("@rules_java//java:defs.bzl", "java_test")
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
-
-kt_jvm_test(
-    name = "BacktestRequestFactoryImplTest",
-    srcs = ["BacktestRequestFactoryImplTest.kt"],
-    # If using Kotlin 1.6+, you might need:
-    # jvm_target = "17",
-    # toolchain = "@rules_kotlin//toolchains/kotlin_jvm:kt_jvm_toolchain_alias",
-    test_class = "com.verlumen.tradestream.backtesting.BacktestRequestFactoryImplTest",
-    deps = [
-        # Library under test
-        "//src/main/java/com/verlumen/tradestream/backtesting:backtest_request_factory_impl",
-        # Interface (needed if the test references the interface type)
-        "//src/main/java/com/verlumen/tradestream/backtesting:backtest_request_factory",
-        # Protobuf dependencies
-        "//protos:backtesting_java_proto",
-        "//protos:marketdata_java_proto",
-        "//protos:strategies_java_proto",
-        # Testing libraries
-        "//third_party/java:junit",
-        "//third_party/java:truth",
-        # Other direct dependencies (if any are added to the test)
-        "//third_party/java:flogger",  # Included because the Impl uses it, might be needed for test setup/verification later
-        "//third_party/java:protobuf_java_util",  # For Timestamps
-        "//third_party/java:guava",  # For ImmutableList if used directly in test
-    ],
-)
 
 java_test(
-    name = "BacktestRunnerImplTest",
-    srcs = ["BacktestRunnerImplTest.java"],
+    name = "FitnessFunctionFactoryImplTest",
+    size = "small",
+    srcs = ["FitnessFunctionFactoryImplTest.java"],
     deps = [
         "//protos:backtesting_java_proto",
         "//protos:marketdata_java_proto",
         "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/backtesting:backtest_request_factory",
+        "//src/main/java/com/verlumen/tradestream/backtesting:backtest_request_factory_impl",
         "//src/main/java/com/verlumen/tradestream/backtesting:backtest_runner",
-        "//src/main/java/com/verlumen/tradestream/backtesting:backtest_runner_impl",
-        "//src/main/java/com/verlumen/tradestream/strategies:strategy_manager",
-        "//src/main/java/com/verlumen/tradestream/ta4j:ta4j_module",
+        "//src/main/java/com/verlumen/tradestream/discovery:fitness_function_factory",
+        "//src/main/java/com/verlumen/tradestream/discovery:fitness_function_factory_impl",
+        "//src/main/java/com/verlumen/tradestream/discovery:genotype_converter",
         "//third_party/java:guava",
         "//third_party/java:guice",
         "//third_party/java:guice_testlib",
+        "//third_party/java:jenetics",
         "//third_party/java:junit",
         "//third_party/java:mockito_core",
         "//third_party/java:protobuf_java",
-        "//third_party/java:protobuf_java_util",
-        "//third_party/java:ta4j_core",
         "//third_party/java:truth",
     ],
 )
 
 java_test(
-    name = "RunBacktestTest",
-    size = "small",
-    srcs = ["RunBacktestTest.java"],
-    runtime_deps = [
-        "//third_party/java:beam_runners_direct_java",
-        "//third_party/java:hamcrest",
-    ],
+    name = "GAEngineFactoryImplTest",
+    srcs = ["GAEngineFactoryImplTest.java"],
     deps = [
         "//protos:backtesting_java_proto",
-        "//protos:marketdata_java_proto",
+        "//protos:marketdata_java_proto",  # Added for Candle
         "//protos:strategies_java_proto",
-        "//src/main/java/com/verlumen/tradestream/backtesting:backtest_runner",
-        "//src/main/java/com/verlumen/tradestream/backtesting:run_backtest",
-        "//third_party/java:beam_sdks_java_core",
-        "//third_party/java:beam_sdks_java_test_utils",
+        "//src/main/java/com/verlumen/tradestream/discovery:fitness_function_factory",
+        "//src/main/java/com/verlumen/tradestream/discovery:ga_engine_factory",
+        "//src/main/java/com/verlumen/tradestream/discovery:ga_engine_factory_impl",
+        "//src/main/java/com/verlumen/tradestream/discovery:ga_engine_params", # Added
+        "//src/main/java/com/verlumen/tradestream/discovery:param_config",
+        "//src/main/java/com/verlumen/tradestream/discovery:param_config_manager",
+        "//third_party/java:guava",
         "//third_party/java:guice",
         "//third_party/java:guice_testlib",
-        "//third_party/java:joda_time",
+        "//third_party/java:jenetics",
         "//third_party/java:junit",
         "//third_party/java:mockito_core",
-        "//third_party/java:ta4j_core",
+        "//third_party/java:truth",
+    ],
+)
+
+java_test(
+    name = "GenotypeConverterImplTest",
+    size = "small",
+    srcs = ["GenotypeConverterImplTest.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/discovery:chromosome_spec",
+        "//src/main/java/com/verlumen/tradestream/discovery:genotype_converter",
+        "//src/main/java/com/verlumen/tradestream/discovery:genotype_converter_impl",
+        "//src/main/java/com/verlumen/tradestream/discovery:param_config",
+        "//src/main/java/com/verlumen/tradestream/discovery:param_config_manager",
+        "//third_party/java:guava",
+        "//third_party/java:guice",
+        "//third_party/java:guice_testlib",
+        "//third_party/java:jenetics",
+        "//third_party/java:junit",
+        "//third_party/java:mockito_core",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:truth",
+    ],
+)
+
+java_test(
+    name = "ParamConfigsTest",
+    srcs = ["ParamConfigsTest.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/discovery:param_config",
+        "//src/main/java/com/verlumen/tradestream/discovery:param_configs",
+        "//src/main/java/com/verlumen/tradestream/strategies:strategy_constants",
+        "//third_party/java:guava",
+        "//third_party/java:junit",
+        "//third_party/java:test_parameter_injector",
         "//third_party/java:truth",
     ],
 )

--- a/src/test/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/test/java/com/verlumen/tradestream/backtesting/BUILD
@@ -1,71 +1,77 @@
 load("@rules_java//java:defs.bzl", "java_test")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 
-java_test(
-    name = "FitnessFunctionFactoryImplTest",
-    size = "small",
-    srcs = ["FitnessFunctionFactoryImplTest.java"],
+kt_jvm_test(
+    name = "BacktestRequestFactoryImplTest",
+    srcs = ["BacktestRequestFactoryImplTest.kt"],
+    # If using Kotlin 1.6+, you might need:
+    # jvm_target = "17",
+    # toolchain = "@rules_kotlin//toolchains/kotlin_jvm:kt_jvm_toolchain_alias",
+    test_class = "com.verlumen.tradestream.backtesting.BacktestRequestFactoryImplTest",
     deps = [
-        "//protos:backtesting_java_proto",
-        "//protos:marketdata_java_proto",
-        "//protos:strategies_java_proto",
-        "//src/main/java/com/verlumen/tradestream/backtesting:backtest_request_factory",
+        # Library under test
         "//src/main/java/com/verlumen/tradestream/backtesting:backtest_request_factory_impl",
-        "//src/main/java/com/verlumen/tradestream/backtesting:backtest_runner",
-        "//src/main/java/com/verlumen/tradestream/discovery:fitness_function_factory",
-        "//src/main/java/com/verlumen/tradestream/discovery:fitness_function_factory_impl",
-        "//src/main/java/com/verlumen/tradestream/discovery:genotype_converter",
-        "//third_party/java:guava",
-        "//third_party/java:guice",
-        "//third_party/java:guice_testlib",
-        "//third_party/java:jenetics",
+        # Interface (needed if the test references the interface type)
+        "//src/main/java/com/verlumen/tradestream/backtesting:backtest_request_factory",
+        # Protobuf dependencies
+        "//protos:backtesting_java_proto",
+        "//protos:marketdata_java_proto",
+        "//protos:strategies_java_proto",
+        # Testing libraries
         "//third_party/java:junit",
-        "//third_party/java:mockito_core",
-        "//third_party/java:protobuf_java",
         "//third_party/java:truth",
+        # Other direct dependencies (if any are added to the test)
+        "//third_party/java:flogger",  # Included because the Impl uses it, might be needed for test setup/verification later
+        "//third_party/java:protobuf_java_util",  # For Timestamps
+        "//third_party/java:guava",  # For ImmutableList if used directly in test
     ],
 )
 
 java_test(
-    name = "GAEngineFactoryImplTest",
-    srcs = ["GAEngineFactoryImplTest.java"],
+    name = "BacktestRunnerImplTest",
+    srcs = ["BacktestRunnerImplTest.java"],
     deps = [
         "//protos:backtesting_java_proto",
         "//protos:marketdata_java_proto",
         "//protos:strategies_java_proto",
-        "//src/main/java/com/verlumen/tradestream/discovery:fitness_function_factory",
-        "//src/main/java/com/verlumen/tradestream/discovery:ga_engine_factory",
-        "//src/main/java/com/verlumen/tradestream/discovery:ga_engine_factory_impl",
-        "//src/main/java/com/verlumen/tradestream/discovery:ga_engine_params",
-        "//src/main/java/com/verlumen/tradestream/discovery:param_config",
-        "//src/main/java/com/verlumen/tradestream/discovery:param_config_manager",
+        "//src/main/java/com/verlumen/tradestream/backtesting:backtest_runner",
+        "//src/main/java/com/verlumen/tradestream/backtesting:backtest_runner_impl",
+        "//src/main/java/com/verlumen/tradestream/strategies:strategy_manager",
+        "//src/main/java/com/verlumen/tradestream/ta4j:ta4j_module",
         "//third_party/java:guava",
         "//third_party/java:guice",
         "//third_party/java:guice_testlib",
-        "//third_party/java:jenetics",
         "//third_party/java:junit",
         "//third_party/java:mockito_core",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:protobuf_java_util",
+        "//third_party/java:ta4j_core",
         "//third_party/java:truth",
     ],
 )
 
 java_test(
-    name = "GenotypeConverterImplTest",
+    name = "RunBacktestTest",
     size = "small",
-    srcs = ["GenotypeConverterImplTest.java"],
+    srcs = ["RunBacktestTest.java"],
+    runtime_deps = [
+        "//third_party/java:beam_runners_direct_java",
+        "//third_party/java:hamcrest",
+    ],
     deps = [
+        "//protos:backtesting_java_proto",
+        "//protos:marketdata_java_proto",
         "//protos:strategies_java_proto",
-        "//src/main/java/com/verlumen/tradestream/discovery:chromosome_spec",
-        "//src/main/java/com/verlumen/tradestream/discovery:genotype_converter",
-        "//src/main/java/com/verlumen/tradestream/discovery:genotype_converter_impl",
-        "//src/main/java/com/verlumen/tradestream/discovery:param_config",
-        "//src/main/java/com/verlumen/tradestream/discovery:param_config_manager",
-        "//third_party/java:guava",
+        "//src/main/java/com/verlumen/tradestream/backtesting:backtest_runner",
+        "//src/main/java/com/verlumen/tradestream/backtesting:run_backtest",
+        "//third_party/java:beam_sdks_java_core",
+        "//third_party/java:beam_sdks_java_test_utils",
         "//third_party/java:guice",
         "//third_party/java:guice_testlib",
-        "//third_party/java:jenetics",
+        "//third_party/java:joda_time",
         "//third_party/java:junit",
         "//third_party/java:mockito_core",
-        "//third_party/java:protobuf_java",
+        "//third_party/java:ta4j_core",
         "//third_party/java:truth",
     ],
 )

--- a/src/test/java/com/verlumen/tradestream/discovery/BUILD
+++ b/src/test/java/com/verlumen/tradestream/discovery/BUILD
@@ -30,10 +30,12 @@ java_test(
     srcs = ["GAEngineFactoryImplTest.java"],
     deps = [
         "//protos:backtesting_java_proto",
+        "//protos:marketdata_java_proto",
         "//protos:strategies_java_proto",
         "//src/main/java/com/verlumen/tradestream/discovery:fitness_function_factory",
         "//src/main/java/com/verlumen/tradestream/discovery:ga_engine_factory",
         "//src/main/java/com/verlumen/tradestream/discovery:ga_engine_factory_impl",
+        "//src/main/java/com/verlumen/tradestream/discovery:ga_engine_params",
         "//src/main/java/com/verlumen/tradestream/discovery:param_config",
         "//src/main/java/com/verlumen/tradestream/discovery:param_config_manager",
         "//third_party/java:guava",

--- a/src/test/java/com/verlumen/tradestream/discovery/GAEngineFactoryImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/discovery/GAEngineFactoryImplTest.java
@@ -80,10 +80,7 @@ public class GAEngineFactoryImplTest {
     // Arrange
     int customSize = 42;
     GAEngineParams customParams =
-        new GAEngineParams(
-            testParams.getStrategyType(),
-            testParams.getCandlesList(),
-            customSize);
+        new GAEngineParams(testParams.getStrategyType(), testParams.getCandlesList(), customSize);
 
     // Act
     Engine<?, Double> engine = engineFactory.createEngine(customParams);

--- a/src/test/java/com/verlumen/tradestream/discovery/GAEngineFactoryImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/discovery/GAEngineFactoryImplTest.java
@@ -98,10 +98,7 @@ public class GAEngineFactoryImplTest {
   public void createEngine_withZeroPopulationSize_usesDefaultSize() {
     // Arrange
     GAEngineParams zeroSizeParams =
-        new GAEngineParams(
-            testParams.getStrategyType(),
-            testParams.getCandlesList(),
-            0);
+        new GAEngineParams(testParams.getStrategyType(), testParams.getCandlesList(), 0);
 
     // Act
     Engine<?, Double> engine = engineFactory.createEngine(zeroSizeParams);


### PR DESCRIPTION
This change refactors the `GAEngineFactory` and related components to decouple the factory from the `GAOptimizationRequest` protocol buffer. A new `GAEngineParams` Kotlin data class has been introduced to represent the necessary configuration for creating a genetic algorithm engine.

### Summary of Changes:

* Introduced `GAEngineParams` as a serializable Kotlin data class to encapsulate `strategyType`, `candlesList`, and `populationSize`.
* Updated `GAEngineFactory` and `GAEngineFactoryImpl` to use `GAEngineParams` instead of `GAOptimizationRequest`.
* Adjusted dependent build targets to reflect new dependencies on `marketdata_java_proto` and `strategies_java_proto`.
* Added a new Bazel target for `ga_engine_params`.
* Updated tests in `GAEngineFactoryImplTest` to construct and use `GAEngineParams`, removing dependency on `GAOptimizationRequest`.

### Rationale:

This refactor improves separation of concerns by decoupling the optimization engine logic from protobuf definitions, promoting better modularity and testability. It also reduces the surface area of dependencies on protobuf-generated classes in core engine logic.

**(MINOR)**: This is a backward-compatible change that introduces new functionality and modular structure without altering existing external APIs.
