### PR TITLE
Add Bazel target for `DryRunDiscoveryRequestSource` implementation

### DIFF
--- a/src/main/java/com/verlumen/tradestream/discovery/BUILD
+++ b/src/main/java/com/verlumen/tradestream/discovery/BUILD
@@ -125,6 +125,20 @@ kt_jvm_library(
 )
 
 kt_jvm_library(
+    name = "dry_run_discovery_request_source",
+    srcs = ["DryRunDiscoveryRequestSource.kt"],
+    deps = [
+        ":deserialize_strategy_discovery_request_fn",
+        ":discovery_request_source",
+        ":strategy_discovery_pipeline_options",
+        "//protos:discovery_java_proto",
+        "//third_party/java:beam_sdks_java_core",
+        "//third_party/java:guice",
+        "//third_party/java:guice_assistedinject",
+    ],
+)
+
+kt_jvm_library(
     name = "extract_discovered_strategies_fn",
     srcs = ["ExtractDiscoveredStrategiesFn.kt"],
     deps = [


### PR DESCRIPTION
Introduced a new `kt_jvm_library` Bazel target named `dry_run_discovery_request_source` in the discovery module's build file. This target includes the `DryRunDiscoveryRequestSource.kt` source file and its associated dependencies, such as core discovery components, Guice for dependency injection, Beam SDK, and required proto definitions.

This update prepares the module for incorporating dry-run logic into the discovery request handling pipeline. No functional changes to runtime behavior are introduced in this patch.
