### PR TITLE
Remove unused `BoundedWindow` parameter from Beam DoFn process method

### DIFF
--- a/src/main/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFn.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFn.kt
@@ -8,7 +8,6 @@ import com.google.protobuf.util.JsonFormat
 import com.verlumen.tradestream.sql.DataSourceConfig
 import com.verlumen.tradestream.sql.DataSourceFactory
 import org.apache.beam.sdk.transforms.DoFn
-import org.apache.beam.sdk.transforms.windowing.BoundedWindow
 import org.postgresql.core.BaseConnection
 import java.io.StringReader
 import java.security.MessageDigest
@@ -89,8 +88,7 @@ class WriteDiscoveredStrategiesToPostgresFn
 
         @ProcessElement
         fun processElement(
-            @Element element: DiscoveredStrategy,
-            window: BoundedWindow,
+            @Element element: DiscoveredStrategy
         ) {
             val csvRow = convertToCsvRow(element)
             batch.offer(csvRow)

--- a/src/main/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFn.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFn.kt
@@ -87,9 +87,7 @@ class WriteDiscoveredStrategiesToPostgresFn
         }
 
         @ProcessElement
-        fun processElement(
-            @Element element: DiscoveredStrategy,
-        ) {
+        fun processElement(@Element element: DiscoveredStrategy) {
             val csvRow = convertToCsvRow(element)
             batch.offer(csvRow)
 

--- a/src/main/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFn.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFn.kt
@@ -88,7 +88,7 @@ class WriteDiscoveredStrategiesToPostgresFn
 
         @ProcessElement
         fun processElement(
-            @Element element: DiscoveredStrategy
+            @Element element: DiscoveredStrategy,
         ) {
             val csvRow = convertToCsvRow(element)
             batch.offer(csvRow)

--- a/src/main/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFn.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFn.kt
@@ -87,7 +87,9 @@ class WriteDiscoveredStrategiesToPostgresFn
         }
 
         @ProcessElement
-        fun processElement(@Element element: DiscoveredStrategy) {
+        fun processElement(
+            @Element element: DiscoveredStrategy,
+        ) {
             val csvRow = convertToCsvRow(element)
             batch.offer(csvRow)
 


### PR DESCRIPTION
This patch removes the unused `BoundedWindow` parameter from the `processElement` method in `WriteDiscoveredStrategiesToPostgresFn.kt`. The parameter was not referenced in the method body and was safely eliminated to reduce clutter and improve readability.

No behavioral changes are introduced; this is a cleanup-level update.
