### PR TITLE
Refactor PostgreSQL Write Fn to Use Single Config Object via Assisted Injection (MINOR)

### DIFF
--- a/src/main/java/com/verlumen/tradestream/discovery/BUILD
+++ b/src/main/java/com/verlumen/tradestream/discovery/BUILD
@@ -35,15 +35,6 @@ kt_jvm_library(
 )
 
 kt_jvm_library(
-    name = "extract_discovered_strategies_fn",
-    srcs = ["ExtractDiscoveredStrategiesFn.kt"],
-    deps = [
-        "//protos:discovery_java_proto",
-        "//third_party/java:beam_sdks_java_core",
-    ],
-)
-
-kt_jvm_library(
     name = "discovery_module",
     srcs = ["DiscoveryModule.kt"],
     visibility = [
@@ -63,7 +54,17 @@ kt_jvm_library(
         "//protos:discovery_java_proto",
         "//third_party/java:guava",
         "//third_party/java:guice",
+        "//third_party/java:guice_assistedinject",
         "//third_party/java:protobuf_java",
+    ],
+)
+
+kt_jvm_library(
+    name = "extract_discovered_strategies_fn",
+    srcs = ["ExtractDiscoveredStrategiesFn.kt"],
+    deps = [
+        "//protos:discovery_java_proto",
+        "//third_party/java:beam_sdks_java_core",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/discovery/BUILD
+++ b/src/main/java/com/verlumen/tradestream/discovery/BUILD
@@ -51,6 +51,7 @@ kt_jvm_library(
         ":param_config_manager",
         ":param_config_manager_impl",
         ":param_configs",
+        ":write_discovered_strategies_to_postgres_fn",
         "//protos:discovery_java_proto",
         "//third_party/java:guava",
         "//third_party/java:guice",

--- a/src/main/java/com/verlumen/tradestream/discovery/DiscoveryModule.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/DiscoveryModule.kt
@@ -3,6 +3,8 @@ package com.verlumen.tradestream.discovery
 import com.google.common.collect.ImmutableList
 import com.google.inject.AbstractModule
 import com.google.inject.TypeLiteral
+import com.google.inject.assistedinject.FactoryModuleBuilder
+
 
 class DiscoveryModule : AbstractModule() {
     override fun configure() {
@@ -11,5 +13,12 @@ class DiscoveryModule : AbstractModule() {
         bind(GenotypeConverter::class.java).to(GenotypeConverterImpl::class.java)
         bind(ParamConfigManager::class.java).to(ParamConfigManagerImpl::class.java)
         bind(object : TypeLiteral<ImmutableList<ParamConfig>>() {}).toInstance(ParamConfigs.ALL_CONFIGS)
+
+        install(
+            FactoryModuleBuilder()
+                .implement(
+                    WriteDiscoveredStrategiesToPostgresFn::class.java,
+                    WriteDiscoveredStrategiesToPostgresFn::class.java)
+                .build(WriteDiscoveredStrategiesToPostgresFnFactory::class.java))
     }
 }

--- a/src/main/java/com/verlumen/tradestream/discovery/DiscoveryModule.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/DiscoveryModule.kt
@@ -5,7 +5,6 @@ import com.google.inject.AbstractModule
 import com.google.inject.TypeLiteral
 import com.google.inject.assistedinject.FactoryModuleBuilder
 
-
 class DiscoveryModule : AbstractModule() {
     override fun configure() {
         bind(FitnessFunctionFactory::class.java).to(FitnessFunctionFactoryImpl::class.java)
@@ -18,7 +17,8 @@ class DiscoveryModule : AbstractModule() {
             FactoryModuleBuilder()
                 .implement(
                     WriteDiscoveredStrategiesToPostgresFn::class.java,
-                    WriteDiscoveredStrategiesToPostgresFn::class.java)
-                .build(WriteDiscoveredStrategiesToPostgresFnFactory::class.java))
+                    WriteDiscoveredStrategiesToPostgresFn::class.java,
+                ).build(WriteDiscoveredStrategiesToPostgresFnFactory::class.java),
+        )
     }
 }

--- a/src/main/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFn.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFn.kt
@@ -61,7 +61,7 @@ class WriteDiscoveredStrategiesToPostgresFn
                 }
 
             logger.atInfo().log(
-                "PostgreSQL connection established for bulk writes to ${config.databaseName}@${config.serverName}",
+                "PostgreSQL connection established for bulk writes to ${dataSourceConfig.databaseName}@${dataSourceConfig.serverName}",
             )
         }
 

--- a/src/main/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFn.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFn.kt
@@ -33,15 +33,7 @@ class WriteDiscoveredStrategiesToPostgresFn
     @Inject
     constructor(
         private val dataSourceFactory: DataSourceFactory,
-        @Assisted private val serverName: String,
-        @Assisted private val databaseName: String,
-        @Assisted private val username: String,
-        @Assisted private val password: String,
-        @Assisted private val portNumber: Int?,
-        @Assisted private val applicationName: String?,
-        @Assisted private val connectTimeout: Int?,
-        @Assisted private val socketTimeout: Int?,
-        @Assisted private val readOnly: Boolean?,
+        @Assisted private val dataSourceConfig: DataSourceConfig,
     ) : DoFn<DiscoveredStrategy, Void>() {
         companion object {
             private val logger = FluentLogger.forEnclosingClass()
@@ -60,22 +52,8 @@ class WriteDiscoveredStrategiesToPostgresFn
 
         @Setup
         fun setup() {
-            // Create DataSource configuration from assisted-injected parameters
-            val config =
-                DataSourceConfig(
-                    serverName = serverName,
-                    databaseName = databaseName,
-                    username = username,
-                    password = password,
-                    portNumber = portNumber,
-                    applicationName = applicationName,
-                    connectTimeout = connectTimeout,
-                    socketTimeout = socketTimeout,
-                    readOnly = readOnly,
-                )
-
             // Create DataSource using the factory
-            dataSource = dataSourceFactory.create(config)
+            dataSource = dataSourceFactory.create(dataSourceConfig)
             // Establish connection
             connection =
                 dataSource!!.connection.apply {
@@ -268,15 +246,5 @@ class WriteDiscoveredStrategiesToPostgresFn
  * with runtime-provided database configuration parameters.
  */
 interface WriteDiscoveredStrategiesToPostgresFnFactory {
-    fun create(
-        serverName: String,
-        databaseName: String,
-        username: String,
-        password: String,
-        portNumber: Int? = null,
-        applicationName: String? = null,
-        connectTimeout: Int? = null,
-        socketTimeout: Int? = null,
-        readOnly: Boolean? = null,
-    ): WriteDiscoveredStrategiesToPostgresFn
+    fun create(        dataSourceConfig: DataSourceConfig    ): WriteDiscoveredStrategiesToPostgresFn
 }

--- a/src/main/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFn.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFn.kt
@@ -246,5 +246,5 @@ class WriteDiscoveredStrategiesToPostgresFn
  * with runtime-provided database configuration parameters.
  */
 interface WriteDiscoveredStrategiesToPostgresFnFactory {
-    fun create(        dataSourceConfig: DataSourceConfig    ): WriteDiscoveredStrategiesToPostgresFn
+    fun create(dataSourceConfig: DataSourceConfig): WriteDiscoveredStrategiesToPostgresFn
 }

--- a/src/test/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFnTest.kt
+++ b/src/test/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFnTest.kt
@@ -1,7 +1,6 @@
 package com.verlumen.tradestream.discovery
 
 import com.google.inject.Guice
-import com.google.inject.Inject
 import com.google.inject.testing.fieldbinder.Bind
 import com.google.inject.testing.fieldbinder.BoundFieldModule
 import com.google.protobuf.Any

--- a/src/test/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFnTest.kt
+++ b/src/test/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFnTest.kt
@@ -1,6 +1,7 @@
 package com.verlumen.tradestream.discovery
 
 import com.google.inject.Guice
+import com.google.inject.Inject
 import com.google.inject.testing.fieldbinder.Bind
 import com.google.inject.testing.fieldbinder.BoundFieldModule
 import com.google.protobuf.Any
@@ -82,15 +83,18 @@ class WriteDiscoveredStrategiesToPostgresFnTest {
         writeDiscoveredStrategiesToPostgresFn =
             WriteDiscoveredStrategiesToPostgresFn(
                 dataSourceFactory = mockDataSourceFactory,
-                serverName = testServerName,
-                databaseName = testDatabaseName,
-                username = testUsername,
-                password = testPassword,
-                portNumber = testPortNumber,
-                applicationName = testApplicationName,
-                connectTimeout = testConnectTimeout,
-                socketTimeout = testSocketTimeout,
-                readOnly = testReadOnly,
+                dataSourceConfig =
+                    DataSourceConfig(
+                        serverName = testServerName,
+                        databaseName = testDatabaseName,
+                        username = testUsername,
+                        password = testPassword,
+                        portNumber = testPortNumber,
+                        applicationName = testApplicationName,
+                        connectTimeout = testConnectTimeout,
+                        socketTimeout = testSocketTimeout,
+                        readOnly = testReadOnly,
+                    ),
             )
     }
 


### PR DESCRIPTION
### Summary

This PR refactors the `WriteDiscoveredStrategiesToPostgresFn` class and its factory to use a single `DataSourceConfig` object for configuration, replacing multiple individual parameters. This change simplifies the constructor signature, reduces boilerplate, and enhances maintainability.

### Changes

* **Consolidated constructor parameters** in `WriteDiscoveredStrategiesToPostgresFn` to a single `@Assisted DataSourceConfig`.
* **Updated `WriteDiscoveredStrategiesToPostgresFnFactory`** interface to match the new constructor signature.
* **Modified `DiscoveryModule`** to use `FactoryModuleBuilder` for assisted injection of `WriteDiscoveredStrategiesToPostgresFn`.
* **Adjusted test setup** in `WriteDiscoveredStrategiesToPostgresFnTest` to pass a `DataSourceConfig` object.
* Reordered and regrouped Bazel build targets for better organization.

### Rationale

This (MINOR) change streamlines dependency injection by encapsulating database connection parameters, improving clarity and reducing the risk of misconfigured injections. It also aligns with best practices for assisted injection and object construction.

No breaking changes to existing behavior are introduced.
