### PR TITLE
Refactor FitnessFunction type to alias java.util.function.Function and remove unused jenetics dependency

### DIFF
--- a/src/main/java/com/verlumen/tradestream/discovery/BUILD
+++ b/src/main/java/com/verlumen/tradestream/discovery/BUILD
@@ -75,6 +75,7 @@ kt_jvm_library(
         "//src/test/java/com/verlumen/tradestream/discovery:__pkg__",
     ],
     deps = [
+        ":fitness_function",
         "//protos:backtesting_java_proto",
         "//protos:marketdata_java_proto",
         "//protos:strategies_java_proto",

--- a/src/main/java/com/verlumen/tradestream/discovery/BUILD
+++ b/src/main/java/com/verlumen/tradestream/discovery/BUILD
@@ -79,7 +79,6 @@ kt_jvm_library(
         "//protos:backtesting_java_proto",
         "//protos:marketdata_java_proto",
         "//protos:strategies_java_proto",
-        "//third_party/java:jenetics",
     ],
 )
 
@@ -96,7 +95,6 @@ kt_jvm_library(
         "//src/main/java/com/verlumen/tradestream/backtesting:backtest_request_factory",
         "//src/main/java/com/verlumen/tradestream/backtesting:backtest_runner",
         "//third_party/java:guice",
-        "//third_party/java:jenetics",
         "//third_party/java:protobuf_java",
     ],
 )

--- a/src/main/java/com/verlumen/tradestream/discovery/BUILD
+++ b/src/main/java/com/verlumen/tradestream/discovery/BUILD
@@ -87,6 +87,7 @@ kt_jvm_library(
     name = "fitness_function_factory_impl",
     srcs = ["FitnessFunctionFactoryImpl.kt"],
     deps = [
+        ":fitness_function",
         ":fitness_function_factory",
         ":genotype_converter",
         "//protos:backtesting_java_proto",

--- a/src/main/java/com/verlumen/tradestream/discovery/FitnessFunction.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/FitnessFunction.kt
@@ -1,6 +1,7 @@
 package com.verlumen.tradestream.discovery
 
 import io.jenetics.Genotype
+import java.util.function.Function
 
 /**
  * Type alias for fitness functions used in genetic algorithms.

--- a/src/main/java/com/verlumen/tradestream/discovery/FitnessFunction.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/FitnessFunction.kt
@@ -6,4 +6,4 @@ import io.jenetics.Genotype
  * Type alias for fitness functions used in genetic algorithms.
  * Takes a Genotype and returns a Double fitness score.
  */
-typealias FitnessFunction = (Genotype<*>) -> Double
+typealias FitnessFunction = Function<Genotype<*>, Double>

--- a/src/main/java/com/verlumen/tradestream/discovery/FitnessFunctionFactory.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/FitnessFunctionFactory.kt
@@ -4,7 +4,6 @@ import com.verlumen.tradestream.marketdata.Candle
 import com.verlumen.tradestream.strategies.StrategyType
 import io.jenetics.Genotype
 import java.io.Serializable
-import java.util.function.Function
 
 /** Defines the contract for calculating fitness scores using backtesting. */
 interface FitnessFunctionFactory : Serializable {
@@ -18,5 +17,5 @@ interface FitnessFunctionFactory : Serializable {
     fun create(
         strategyType: StrategyType,
         candles: List<Candle>,
-    ): Function<Genotype<*>, Double>
+    ): FitnessFunction
 }

--- a/src/main/java/com/verlumen/tradestream/discovery/FitnessFunctionFactory.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/FitnessFunctionFactory.kt
@@ -2,7 +2,6 @@ package com.verlumen.tradestream.discovery
 
 import com.verlumen.tradestream.marketdata.Candle
 import com.verlumen.tradestream.strategies.StrategyType
-import io.jenetics.Genotype
 import java.io.Serializable
 
 /** Defines the contract for calculating fitness scores using backtesting. */

--- a/src/main/java/com/verlumen/tradestream/discovery/FitnessFunctionFactoryImpl.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/FitnessFunctionFactoryImpl.kt
@@ -9,7 +9,6 @@ import com.verlumen.tradestream.backtesting.BacktestRunner
 import com.verlumen.tradestream.marketdata.Candle
 import com.verlumen.tradestream.strategies.Strategy
 import com.verlumen.tradestream.strategies.StrategyType
-import io.jenetics.Genotype
 import java.util.function.Function
 
 /**

--- a/src/main/java/com/verlumen/tradestream/discovery/FitnessFunctionFactoryImpl.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/FitnessFunctionFactoryImpl.kt
@@ -26,7 +26,7 @@ class FitnessFunctionFactoryImpl
         override fun create(
             strategyType: StrategyType,
             candles: List<Candle>,
-        ): Function<Genotype<*>, Double> =
+        ): FitnessFunction =
             Function { genotype ->
                 try {
                     val params: Any = genotypeConverter.convertToParameters(genotype, strategyType)


### PR DESCRIPTION
This patch refactors the `FitnessFunction` type alias to use `java.util.function.Function` instead of a Kotlin lambda. This change ensures better Java interoperability and clarifies the functional contract of fitness functions within the genetic algorithm context.

### Summary of Changes:

* Updated `FitnessFunction` to alias `Function<Genotype<*>, Double>`.
* Refactored `FitnessFunctionFactory` and `FitnessFunctionFactoryImpl` to use the new alias.
* Removed unnecessary direct imports of `Genotype` and `Function` where no longer required.
* Cleaned up `BUILD` targets by:

  * Removing the unused `jenetics` dependency.
  * Adding explicit dependency on the local `:fitness_function` target where needed.

These updates help improve modularity, remove unused dependencies, and maintain clearer functional interfaces between Java and Kotlin components.
