### PR TITLE
Add Strategy Discovery Pipeline Flink Deployment and CI/CD Integration (MINOR)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,9 @@ jobs:
             --from-literal=INFLUXDB_TOKEN="$(openssl rand -hex 32)" \
             --from-literal=INFLUXDB_ORG="tradestream-org" \
             --namespace=tradestream-namespace --dry-run=client -o yaml | kubectl apply -f -
+          kubectl create secret generic tradestream-postgres-secret \
+            --from-literal=password=fakepass \
+            --namespace=tradestream-namespace --dry-run=client -o yaml | kubectl apply -f -
 
       - uses: bazel-contrib/setup-bazel@0.14.0
         with:
@@ -87,6 +90,12 @@ jobs:
             --repository localhost:5000/strategy-discovery-request-factory \
             --tag "latest"
 
+          # Build and push strategy-discovery-pipeline image
+          bazel run //src/main/java/com/verlumen/tradestream/discovery:push_image \
+            -- \
+            --repository localhost:5000/strategy-discovery-pipeline \
+            --tag "latest"
+
           # Load images into minikube
           docker pull localhost:5000/tradestream-data-pipeline:latest
           docker tag localhost:5000/tradestream-data-pipeline:latest tradestream-data-pipeline:latest
@@ -100,6 +109,9 @@ jobs:
           docker pull localhost:5000/strategy-discovery-request-factory:latest
           docker tag localhost:5000/strategy-discovery-request-factory:latest strategy-discovery-request-factory:latest
           minikube image load strategy-discovery-request-factory:latest
+          docker pull localhost:5000/strategy-discovery-pipeline:latest
+          docker tag localhost:5000/strategy-discovery-pipeline:latest strategy-discovery-pipeline:latest
+          minikube image load strategy-discovery-pipeline:latest
 
       - name: Install Cert Manager
         run: |
@@ -123,6 +135,8 @@ jobs:
             --set topCryptoUpdaterCronjob.image.tag=latest \
             --set strategyDiscoveryRequestFactory.image.repository=strategy-discovery-request-factory \
             --set strategyDiscoveryRequestFactory.image.tag=latest \
+            --set strategyDiscoveryPipeline.image.repository=strategy-discovery-pipeline \
+            --set strategyDiscoveryPipeline.image.tag=latest \
             --set pipeline.runMode=dry \
             --set redis.enabled=true \
             --set topCryptoUpdaterCronjob.enabled=true \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,10 +12,12 @@ jobs:
       CANDLE_INGESTOR_REPO: tradestreamhq/candle-ingestor
       TOP_CRYPTO_UPDATER_REPO: tradestreamhq/top-crypto-updater
       STRATEGY_DISCOVERY_REQUEST_FACTORY_REPO: tradestreamhq/strategy-discovery-request-factory
+      STRATEGY_DISCOVERY_PIPELINE_REPO: tradestreamhq/strategy-discovery-pipeline
       PIPELINE_SECTION_KEY: pipeline
       CANDLE_INGESTOR_SECTION_KEY: candleIngestor
       TOP_CRYPTO_UPDATER_SECTION_KEY: topCryptoUpdaterCronjob
       STRATEGY_DISCOVERY_REQUEST_FACTORY_SECTION_KEY: strategyDiscoveryRequestFactory
+      STRATEGY_DISCOVERY_PIPELINE_SECTION_KEY: strategyDiscoveryPipeline
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -82,6 +84,11 @@ jobs:
           bazel run //services/strategy_discovery_request_factory:push_strategy_discovery_request_factory_image \
             -- \
             --tag ${{ steps.version.outputs.version_tag }}
+      - name: Push the Strategy Discovery Pipeline image
+        run: |
+          bazel run //src/main/java/com/verlumen/tradestream/discovery:push_image \
+            -- \
+            --tag ${{ steps.version.outputs.version_tag }}
 
       - name: Install yq
         run: |
@@ -99,7 +106,9 @@ jobs:
             .["${{ env.TOP_CRYPTO_UPDATER_SECTION_KEY }}"].image.repository = "${{ env.TOP_CRYPTO_UPDATER_REPO }}" |
             .["${{ env.TOP_CRYPTO_UPDATER_SECTION_KEY }}"].image.tag = "${{ steps.version.outputs.version_tag }}" |
             .["${{ env.STRATEGY_DISCOVERY_REQUEST_FACTORY_SECTION_KEY }}"].image.repository = "${{ env.STRATEGY_DISCOVERY_REQUEST_FACTORY_REPO }}" |
