### PR TITLE
Refactor MarketDataModule and Expose TradeSource for DI Integration (MINOR)

### DIFF
--- a/src/main/java/com/verlumen/tradestream/marketdata/DryRunTradeSource.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/DryRunTradeSource.java
@@ -7,7 +7,7 @@ import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 
 @AutoValue
-abstract class DryRunTradeSource extends TradeSource {
+public abstract class DryRunTradeSource extends TradeSource {
   static DryRunTradeSource create(ImmutableList<Trade> trades) {
     return new AutoValue_DryRunTradeSource(trades);
   }

--- a/src/main/java/com/verlumen/tradestream/marketdata/DryRunTradeSource.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/DryRunTradeSource.java
@@ -8,7 +8,7 @@ import org.apache.beam.sdk.values.PCollection;
 
 @AutoValue
 public abstract class DryRunTradeSource extends TradeSource {
-  static DryRunTradeSource create(ImmutableList<Trade> trades) {
+  public static DryRunTradeSource create(ImmutableList<Trade> trades) {
     return new AutoValue_DryRunTradeSource(trades);
   }
 

--- a/src/main/java/com/verlumen/tradestream/marketdata/MarketDataModule.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/MarketDataModule.java
@@ -1,32 +1,13 @@
 package com.verlumen.tradestream.marketdata;
 
-import static com.google.protobuf.util.Timestamps.fromMillis;
-
-import com.google.auto.value.AutoValue;
-import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
-import com.google.inject.Provider;
-import com.google.inject.Provides;
-import com.google.inject.Singleton;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
-import com.verlumen.tradestream.execution.RunMode;
-import org.joda.time.Duration;
 
-@AutoValue
-public abstract class MarketDataModule extends AbstractModule {
+public class MarketDataModule extends AbstractModule {
 
-  public static MarketDataModule create(
-      String exchangeName, Duration granularity, RunMode runMode, String tiingoApiKey) {
-    return new AutoValue_MarketDataModule(exchangeName, granularity, runMode, tiingoApiKey);
+  public static MarketDataModule create() {
+    return new MarketDataModule();
   }
-
-  abstract String exchangeName();
-
-  abstract Duration granularity();
-
-  abstract RunMode runMode();
-
-  abstract String tiingoApiKey();
 
   @Override
   protected void configure() {
@@ -49,40 +30,5 @@ public abstract class MarketDataModule extends AbstractModule {
         new FactoryModuleBuilder()
             .implement(TradeToCandle.class, TradeToCandle.class)
             .build(TradeToCandle.Factory.class));
-  }
-
-  @Provides
-  @Singleton
-  CandleSource provideCandleSource(
-      Provider<TradeBackedCandleSource> tradeBackedCandleSource,
-      TiingoCryptoCandleSource.Factory tiingoCryptoCandleSourceFactory) {
-    switch (runMode()) {
-      case DRY:
-        return tradeBackedCandleSource.get();
-      case WET:
-        return tiingoCryptoCandleSourceFactory.create(granularity(), tiingoApiKey());
-      default:
-        throw new UnsupportedOperationException("Unsupported RunMode: " + runMode());
-    }
-  }
-
-  @Provides
-  @Singleton
-  TradeSource provideTradeSource() {
-    switch (runMode()) {
-      case DRY:
-        return DryRunTradeSource.create(
-            ImmutableList.of(
-                Trade.newBuilder()
-                    .setExchange(exchangeName())
-                    .setCurrencyPair("DRY/RUN")
-                    .setTradeId("trade-123")
-                    .setTimestamp(fromMillis(1259999L))
-                    .setPrice(50000.0)
-                    .setVolume(0.1)
-                    .build()));
-      default:
-        throw new UnsupportedOperationException("Unsupported RunMode: " + runMode());
-    }
   }
 }

--- a/src/main/java/com/verlumen/tradestream/marketdata/TradeSource.java
+++ b/src/main/java/com/verlumen/tradestream/marketdata/TradeSource.java
@@ -4,4 +4,4 @@ import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 
-abstract class TradeSource extends PTransform<PBegin, PCollection<Trade>> {}
+public abstract class TradeSource extends PTransform<PBegin, PCollection<Trade>> {}

--- a/src/main/java/com/verlumen/tradestream/pipeline/BUILD
+++ b/src/main/java/com/verlumen/tradestream/pipeline/BUILD
@@ -110,6 +110,7 @@ java_library(
         "//src/main/java/com/verlumen/tradestream/strategies:strategies_module",
         "//src/main/java/com/verlumen/tradestream/ta4j:ta4j_module",
         "//third_party/java:auto_value",
+        "//third_party/java:guava",
         "//third_party/java:guice",
         "//third_party/java:joda_time",
         "//third_party/java:protobuf_java_util",

--- a/src/main/java/com/verlumen/tradestream/pipeline/BUILD
+++ b/src/main/java/com/verlumen/tradestream/pipeline/BUILD
@@ -89,6 +89,7 @@ java_library(
     srcs = ["PipelineModule.java"],
     deps = [
         ":timing_config",
+        "//protos:marketdata_java_proto",  # Added for Trade
         "//src/main/java/com/verlumen/tradestream/backtesting:backtesting_module",
         "//src/main/java/com/verlumen/tradestream/discovery:discovery_module",
         "//src/main/java/com/verlumen/tradestream/execution:run_mode",
@@ -96,8 +97,13 @@ java_library(
         "//src/main/java/com/verlumen/tradestream/influxdb:influx_db_module",
         "//src/main/java/com/verlumen/tradestream/instruments:instruments_module",
         "//src/main/java/com/verlumen/tradestream/kafka:kafka_module",
+        "//src/main/java/com/verlumen/tradestream/marketdata:candle_source",  # Added for CandleSource
+        "//src/main/java/com/verlumen/tradestream/marketdata:dry_run_trade_source",  # Added for DryRunTradeSource
         "//src/main/java/com/verlumen/tradestream/marketdata:fill_forward_candles",
         "//src/main/java/com/verlumen/tradestream/marketdata:market_data_module",
+        "//src/main/java/com/verlumen/tradestream/marketdata:tiingo_crypto_candle_source",  # Added for TiingoCryptoCandleSource
+        "//src/main/java/com/verlumen/tradestream/marketdata:trade_backed_candle_source",  # Added for TradeBackedCandleSource
+        "//src/main/java/com/verlumen/tradestream/marketdata:trade_source",  # Added for TradeSource
         "//src/main/java/com/verlumen/tradestream/marketdata:trade_to_candle",
         "//src/main/java/com/verlumen/tradestream/postgres:postgres_module",
         "//src/main/java/com/verlumen/tradestream/signals:signals_module",

--- a/src/main/java/com/verlumen/tradestream/pipeline/PipelineModule.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/PipelineModule.java
@@ -1,8 +1,13 @@
 package com.verlumen.tradestream.pipeline;
 
+import static com.google.protobuf.util.Timestamps.fromMillis;
+
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
+import com.google.inject.Provider;
 import com.google.inject.Provides;
+import com.google.inject.Singleton;
 import com.verlumen.tradestream.backtesting.BacktestingModule;
 import com.verlumen.tradestream.discovery.DiscoveryModule;
 import com.verlumen.tradestream.execution.RunMode;
@@ -10,8 +15,14 @@ import com.verlumen.tradestream.http.HttpModule;
 import com.verlumen.tradestream.influxdb.InfluxDbModule;
 import com.verlumen.tradestream.instruments.InstrumentsModule;
 import com.verlumen.tradestream.kafka.KafkaModule;
+import com.verlumen.tradestream.marketdata.CandleSource;
+import com.verlumen.tradestream.marketdata.DryRunTradeSource;
 import com.verlumen.tradestream.marketdata.FillForwardCandles;
 import com.verlumen.tradestream.marketdata.MarketDataModule;
+import com.verlumen.tradestream.marketdata.TiingoCryptoCandleSource;
+import com.verlumen.tradestream.marketdata.Trade;
+import com.verlumen.tradestream.marketdata.TradeBackedCandleSource;
+import com.verlumen.tradestream.marketdata.TradeSource;
 import com.verlumen.tradestream.marketdata.TradeToCandle;
 import com.verlumen.tradestream.postgres.PostgresModule;
 import com.verlumen.tradestream.signals.SignalsModule;
@@ -85,11 +96,46 @@ abstract class PipelineModule extends AbstractModule {
     install(new InfluxDbModule(influxDbUrl(), influxDbToken(), influxDbOrg(), influxDbBucket()));
     install(InstrumentsModule.create(runMode(), coinMarketCapApiKey(), topCurrencyCount()));
     install(KafkaModule.create(bootstrapServers()));
-    install(MarketDataModule.create(exchangeName(), candleDuration(), runMode(), tiingoApiKey()));
+    install(MarketDataModule.create()); // No parameters needed anymore
     install(new PostgresModule());
     install(SignalsModule.create(signalTopic()));
     install(new StrategiesModule());
     install(Ta4jModule.create());
+  }
+
+  @Provides
+  @Singleton
+  CandleSource provideCandleSource(
+      Provider<TradeBackedCandleSource> tradeBackedCandleSource,
+      TiingoCryptoCandleSource.Factory tiingoCryptoCandleSourceFactory) {
+    switch (runMode()) {
+      case DRY:
+        return tradeBackedCandleSource.get();
+      case WET:
+        return tiingoCryptoCandleSourceFactory.create(candleDuration(), tiingoApiKey());
+      default:
+        throw new UnsupportedOperationException("Unsupported RunMode: " + runMode());
+    }
+  }
+
+  @Provides
+  @Singleton
+  TradeSource provideTradeSource() {
+    switch (runMode()) {
+      case DRY:
+        return DryRunTradeSource.create(
+            ImmutableList.of(
+                Trade.newBuilder()
+                    .setExchange(exchangeName())
+                    .setCurrencyPair("DRY/RUN")
+                    .setTradeId("trade-123")
+                    .setTimestamp(fromMillis(1259999L))
+                    .setPrice(50000.0)
+                    .setVolume(0.1)
+                    .build()));
+      default:
+        throw new UnsupportedOperationException("Unsupported RunMode: " + runMode());
+    }
   }
 
   @Provides


### PR DESCRIPTION
This PR introduces a refactor to improve configurability and dependency injection support for market data components, particularly around trade and candle sources.

### Summary of Changes

* **Refactored `MarketDataModule`:**

  * Removed AutoValue usage and its parameters.
  * Simplified to a parameterless instantiation (`MarketDataModule.create()`).
  * Removed `@Provides` methods for `CandleSource` and `TradeSource`.

* **Introduced DI bindings in `PipelineModule`:**

  * Added `@Provides` methods for `CandleSource` and `TradeSource` based on `RunMode`.
  * In DRY mode, creates a mock trade using `DryRunTradeSource`.

* **Modified visibility of key components:**

  * `TradeSource`, `DryRunTradeSource` are now `public` to support external instantiation.
  * Made `DryRunTradeSource.create(...)` public.

* **BUILD file updates:**

  * Added new dependencies for the now externally provided types (`DryRunTradeSource`, `CandleSource`, etc.).
  * Ensured required third-party libraries like Guava and Protobuf utilities are listed.

### Rationale

This change decouples the configuration details from `MarketDataModule`, making trade and candle source provisioning consistent with the rest of the pipeline's module pattern. It enables greater flexibility for runtime configuration and testing.

### Versioning

(MINOR): Introduces new functionality and public APIs for instantiating trade sources, expanding the supported configuration model.
