### PR TITLE
Add PostgresModule integration to PipelineModule and BUILD dependencies

### DIFF
--- a/src/main/java/com/verlumen/tradestream/pipeline/BUILD
+++ b/src/main/java/com/verlumen/tradestream/pipeline/BUILD
@@ -99,6 +99,7 @@ java_library(
         "//src/main/java/com/verlumen/tradestream/marketdata:fill_forward_candles",
         "//src/main/java/com/verlumen/tradestream/marketdata:market_data_module",
         "//src/main/java/com/verlumen/tradestream/marketdata:trade_to_candle",
+        "//src/main/java/com/verlumen/tradestream/postgres:postgres_module",
         "//src/main/java/com/verlumen/tradestream/signals:signals_module",
         "//src/main/java/com/verlumen/tradestream/strategies:strategies_module",
         "//src/main/java/com/verlumen/tradestream/ta4j:ta4j_module",

--- a/src/main/java/com/verlumen/tradestream/pipeline/PipelineModule.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/PipelineModule.java
@@ -13,6 +13,7 @@ import com.verlumen.tradestream.kafka.KafkaModule;
 import com.verlumen.tradestream.marketdata.FillForwardCandles;
 import com.verlumen.tradestream.marketdata.MarketDataModule;
 import com.verlumen.tradestream.marketdata.TradeToCandle;
+import com.verlumen.tradestream.postgres.PostgresModule;
 import com.verlumen.tradestream.signals.SignalsModule;
 import com.verlumen.tradestream.strategies.StrategiesModule;
 import com.verlumen.tradestream.ta4j.Ta4jModule;
@@ -85,6 +86,7 @@ abstract class PipelineModule extends AbstractModule {
     install(InstrumentsModule.create(runMode(), coinMarketCapApiKey(), topCurrencyCount()));
     install(KafkaModule.create(bootstrapServers()));
     install(MarketDataModule.create(exchangeName(), candleDuration(), runMode(), tiingoApiKey()));
+    install(new PostgresModule());
     install(SignalsModule.create(signalTopic()));
     install(new StrategiesModule());
     install(Ta4jModule.create());

--- a/src/main/java/com/verlumen/tradestream/postgres/BUILD
+++ b/src/main/java/com/verlumen/tradestream/postgres/BUILD
@@ -20,6 +20,10 @@ kt_jvm_library(
 kt_jvm_library(
     name = "postgres_module",
     srcs = ["PostgresModule.kt"],
+    visibility = [
+        "//src/main/java/com/verlumen/tradestream/discovery:__pkg__",
+        "//src/main/java/com/verlumen/tradestream/pipeline:__pkg__",
+    ],
     deps = [
         ":postgre_sql_data_source_factory",
         "//src/main/java/com/verlumen/tradestream/sql:data_source_factory",

--- a/src/main/java/com/verlumen/tradestream/postgres/BUILD
+++ b/src/main/java/com/verlumen/tradestream/postgres/BUILD
@@ -5,6 +5,7 @@ kt_jvm_library(
     srcs = ["PostgreSQLDataSourceFactory.kt"],
     visibility = [
         "//src/main/java/com/verlumen/tradestream/discovery:__pkg__",
+        "//src/main/java/com/verlumen/tradestream/pipeline:__pkg__",
         "//src/test/java/com/verlumen/tradestream/discovery:__pkg__",
         "//src/test/java/com/verlumen/tradestream/postgres:__pkg__",
     ],


### PR DESCRIPTION
This change integrates the `PostgresModule` into the `PipelineModule` by:

* Adding `PostgresModule` installation in `PipelineModule.configure()`.
* Declaring `postgres_module` as a dependency in the pipeline's `BUILD` file.
* Updating the `postgres_module` and `postgre_sql_data_source_factory` visibility to include the pipeline package, allowing for direct usage.

This enables pipeline-level access to PostgreSQL-backed data sources, laying the groundwork for database-related features or persistence.

No version bump necessary—changes are limited to dependency wiring and do not introduce new functionality exposed outside the pipeline module.