-            .["${{ env.STRATEGY_DISCOVERY_REQUEST_FACTORY_SECTION_KEY }}"].image.tag = "${{ steps.version.outputs.version_tag }}"
+            .["${{ env.STRATEGY_DISCOVERY_REQUEST_FACTORY_SECTION_KEY }}"].image.tag = "${{ steps.version.outputs.version_tag }}" |
+            .["${{ env.STRATEGY_DISCOVERY_PIPELINE_SECTION_KEY }}"].image.repository = "${{ env.STRATEGY_DISCOVERY_PIPELINE_REPO }}" |
+            .["${{ env.STRATEGY_DISCOVERY_PIPELINE_SECTION_KEY }}"].image.tag = "${{ steps.version.outputs.version_tag }}"
           ' charts/tradestream/values.yaml > charts/tradestream/values.yaml.tmp
           mv charts/tradestream/values.yaml.tmp charts/tradestream/values.yaml
 

--- a/charts/tradestream/templates/strategy-discovery-pipeline.yaml
+++ b/charts/tradestream/templates/strategy-discovery-pipeline.yaml
@@ -1,0 +1,74 @@
+{{- if .Values.strategyDiscoveryPipeline.enabled }}
+apiVersion: flink.apache.org/v1beta1
+kind: FlinkDeployment
+metadata:
+  name: {{ include "tradestream.fullname" . }}-strategy-discovery-pipeline
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "tradestream.name" . }}
+    component: strategy-discovery-pipeline
+    release: {{ .Release.Name }}
+spec:
+  image: {{ .Values.strategyDiscoveryPipeline.image.repository }}:{{ .Values.strategyDiscoveryPipeline.image.tag }}
+  imagePullPolicy: {{ default "IfNotPresent" .Values.strategyDiscoveryPipeline.image.pullPolicy }}
+  flinkVersion: {{ .Values.strategyDiscoveryPipeline.version }}
+  flinkConfiguration:
+    {{- toYaml .Values.strategyDiscoveryPipeline.configuration | nindent 4 }}
+    io.tmp.dirs: "/opt/flink/writable-tmp"
+  serviceAccount: {{ .Values.strategyDiscoveryPipeline.serviceAccount }}
+  jobManager:
+    resource:
+      memory: {{ .Values.strategyDiscoveryPipeline.jobManager.memory }}
+      cpu: {{ .Values.strategyDiscoveryPipeline.jobManager.cpu }}
+  taskManager:
+    resource:
+      memory: {{ .Values.strategyDiscoveryPipeline.taskManager.memory }}
+      cpu: {{ .Values.strategyDiscoveryPipeline.taskManager.cpu }}
+  job:
+    entryClass: {{ .Values.strategyDiscoveryPipeline.job.entryClass }}
+    jarURI: {{ .Values.strategyDiscoveryPipeline.job.jarURI }}
+    args:
+      - "--bootstrapServers={{ include "tradestream.fullname" . }}-kafka.{{ .Release.Namespace }}.svc.cluster.local:9092"
+      - "--runner=FlinkRunner"
+      - "--isStreaming=true"
+      - "--dbServerName={{ .Values.strategyDiscoveryPipeline.database.host }}"
+      - "--dbDatabaseName={{ .Values.strategyDiscoveryPipeline.database.database }}"
+      - "--dbPortNumber={{ .Values.strategyDiscoveryPipeline.database.port }}"
+      # InfluxDB args - for candle fetcher
+      - "--influxDbUrl=http://{{ include "tradestream.fullname" . }}-influxdb:80"
+      - "--influxDbOrg={{ .Values.influxdb.adminUser.organization }}"
+      - "--influxDbBucket={{ .Values.influxdb.adminUser.bucket }}"
+    parallelism: {{ .Values.strategyDiscoveryPipeline.job.parallelism }}
+    upgradeMode: {{ .Values.strategyDiscoveryPipeline.job.upgradeMode }}
+  podTemplate:
+    metadata:
+      labels:
+        custom-pod-template: "true"
+    spec:
+      volumes:
+        - name: flink-writable-volume
+          emptyDir: {}
+      containers:
+        - name: flink-main-container
+          env:
+            - name: TMPDIR
+              value: /opt/flink/writable-tmp
+            # Secret for Postgres credentials
+            - name: DATABASE_USERNAME
+              value: {{ .Values.strategyDiscoveryPipeline.database.username | quote }}
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.strategyDiscoveryPipeline.database.passwordSecret.name }}
+                  key: {{ .Values.strategyDiscoveryPipeline.database.passwordSecret.key }}
+            # Secret for InfluxDB token
+            - name: INFLUXDB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.influxdb.adminUser.existingSecret | default (printf "%s-influxdb-admin-secret" (include "tradestream.fullname" .)) }}
+                  key: admin-token
+          volumeMounts:
+            - name: flink-writable-volume
+              mountPath: /opt/flink/writable-tmp
+              readOnly: false
+{{- end }}

