### PR TITLE
Add Beam transform and tests for deserializing StrategyDiscoveryRequest from Kafka (MINOR)

### DIFF
--- a/src/main/java/com/verlumen/tradestream/discovery/BUILD
+++ b/src/main/java/com/verlumen/tradestream/discovery/BUILD
@@ -27,8 +27,10 @@ kt_jvm_library(
     name = "deserialize_strategy_discovery_request_fn",
     srcs = ["DeserializeStrategyDiscoveryRequestFn.kt"],
     deps = [
+        "//protos:discovery_java_proto",
         "//third_party/java:beam_sdks_java_core",
         "//third_party/java:flogger",
+        "//third_party/java:protobuf_java",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/discovery/BUILD
+++ b/src/main/java/com/verlumen/tradestream/discovery/BUILD
@@ -24,7 +24,7 @@ java_library(
 )
 
 kt_jvm_library(
-    name = "deserialize_strategy_discovery_request_fn"
+    name = "deserialize_strategy_discovery_request_fn",
     srcs = ["DeserializeStrategyDiscoveryRequestFn.kt"],
     deps = [
         "//third_party/java:beam_sdks_java_core",

--- a/src/main/java/com/verlumen/tradestream/discovery/BUILD
+++ b/src/main/java/com/verlumen/tradestream/discovery/BUILD
@@ -24,6 +24,15 @@ java_library(
 )
 
 kt_jvm_library(
+    name = "deserialize_strategy_discovery_request_fn"
+    srcs = ["DeserializeStrategyDiscoveryRequestFn.kt"],
+    deps = [
+        "//third_party/java:beam_sdks_java_core",
+        "//third_party/java:flogger",
+    ],
+)
+
+kt_jvm_library(
     name = "discovery_module",
     srcs = ["DiscoveryModule.kt"],
     visibility = [
@@ -40,8 +49,10 @@ kt_jvm_library(
         ":param_config_manager",
         ":param_config_manager_impl",
         ":param_configs",
+        "//protos:discovery_java_proto",
         "//third_party/java:guava",
         "//third_party/java:guice",
+        "//third_party/java:protobuf_java",
     ],
 )
 
@@ -62,7 +73,7 @@ kt_jvm_library(
         "//src/test/java/com/verlumen/tradestream/discovery:__pkg__",
     ],
     deps = [
-        "//protos:backtesting_java_proto",  # GAOptimizationRequest is still used by some callers, even if GAEngineFactory is decoupled
+        "//protos:backtesting_java_proto",
         "//protos:marketdata_java_proto",
         "//protos:strategies_java_proto",
         "//third_party/java:jenetics",

--- a/src/main/java/com/verlumen/tradestream/discovery/DeserializeStrategyDiscoveryRequestFn.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/DeserializeStrategyDiscoveryRequestFn.kt
@@ -4,7 +4,6 @@ import com.google.protobuf.InvalidProtocolBufferException
 import com.verlumen.tradestream.discovery.proto.Discovery.StrategyDiscoveryRequest
 import org.apache.beam.sdk.transforms.DoFn
 import org.apache.beam.sdk.values.KV
-import com.google.common.flogger.FluentLogger
 
 /**
  * Apache Beam transform that deserializes Kafka messages containing

--- a/src/main/java/com/verlumen/tradestream/discovery/DeserializeStrategyDiscoveryRequestFn.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/DeserializeStrategyDiscoveryRequestFn.kt
@@ -16,7 +16,6 @@ import com.google.common.flogger.FluentLogger
  * Handles deserialization errors gracefully by logging and dropping invalid messages.
  */
 class DeserializeStrategyDiscoveryRequestFn : DoFn<KV<String, ByteArray>, StrategyDiscoveryRequest>() {
-    
     companion object {
         private val logger = FluentLogger.forEnclosingClass()
     }

--- a/src/main/java/com/verlumen/tradestream/discovery/DeserializeStrategyDiscoveryRequestFn.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/DeserializeStrategyDiscoveryRequestFn.kt
@@ -2,7 +2,7 @@ package com.verlumen.tradestream.discovery
 
 import com.google.common.flogger.FluentLogger
 import com.google.protobuf.InvalidProtocolBufferException
-import com.verlumen.tradestream.discovery.Discovery.StrategyDiscoveryRequest
+import com.verlumen.tradestream.discovery.StrategyDiscoveryRequest
 import org.apache.beam.sdk.transforms.DoFn
 import org.apache.beam.sdk.values.KV
 

--- a/src/main/java/com/verlumen/tradestream/discovery/DeserializeStrategyDiscoveryRequestFn.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/DeserializeStrategyDiscoveryRequestFn.kt
@@ -24,7 +24,6 @@ class DeserializeStrategyDiscoveryRequestFn : DoFn<KV<String, ByteArray>, Strate
     @ProcessElement
     fun processElement(context: ProcessContext) {
         val kafkaValue = context.element().value
-        
         if (kafkaValue != null) {
             try {
                 val request = StrategyDiscoveryRequest.parseFrom(kafkaValue)

--- a/src/main/java/com/verlumen/tradestream/discovery/DeserializeStrategyDiscoveryRequestFn.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/DeserializeStrategyDiscoveryRequestFn.kt
@@ -1,8 +1,7 @@
 package com.verlumen.tradestream.discovery
 
 import com.google.common.flogger.FluentLogger
-import com.google.common.flogger.FluentLogger
-import com.google.common.flogger.FluentLogger
+import com.google.protobuf.InvalidProtocolBufferException
 import com.verlumen.tradestream.discovery.proto.Discovery.StrategyDiscoveryRequest
 import org.apache.beam.sdk.transforms.DoFn
 import org.apache.beam.sdk.values.KV

--- a/src/main/java/com/verlumen/tradestream/discovery/DeserializeStrategyDiscoveryRequestFn.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/DeserializeStrategyDiscoveryRequestFn.kt
@@ -2,7 +2,7 @@ package com.verlumen.tradestream.discovery
 
 import com.google.common.flogger.FluentLogger
 import com.google.protobuf.InvalidProtocolBufferException
-import com.verlumen.tradestream.discovery.proto.Discovery.StrategyDiscoveryRequest
+import com.verlumen.tradestream.discovery.Discovery.StrategyDiscoveryRequest
 import org.apache.beam.sdk.transforms.DoFn
 import org.apache.beam.sdk.values.KV
 

--- a/src/main/java/com/verlumen/tradestream/discovery/DeserializeStrategyDiscoveryRequestFn.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/DeserializeStrategyDiscoveryRequestFn.kt
@@ -30,7 +30,8 @@ class DeserializeStrategyDiscoveryRequestFn : DoFn<KV<String, ByteArray>, Strate
                 val request = StrategyDiscoveryRequest.parseFrom(kafkaValue)
                 context.output(request)
             } catch (e: InvalidProtocolBufferException) {
-                logger.atSevere()
+                logger
+                    .atSevere()
                     .withCause(e)
                     .log("Failed to deserialize StrategyDiscoveryRequest proto.")
             }

--- a/src/main/java/com/verlumen/tradestream/discovery/DeserializeStrategyDiscoveryRequestFn.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/DeserializeStrategyDiscoveryRequestFn.kt
@@ -1,0 +1,39 @@
+package com.verlumen.tradestream.discovery
+
+import com.google.protobuf.InvalidProtocolBufferException
+import com.verlumen.tradestream.discovery.proto.Discovery.StrategyDiscoveryRequest
+import org.apache.beam.sdk.transforms.DoFn
+import org.apache.beam.sdk.values.KV
+import com.google.common.flogger.FluentLogger
+
+/**
+ * Apache Beam transform that deserializes Kafka messages containing
+ * StrategyDiscoveryRequest protobuf messages.
+ * 
+ * Input: KV<String, ByteArray> from Kafka
+ * Output: StrategyDiscoveryRequest proto objects
+ * 
+ * Handles deserialization errors gracefully by logging and dropping invalid messages.
+ */
+class DeserializeStrategyDiscoveryRequestFn : DoFn<KV<String, ByteArray>, StrategyDiscoveryRequest>() {
+    
+    companion object {
+        private val logger = FluentLogger.forEnclosingClass()
+    }
+
+    @ProcessElement
+    fun processElement(context: ProcessContext) {
+        val kafkaValue = context.element().value
+        
+        if (kafkaValue != null) {
+            try {
+                val request = StrategyDiscoveryRequest.parseFrom(kafkaValue)
+                context.output(request)
+            } catch (e: InvalidProtocolBufferException) {
+                logger.atSevere()
+                    .withCause(e)
+                    .log("Failed to deserialize StrategyDiscoveryRequest proto.")
+            }
+        }
+    }
+}

--- a/src/main/java/com/verlumen/tradestream/discovery/DeserializeStrategyDiscoveryRequestFn.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/DeserializeStrategyDiscoveryRequestFn.kt
@@ -12,7 +12,7 @@ import com.google.common.flogger.FluentLogger
  * 
  * Input: KV<String, ByteArray> from Kafka
  * Output: StrategyDiscoveryRequest proto objects
- * 
+ *
  * Handles deserialization errors gracefully by logging and dropping invalid messages.
  */
 class DeserializeStrategyDiscoveryRequestFn : DoFn<KV<String, ByteArray>, StrategyDiscoveryRequest>() {

--- a/src/main/java/com/verlumen/tradestream/discovery/DeserializeStrategyDiscoveryRequestFn.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/DeserializeStrategyDiscoveryRequestFn.kt
@@ -9,7 +9,7 @@ import com.google.common.flogger.FluentLogger
 /**
  * Apache Beam transform that deserializes Kafka messages containing
  * StrategyDiscoveryRequest protobuf messages.
- * 
+ *
  * Input: KV<String, ByteArray> from Kafka
  * Output: StrategyDiscoveryRequest proto objects
  *

--- a/src/main/java/com/verlumen/tradestream/discovery/DeserializeStrategyDiscoveryRequestFn.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/DeserializeStrategyDiscoveryRequestFn.kt
@@ -2,7 +2,6 @@ package com.verlumen.tradestream.discovery
 
 import com.google.common.flogger.FluentLogger
 import com.google.protobuf.InvalidProtocolBufferException
-import com.verlumen.tradestream.discovery.StrategyDiscoveryRequest
 import org.apache.beam.sdk.transforms.DoFn
 import org.apache.beam.sdk.values.KV
 

--- a/src/main/java/com/verlumen/tradestream/discovery/DeserializeStrategyDiscoveryRequestFn.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/DeserializeStrategyDiscoveryRequestFn.kt
@@ -1,7 +1,8 @@
 package com.verlumen.tradestream.discovery
 
 import com.google.common.flogger.FluentLogger
-import com.google.protobuf.InvalidProtocolBufferException
+import com.google.common.flogger.FluentLogger
+import com.google.common.flogger.FluentLogger
 import com.verlumen.tradestream.discovery.proto.Discovery.StrategyDiscoveryRequest
 import org.apache.beam.sdk.transforms.DoFn
 import org.apache.beam.sdk.values.KV

--- a/src/main/java/com/verlumen/tradestream/discovery/DeserializeStrategyDiscoveryRequestFn.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/DeserializeStrategyDiscoveryRequestFn.kt
@@ -1,5 +1,6 @@
 package com.verlumen.tradestream.discovery
 
+import com.google.common.flogger.FluentLogger
 import com.google.protobuf.InvalidProtocolBufferException
 import com.verlumen.tradestream.discovery.proto.Discovery.StrategyDiscoveryRequest
 import org.apache.beam.sdk.transforms.DoFn

--- a/src/test/java/com/verlumen/tradestream/discovery/BUILD
+++ b/src/test/java/com/verlumen/tradestream/discovery/BUILD
@@ -1,9 +1,44 @@
 load("@rules_java//java:defs.bzl", "java_test")
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 
+import com.google.inject.Guice
+import com.google.inject.testing.fieldbinder.BoundFieldModule
+import com.google.protobuf.util.Timestamps
+import com.verlumen.tradestream.strategies.StrategyType
+import org.apache.beam.sdk.testing.PAssert
+import org.apache.beam.sdk.testing.TestPipeline
+import org.apache.beam.sdk.transforms.Create
+import org.apache.beam.sdk.transforms.ParDo
+import org.apache.beam.sdk.values.KV
+import org.apache.beam.sdk.values.PCollection
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.MockitoAnnotations
+
+kt_jvm_test(
+    name = "DeserializeStrategyDiscoveryRequestFnTest",
+    srcs = ["DeserializeStrategyDiscoveryRequestFnTest.kt"],
+    runtime_deps = [
+        "//third_party/java:beam_runners_direct_java",
+        "//third_party/java:hamcrest",
+    ],
+    deps = [
+        "//protos:discovery_java_proto",
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/discovery:deserialize_strategy_discovery_request_fn",
+        "//third_party/java:guice",
+        "//third_party/java:guice_testlib",
+        "//third_party/java:junit",
+        "//third_party/java:mockito_core",
+        "//third_party/java:protobuf_java",
+    ],
+)
+
 java_test(
     name = "FitnessFunctionFactoryImplTest",
-    size = "small",
     srcs = ["FitnessFunctionFactoryImplTest.java"],
     deps = [
         "//protos:backtesting_java_proto",
@@ -51,7 +86,6 @@ java_test(
 
 java_test(
     name = "GenotypeConverterImplTest",
-    size = "small",
     srcs = ["GenotypeConverterImplTest.java"],
     deps = [
         "//protos:strategies_java_proto",

--- a/src/test/java/com/verlumen/tradestream/discovery/BUILD
+++ b/src/test/java/com/verlumen/tradestream/discovery/BUILD
@@ -1,23 +1,6 @@
 load("@rules_java//java:defs.bzl", "java_test")
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 
-import com.google.inject.Guice
-import com.google.inject.testing.fieldbinder.BoundFieldModule
-import com.google.protobuf.util.Timestamps
-import com.verlumen.tradestream.strategies.StrategyType
-import org.apache.beam.sdk.testing.PAssert
-import org.apache.beam.sdk.testing.TestPipeline
-import org.apache.beam.sdk.transforms.Create
-import org.apache.beam.sdk.transforms.ParDo
-import org.apache.beam.sdk.values.KV
-import org.apache.beam.sdk.values.PCollection
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.mockito.MockitoAnnotations
-
 kt_jvm_test(
     name = "DeserializeStrategyDiscoveryRequestFnTest",
     srcs = ["DeserializeStrategyDiscoveryRequestFnTest.kt"],
@@ -29,6 +12,8 @@ kt_jvm_test(
         "//protos:discovery_java_proto",
         "//protos:strategies_java_proto",
         "//src/main/java/com/verlumen/tradestream/discovery:deserialize_strategy_discovery_request_fn",
+        "//third_party/java:beam_sdks_java_core",
+        "//third_party/java:beam_sdks_java_test_utils",
         "//third_party/java:guice",
         "//third_party/java:guice_testlib",
         "//third_party/java:junit",

--- a/src/test/java/com/verlumen/tradestream/discovery/DeserializeStrategyDiscoveryRequestFnTest.kt
+++ b/src/test/java/com/verlumen/tradestream/discovery/DeserializeStrategyDiscoveryRequestFnTest.kt
@@ -1,0 +1,95 @@
+package com.verlumen.tradestream.discovery
+
+import com.google.inject.Guice
+import com.google.inject.testing.fieldbinder.BoundFieldModule
+import com.google.protobuf.util.Timestamps
+import com.verlumen.tradestream.discovery.proto.Discovery.GAConfig
+import com.verlumen.tradestream.discovery.proto.Discovery.StrategyDiscoveryRequest
+import com.verlumen.tradestream.strategies.StrategyType
+import org.apache.beam.sdk.testing.PAssert
+import org.apache.beam.sdk.testing.TestPipeline
+import org.apache.beam.sdk.transforms.Create
+import org.apache.beam.sdk.transforms.ParDo
+import org.apache.beam.sdk.values.KV
+import org.apache.beam.sdk.values.PCollection
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.MockitoAnnotations
+import javax.inject.Inject
+
+@RunWith(JUnit4::class)
+class DeserializeStrategyDiscoveryRequestFnTest {
+    @get:Rule
+    val pipeline: TestPipeline = TestPipeline.create()
+
+    // The class under test - will be injected by Guice
+    @Inject
+    lateinit var deserializeStrategyDiscoveryRequestFn: DeserializeStrategyDiscoveryRequestFn
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        
+        // Create Guice injector with BoundFieldModule to inject the test fixture
+        val injector = Guice.createInjector(BoundFieldModule.of(this))
+        injector.injectMembers(this)
+    }
+
+    @Test
+    fun testValidDeserialization() {
+        val now = System.currentTimeMillis()
+        val startTime = Timestamps.fromMillis(now - 100000)
+        val endTime = Timestamps.fromMillis(now)
+
+        val requestProto =
+            StrategyDiscoveryRequest
+                .newBuilder()
+                .setSymbol("BTC/USD")
+                .setStartTime(startTime)
+                .setEndTime(endTime)
+                .setStrategyType(StrategyType.SMA_RSI)
+                .setTopN(10)
+                .setGaConfig(
+                    GAConfig
+                        .newBuilder()
+                        .setMaxGenerations(50)
+                        .setPopulationSize(100)
+                        .build(),
+                ).build()
+
+        val serializedRequest = requestProto.toByteArray()
+        val input: PCollection<KV<String, ByteArray>> = pipeline.apply(Create.of(KV.of("key1", serializedRequest)))
+
+        val output: PCollection<StrategyDiscoveryRequest> = input.apply(ParDo.of(deserializeStrategyDiscoveryRequestFn))
+
+        PAssert.that(output).containsInAnyOrder(requestProto)
+        pipeline.run().waitUntilFinish()
+    }
+
+    @Test
+    fun testInvalidDeserialization() {
+        val invalidBytes = "not-a-proto".toByteArray()
+        val input: PCollection<KV<String, ByteArray>> = pipeline.apply(Create.of(KV.of("key2", invalidBytes)))
+
+        val output: PCollection<StrategyDiscoveryRequest> = input.apply(ParDo.of(deserializeStrategyDiscoveryRequestFn))
+
+        PAssert.that(output).empty() // Expect no output for invalid proto
+        pipeline.run().waitUntilFinish()
+    }
+
+    @Test
+    fun testNullValue() {
+        val input: PCollection<KV<String, ByteArray?>> = pipeline.apply(Create.of(KV.of<String, ByteArray?>("key3", null)))
+
+        @Suppress("UNCHECKED_CAST")
+        val castedInput = input as PCollection<KV<String, ByteArray>>
+
+        val output: PCollection<StrategyDiscoveryRequest> = castedInput.apply(ParDo.of(deserializeStrategyDiscoveryRequestFn))
+
+        PAssert.that(output).empty()
+        pipeline.run().waitUntilFinish()
+    }
+}

--- a/src/test/java/com/verlumen/tradestream/discovery/DeserializeStrategyDiscoveryRequestFnTest.kt
+++ b/src/test/java/com/verlumen/tradestream/discovery/DeserializeStrategyDiscoveryRequestFnTest.kt
@@ -1,6 +1,7 @@
 package com.verlumen.tradestream.discovery
 
 import com.google.inject.Guice
+import com.google.inject.Inject
 import com.google.inject.testing.fieldbinder.BoundFieldModule
 import com.google.protobuf.util.Timestamps
 import com.verlumen.tradestream.strategies.StrategyType
@@ -16,7 +17,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.mockito.MockitoAnnotations
-import javax.inject.Inject
 
 @RunWith(JUnit4::class)
 class DeserializeStrategyDiscoveryRequestFnTest {

--- a/src/test/java/com/verlumen/tradestream/discovery/DeserializeStrategyDiscoveryRequestFnTest.kt
+++ b/src/test/java/com/verlumen/tradestream/discovery/DeserializeStrategyDiscoveryRequestFnTest.kt
@@ -30,7 +30,6 @@ class DeserializeStrategyDiscoveryRequestFnTest {
     @Before
     fun setUp() {
         MockitoAnnotations.openMocks(this)
-        
         // Create Guice injector with BoundFieldModule to inject the test fixture
         val injector = Guice.createInjector(BoundFieldModule.of(this))
         injector.injectMembers(this)

--- a/src/test/java/com/verlumen/tradestream/discovery/DeserializeStrategyDiscoveryRequestFnTest.kt
+++ b/src/test/java/com/verlumen/tradestream/discovery/DeserializeStrategyDiscoveryRequestFnTest.kt
@@ -3,8 +3,6 @@ package com.verlumen.tradestream.discovery
 import com.google.inject.Guice
 import com.google.inject.testing.fieldbinder.BoundFieldModule
 import com.google.protobuf.util.Timestamps
-import com.verlumen.tradestream.discovery.proto.Discovery.GAConfig
-import com.verlumen.tradestream.discovery.proto.Discovery.StrategyDiscoveryRequest
 import com.verlumen.tradestream.strategies.StrategyType
 import org.apache.beam.sdk.testing.PAssert
 import org.apache.beam.sdk.testing.TestPipeline


### PR DESCRIPTION
This change introduces a new Apache Beam `DoFn` transform that deserializes Kafka message payloads into `StrategyDiscoveryRequest` protobufs:

* **New component:** `DeserializeStrategyDiscoveryRequestFn`, a `DoFn<KV<String, ByteArray>, StrategyDiscoveryRequest>`, which:

  * Parses incoming Kafka message values.
  * Emits successfully parsed protos.
  * Logs and discards malformed inputs.
* **Unit tests:** `DeserializeStrategyDiscoveryRequestFnTest` added with full coverage of:

  * Valid deserialization.
  * Handling of malformed data.
  * Null value edge cases.
* **Build updates:**

  * Added `kt_jvm_library` and `kt_jvm_test` rules for the new class and test.
  * Updated dependencies to support Beam, protobuf, and logging.

This introduces new reusable deserialization logic for `StrategyDiscoveryRequest` in the data pipeline and is version-significant as it adds new public functionality.

(MINOR)
