### PR TITLE
Add PostgreSQL JDBC Driver Dependency to Bazel Build

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -100,6 +100,7 @@ maven.install(
         "org.knowm.xchange:xchange-core:5.2.0",
         "org.knowm.xchange:xchange-stream-core:5.2.0",
         "org.knowm.xchange:xchange-stream-coinbasepro:5.2.0",
+        "org.postgresql:postgresql:42.7.6",
         "org.ta4j:ta4j-core:0.17",
 
         # Test Dependencies

--- a/third_party/java/BUILD
+++ b/third_party/java/BUILD
@@ -272,6 +272,14 @@ java_library(
 )
 
 java_library(
+    name = "postgresql",
+    visiblity = ["//visiblity:public"],
+    exports = [
+        "@tradestream_maven//:org_postgresql_postgresql"
+    ],
+)
+
+java_library(
     name = "protobuf_java",
     visibility = ["//visibility:public"],
     exports = [

--- a/third_party/java/BUILD
+++ b/third_party/java/BUILD
@@ -273,9 +273,9 @@ java_library(
 
 java_library(
     name = "postgresql",
-    visiblity = ["//visiblity:public"],
+    visiblity = ["//visibility:public"],
     exports = [
-        "@tradestream_maven//:org_postgresql_postgresql"
+        "@tradestream_maven//:org_postgresql_postgresql",
     ],
 )
 

--- a/third_party/java/BUILD
+++ b/third_party/java/BUILD
@@ -273,7 +273,7 @@ java_library(
 
 java_library(
     name = "postgresql",
-    visiblity = ["//visibility:public"],
+    visibility = ["//visibility:public"],
     exports = [
         "@tradestream_maven//:org_postgresql_postgresql",
     ],


### PR DESCRIPTION
This change introduces the PostgreSQL JDBC driver (`org.postgresql:postgresql:42.7.6`) as a new Maven dependency in the Bazel `MODULE.bazel` file. A corresponding `java_library` target named `postgresql` has been added to `third_party/java/BUILD`, exposing the driver via `@tradestream_maven`.

This addition enables Bazel targets to depend on PostgreSQL for database connectivity and integration.

No functional changes to application logic were made—this is a dependency-only update.