--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -80,6 +80,47 @@ pipeline:
     jarURI: local:///src/main/java/com/verlumen/tradestream/pipeline/app_deploy.jar
     parallelism: 1
     upgradeMode: stateless
+strategyDiscoveryPipeline:
+  enabled: false
+  runMode: wet
+  image:
+    repository: tradestreamhq/strategy-discovery-pipeline
+    tag: v2.13.1-develop
+    pullPolicy: IfNotPresent
+  version: v1_18
+  configuration:
+    env.java.opts.jobmanager: "-Dio.jenetics.util.defaultRandomGenerator=Random"
+    env.java.opts.taskmanager: "-Dio.jenetics.util.defaultRandomGenerator=Random"
+    taskmanager.numberOfTaskSlots: "1"
+    execution.checkpointing.interval: "300000"
+    execution.checkpointing.mode: "EXACTLY_ONCE"
+    execution.checkpointing.timeout: "1800000"
+    execution.checkpointing.externalized-checkpoint-retention: "RETAIN_ON_CANCELLATION"
+    state.backend: "rocksdb"
+    state.backend.incremental: "true"
+  serviceAccount: flink
+  jobManager:
+    memory: 2048m
+    cpu: 1
+  taskManager:
+    memory: 2048m
+    cpu: 1
+  job:
+    entryClass: com.verlumen.tradestream.discovery.StrategyDiscoveryPipelineRunner
+    jarURI: local:///src/main/java/com/verlumen/tradestream/discovery/app_deploy.jar
+    parallelism: 1
+    upgradeMode: stateless
+  # Database configuration for this specific pipeline.
+  # These are examples, you must configure your PostgreSQL instance and secrets.
+  database:
+    host: "your-postgres-host" # e.g., my-tradestream-postgresql.tradestream-namespace.svc.cluster.local
+    port: 5432
+    database: "tradestream"
+    username: "postgres"
+    # Recommend creating a secret with the password.
+    passwordSecret:
+      name: "tradestream-postgres-secret"
+      key: "password"
 candleIngestor:
   enabled: true
   schedule: "*/1 * * * *" # Run every 1 minute
@@ -91,7 +132,7 @@ candleIngestor:
   image:
     repository: "tradestreamhq/candle-ingestor"
     pullPolicy: IfNotPresent
-    tag: "v2.13.2-develop"
+    tag: "v2.13.1-develop"
   config:
     # CCXT Exchange Configuration
     exchanges:
@@ -146,7 +187,7 @@ topCryptoUpdaterCronjob:
   image:
     repository: "tradestreamhq/top-crypto-updater"
     pullPolicy: IfNotPresent
-    tag: "v2.13.2-develop"
+    tag: "v2.13.1-develop"
   concurrencyPolicy: "Forbid" # Prevents multiple jobs from running concurrently
   failedJobsHistoryLimit: 1
   successfulJobsHistoryLimit: 3
@@ -170,7 +211,7 @@ strategyDiscoveryRequestFactory:
   image:
     repository: "tradestreamhq/strategy-discovery-request-factory"
     pullPolicy: IfNotPresent
