### PR TITLE
Add Beam transform to extract individual strategies from discovery results (MINOR)

### DIFF
--- a/src/main/java/com/verlumen/tradestream/discovery/BUILD
+++ b/src/main/java/com/verlumen/tradestream/discovery/BUILD
@@ -35,6 +35,15 @@ kt_jvm_library(
 )
 
 kt_jvm_library(
+    name = "extract_discovered_strategies_fn",
+    srcs = ["ExtractDiscoveredStrategiesFn.kt"],
+    deps = [
+        "//protos:discovery_java_proto",
+        "//third_party/java:beam_sdks_java_core",
+    ],
+)
+
+kt_jvm_library(
     name = "discovery_module",
     srcs = ["DiscoveryModule.kt"],
     visibility = [

--- a/src/main/java/com/verlumen/tradestream/discovery/ExtractDiscoveredStrategiesFn.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/ExtractDiscoveredStrategiesFn.kt
@@ -13,7 +13,6 @@ import org.apache.beam.sdk.transforms.DoFn
  * of each discovered strategy.
  */
 class ExtractDiscoveredStrategiesFn : DoFn<StrategyDiscoveryResult, DiscoveredStrategy>() {
-    
     @ProcessElement
     fun processElement(context: ProcessContext) {
         val result = context.element()

--- a/src/main/java/com/verlumen/tradestream/discovery/ExtractDiscoveredStrategiesFn.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/ExtractDiscoveredStrategiesFn.kt
@@ -8,7 +8,7 @@ import org.apache.beam.sdk.transforms.DoFn
  * 
  * Input: StrategyDiscoveryResult (containing multiple strategies)
  * Output: Individual DiscoveredStrategy objects
- * 
+ *
  * This flattens the result structure to enable individual processing
  * of each discovered strategy.
  */

--- a/src/main/java/com/verlumen/tradestream/discovery/ExtractDiscoveredStrategiesFn.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/ExtractDiscoveredStrategiesFn.kt
@@ -1,7 +1,5 @@
 package com.verlumen.tradestream.discovery
 
-import com.verlumen.tradestream.discovery.proto.Discovery.DiscoveredStrategy
-import com.verlumen.tradestream.discovery.proto.Discovery.StrategyDiscoveryResult
 import org.apache.beam.sdk.transforms.DoFn
 
 /**

--- a/src/main/java/com/verlumen/tradestream/discovery/ExtractDiscoveredStrategiesFn.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/ExtractDiscoveredStrategiesFn.kt
@@ -1,0 +1,26 @@
+package com.verlumen.tradestream.discovery
+
+import com.verlumen.tradestream.discovery.proto.Discovery.DiscoveredStrategy
+import com.verlumen.tradestream.discovery.proto.Discovery.StrategyDiscoveryResult
+import org.apache.beam.sdk.transforms.DoFn
+
+/**
+ * Apache Beam transform that extracts individual discovered strategies from
+ * StrategyDiscoveryResult objects.
+ * 
+ * Input: StrategyDiscoveryResult (containing multiple strategies)
+ * Output: Individual DiscoveredStrategy objects
+ * 
+ * This flattens the result structure to enable individual processing
+ * of each discovered strategy.
+ */
+class ExtractDiscoveredStrategiesFn : DoFn<StrategyDiscoveryResult, DiscoveredStrategy>() {
+    
+    @ProcessElement
+    fun processElement(context: ProcessContext) {
+        val result = context.element()
+        result?.topStrategiesList?.forEach { strategy ->
+            context.output(strategy)
+        }
+    }
+}

--- a/src/main/java/com/verlumen/tradestream/discovery/ExtractDiscoveredStrategiesFn.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/ExtractDiscoveredStrategiesFn.kt
@@ -5,7 +5,7 @@ import org.apache.beam.sdk.transforms.DoFn
 /**
  * Apache Beam transform that extracts individual discovered strategies from
  * StrategyDiscoveryResult objects.
- * 
+ *
  * Input: StrategyDiscoveryResult (containing multiple strategies)
  * Output: Individual DiscoveredStrategy objects
  *

--- a/src/test/java/com/verlumen/tradestream/discovery/BUILD
+++ b/src/test/java/com/verlumen/tradestream/discovery/BUILD
@@ -22,6 +22,27 @@ kt_jvm_test(
     ],
 )
 
+kt_jvm_test(
+    name = "ExtractDiscoveredStrategiesFnTest",
+    srcs = ["ExtractDiscoveredStrategiesFnTest.kt"],
+    runtime_deps = [
+        "//third_party/java:beam_runners_direct_java",
+        "//third_party/java:hamcrest",
+    ],
+    deps = [
+        "//protos:discovery_java_proto",
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/discovery:extract_discovered_strategies_fn",
+        "//third_party/java:beam_sdks_java_core",
+        "//third_party/java:beam_sdks_java_test_utils",
+        "//third_party/java:guice",
+        "//third_party/java:guice_testlib",
+        "//third_party/java:junit",
+        "//third_party/java:mockito_core",
+        "//third_party/java:protobuf_java",
+    ],
+)
+
 java_test(
     name = "FitnessFunctionFactoryImplTest",
     srcs = ["FitnessFunctionFactoryImplTest.java"],

--- a/src/test/java/com/verlumen/tradestream/discovery/ExtractDiscoveredStrategiesFnTest.kt
+++ b/src/test/java/com/verlumen/tradestream/discovery/ExtractDiscoveredStrategiesFnTest.kt
@@ -1,0 +1,126 @@
+package com.verlumen.tradestream.discovery
+
+import com.google.inject.Guice
+import com.google.inject.Inject
+import com.google.inject.testing.fieldbinder.BoundFieldModule
+import com.google.protobuf.Any
+import com.google.protobuf.util.Timestamps
+import com.verlumen.tradestream.strategies.SmaRsiParameters
+import com.verlumen.tradestream.strategies.Strategy
+import com.verlumen.tradestream.strategies.StrategyType
+import org.apache.beam.sdk.testing.PAssert
+import org.apache.beam.sdk.testing.TestPipeline
+import org.apache.beam.sdk.transforms.Create
+import org.apache.beam.sdk.transforms.ParDo
+import org.apache.beam.sdk.values.PCollection
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.MockitoAnnotations
+
+@RunWith(JUnit4::class)
+class ExtractDiscoveredStrategiesFnTest {
+    @get:Rule
+    val pipeline: TestPipeline = TestPipeline.create()
+
+    // The class under test - will be injected by Guice
+    @Inject
+    lateinit var extractDiscoveredStrategiesFn: ExtractDiscoveredStrategiesFn
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        
+        // Create Guice injector with BoundFieldModule to inject the test fixture
+        val injector = Guice.createInjector(BoundFieldModule.of(this))
+        injector.injectMembers(this)
+    }
+
+    @Test
+    fun testExtractMultipleStrategies() {
+        val params1 = SmaRsiParameters.newBuilder().setRsiPeriod(10).build()
+        val strategy1 =
+            DiscoveredStrategy
+                .newBuilder()
+                .setStrategy(Strategy.newBuilder().setType(StrategyType.SMA_RSI).setParameters(Any.pack(params1)))
+                .setScore(0.5)
+                .setSymbol("BTC/USD")
+                .setStartTime(Timestamps.fromMillis(1000L))
+                .setEndTime(Timestamps.fromMillis(2000L))
+                .build()
+
+        val params2 = SmaRsiParameters.newBuilder().setRsiPeriod(20).build()
+        val strategy2 =
+            DiscoveredStrategy
+                .newBuilder()
+                .setStrategy(Strategy.newBuilder().setType(StrategyType.EMA_MACD).setParameters(Any.pack(params2)))
+                .setScore(0.8)
+                .setSymbol("ETH/USD")
+                .setStartTime(Timestamps.fromMillis(3000L))
+                .setEndTime(Timestamps.fromMillis(4000L))
+                .build()
+
+        val discoveryResult =
+            StrategyDiscoveryResult
+                .newBuilder()
+                .addTopStrategies(strategy1)
+                .addTopStrategies(strategy2)
+                .build()
+
+        val input: PCollection<StrategyDiscoveryResult> = pipeline.apply(Create.of(discoveryResult))
+        val output: PCollection<DiscoveredStrategy> = input.apply(ParDo.of(extractDiscoveredStrategiesFn))
+
+        PAssert.that(output).containsInAnyOrder(strategy1, strategy2)
+        pipeline.run().waitUntilFinish()
+    }
+
+    @Test
+    fun testExtractSingleStrategy() {
+        val params1 = SmaRsiParameters.newBuilder().setRsiPeriod(10).build()
+        val strategy1 =
+            DiscoveredStrategy
+                .newBuilder()
+                .setStrategy(Strategy.newBuilder().setType(StrategyType.SMA_RSI).setParameters(Any.pack(params1)))
+                .setScore(0.5)
+                .build()
+
+        val discoveryResult =
+            StrategyDiscoveryResult
+                .newBuilder()
+                .addTopStrategies(strategy1)
+                .build()
+
+        val input: PCollection<StrategyDiscoveryResult> = pipeline.apply(Create.of(discoveryResult))
+        val output: PCollection<DiscoveredStrategy> = input.apply(ParDo.of(extractDiscoveredStrategiesFn))
+
+        PAssert.that(output).containsInAnyOrder(strategy1)
+        pipeline.run().waitUntilFinish()
+    }
+
+    @Test
+    fun testExtractEmptyResult() {
+        val discoveryResult = StrategyDiscoveryResult.newBuilder().build() // No strategies
+
+        val input: PCollection<StrategyDiscoveryResult> = pipeline.apply(Create.of(discoveryResult))
+        val output: PCollection<DiscoveredStrategy> = input.apply(ParDo.of(extractDiscoveredStrategiesFn))
+
+        PAssert.that(output).empty()
+        pipeline.run().waitUntilFinish()
+    }
+
+    @Test
+    fun testExtractFromNullElementInPCollection() {
+        val nullResult: StrategyDiscoveryResult? = null
+        val input: PCollection<StrategyDiscoveryResult?> = pipeline.apply(Create.of(nullResult))
+
+        @Suppress("UNCHECKED_CAST")
+        val castedInput = input as PCollection<StrategyDiscoveryResult>
+
+        val output: PCollection<DiscoveredStrategy> = castedInput.apply(ParDo.of(extractDiscoveredStrategiesFn))
+
+        PAssert.that(output).empty()
+        pipeline.run().waitUntilFinish()
+    }
+}

--- a/src/test/java/com/verlumen/tradestream/discovery/ExtractDiscoveredStrategiesFnTest.kt
+++ b/src/test/java/com/verlumen/tradestream/discovery/ExtractDiscoveredStrategiesFnTest.kt
@@ -32,7 +32,6 @@ class ExtractDiscoveredStrategiesFnTest {
     @Before
     fun setUp() {
         MockitoAnnotations.openMocks(this)
-        
         // Create Guice injector with BoundFieldModule to inject the test fixture
         val injector = Guice.createInjector(BoundFieldModule.of(this))
         injector.injectMembers(this)


### PR DESCRIPTION
### Summary

This change introduces a new Apache Beam `DoFn`, `ExtractDiscoveredStrategiesFn`, which extracts individual `DiscoveredStrategy` elements from a `StrategyDiscoveryResult`. This flattening enables more granular downstream processing of discovered strategies.

### Changes

* **New transform:** `ExtractDiscoveredStrategiesFn` outputs each strategy from the `topStrategiesList` field.
* **Test coverage:** Added `ExtractDiscoveredStrategiesFnTest` with cases covering:

  * Multiple strategies
  * Single strategy
  * Empty discovery result
  * Null input handling
* **BUILD targets:** Updated `BUILD` files to include the new library and corresponding test.

### Rationale

This transformation facilitates finer-grained pipeline stages and simplifies processing of strategy results. Since this is new functionality usable by downstream consumers, it's classified as a **(MINOR)** version change.