-    tag: "v2.13.2-develop"
+    tag: "v2.13.1-develop"
   concurrencyPolicy: "Forbid" # Prevents multiple jobs from running concurrently
   failedJobsHistoryLimit: 1
   successfulJobsHistoryLimit: 3

--- a/src/main/java/com/verlumen/tradestream/discovery/BUILD
+++ b/src/main/java/com/verlumen/tradestream/discovery/BUILD
@@ -1,5 +1,9 @@
 load("@rules_java//java:defs.bzl", "java_library")
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+load("@aspect_bazel_lib//lib:tar.bzl", "tar")
+load("@container_structure_test//:defs.bzl", "container_structure_test")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index", "oci_push")
+load("//platforms:transition.bzl", "multi_arch")
 
 package(default_visibility = [
     "//src/test/java/com/verlumen/tradestream/discovery:__pkg__",
@@ -9,6 +13,46 @@ java_binary(
     name = "app",
     main_class = "com.verlumen.tradestream.discovery.StrategyDiscoveryPipelineRunner",
     runtime_deps = [":strategy_discovery_pipeline_runner"],
+)
+
+tar(
+    name = "layer",
+    srcs = [":app_deploy.jar"],
+)
+
+oci_image(
+    name = "image",
+    base = "@flink_java17",
+    entrypoint = [
+        "java",
+        "-jar",
+        "/src/main/java/com/verlumen/tradestream/discovery/app_deploy.jar",
+    ],
+    tars = [
+        ":layer",
+    ],
+)
+
+multi_arch(
+    name = "images",
+    image = ":image",
+    platforms = [
+        "//platforms:linux_arm64",
+        "//platforms:linux_amd64",
+    ],
+)
+
+oci_image_index(
+    name = "index",
+    images = [
+        ":images",
+    ],
+)
+
+oci_push(
+    name = "push_image",
+    image = ":index",
+    repository = "tradestreamhq/strategy-discovery-pipeline",
 )
 
 java_library(
@@ -325,4 +369,11 @@ kt_jvm_library(
         "//third_party/java:protobuf_java",
         "//third_party/java:protobuf_java_util",
     ],
+)
+
+container_structure_test(
+    name = "container_test",
+    configs = ["container-structure-test.yaml"],
+    image = ":image",
+    tags = ["requires-docker"],
 )

--- a/src/main/java/com/verlumen/tradestream/discovery/StrategyDiscoveryPipelineRunner.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/StrategyDiscoveryPipelineRunner.kt
@@ -21,15 +21,13 @@ class StrategyDiscoveryPipelineRunner {
         private const val DATABASE_USERNAME_ENV_VAR = "DATABASE_USERNAME"
         private const val DATABASE_PASSWORD_ENV_VAR = "DATABASE_PASSWORD"
 
-        private fun getDatabaseUsername(options: StrategyDiscoveryPipelineOptions): String? {
-            return options.databaseUsername.takeIf { !it.isNullOrEmpty() }
+        private fun getDatabaseUsername(options: StrategyDiscoveryPipelineOptions): String? =
+            options.databaseUsername.takeIf { !it.isNullOrEmpty() }
                 ?: System.getenv(DATABASE_USERNAME_ENV_VAR)
-        }
 
-        private fun getDatabasePassword(options: StrategyDiscoveryPipelineOptions): String? {
-            return options.databasePassword.takeIf { !it.isNullOrEmpty() }
+        private fun getDatabasePassword(options: StrategyDiscoveryPipelineOptions): String? =
+            options.databasePassword.takeIf { !it.isNullOrEmpty() }
                 ?: System.getenv(DATABASE_PASSWORD_ENV_VAR)
-        }
 
         /**
          * Entry-point. Builds the injector, gets a factory instance,

--- a/src/main/java/com/verlumen/tradestream/discovery/StrategyDiscoveryPipelineRunner.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/StrategyDiscoveryPipelineRunner.kt
@@ -18,6 +18,19 @@ import org.apache.beam.sdk.options.PipelineOptionsFactory
  */
 class StrategyDiscoveryPipelineRunner {
     companion object {
+        private const val DATABASE_USERNAME_ENV_VAR = "DATABASE_USERNAME"
+        private const val DATABASE_PASSWORD_ENV_VAR = "DATABASE_PASSWORD"
+
+        private fun getDatabaseUsername(options: StrategyDiscoveryPipelineOptions): String? {
+            return options.databaseUsername.takeIf { !it.isNullOrEmpty() }
+                ?: System.getenv(DATABASE_USERNAME_ENV_VAR)
+        }
+
+        private fun getDatabasePassword(options: StrategyDiscoveryPipelineOptions): String? {
+            return options.databasePassword.takeIf { !it.isNullOrEmpty() }
+                ?: System.getenv(DATABASE_PASSWORD_ENV_VAR)
+        }
+
         /**
          * Entry-point. Builds the injector, gets a factory instance,
          * creates a fully-configured [StrategyDiscoveryPipeline], and executes it.
@@ -29,6 +42,10 @@ class StrategyDiscoveryPipelineRunner {
                     .fromArgs(*args)
                     .withValidation()
                     .`as`(StrategyDiscoveryPipelineOptions::class.java)
+
+            // Override from environment variables if not set in args
+            options.databaseUsername = getDatabaseUsername(options)
+            options.databasePassword = getDatabasePassword(options)
 
             val injector =
                 Guice.createInjector(

--- a/src/main/java/com/verlumen/tradestream/discovery/StrategyDiscoveryPipelineRunner.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/StrategyDiscoveryPipelineRunner.kt
@@ -35,6 +35,7 @@ class StrategyDiscoveryPipelineRunner {
          */
         @JvmStatic
         fun main(args: Array<String>) {
+            PipelineOptionsFactory.register(StrategyDiscoveryPipelineOptions::class.java)
             val options =
                 PipelineOptionsFactory
                     .fromArgs(*args)

--- a/src/main/java/com/verlumen/tradestream/discovery/container-structure-test.yaml
+++ b/src/main/java/com/verlumen/tradestream/discovery/container-structure-test.yaml
@@ -5,7 +5,7 @@ commandTests:
     args:
       - "-jar"
       - "/src/main/java/com/verlumen/tradestream/discovery/app_deploy.jar"
-      - "--help"
+      - "--help=StrategyDiscoveryPipelineOptions"
     expectedOutput:
       - "kafkaBootstrapServers"
       - "databaseUsername"

--- a/src/main/java/com/verlumen/tradestream/discovery/container-structure-test.yaml
+++ b/src/main/java/com/verlumen/tradestream/discovery/container-structure-test.yaml
@@ -1,0 +1,11 @@
+schemaVersion: "2.0.0"
+commandTests:
+  - name: "Strategy Discovery Pipeline Help"
+    command: "java"
+    args:
+      - "-jar"
+      - "/src/main/java/com/verlumen/tradestream/discovery/app_deploy.jar"
+      - "--help"
+    expectedOutput:
+      - "kafkaBootstrapServers"
+      - "databaseUsername"


### PR DESCRIPTION
This pull request introduces the Strategy Discovery Pipeline as a new Flink deployment in the Tradestream platform. It includes full CI/CD integration, Helm chart configuration, and Bazel-based image building and publishing.

### Summary of Changes:

* **Helm/Chart Updates:**

  * Added `strategyDiscoveryPipeline` configuration block to `values.yaml` with job, image, and DB parameters.
  * Created `strategy-discovery-pipeline.yaml` template for FlinkDeployment resource.
  * Hooked up Helm values for image tag/repo, Flink configs, and secrets.

* **CI Pipeline (`ci.yaml`):**

  * Added Docker image build and push for `strategy-discovery-pipeline`.
  * Included minikube loading and Helm chart injection for the new component.
  * Created Kubernetes secret for Postgres password used by the pipeline.

* **Release Pipeline (`release.yaml`):**

  * Integrated image build and push step for the pipeline.
  * Updated values.yaml via `yq` to inject versioned image reference.

* **Bazel Build Configuration:**

  * Defined multi-platform OCI image build and push rules for the pipeline JAR.
  * Added container structure test configuration and integration.

* **Runtime Logic:**

  * Modified `StrategyDiscoveryPipelineRunner` to support environment variable overrides for database credentials, improving deploy-time flexibility and security.

This change introduces a new functional component and associated infrastructure, marking a feature-level update.

**Tag: (MINOR)**
