### PR TITLE
Add TemporaryCurrencyPairModule for transitional binding support

### DIFF
--- a/src/main/java/com/verlumen/tradestream/discovery/BUILD
+++ b/src/main/java/com/verlumen/tradestream/discovery/BUILD
@@ -413,6 +413,16 @@ kt_jvm_library(
 )
 
 kt_jvm_library(
+    name = "temporary_currency_pair_module",
+    srcs = ["TemporaryCurrencyPairModule.kt"],
+    deps = [
+        "//src/main/java/com/verlumen/tradestream/instruments:currency_pair",
+        "//third_party/java:guava",
+        "//third_party/java:guice",
+    ],
+)
+
+kt_jvm_library(
     name = "write_discovered_strategies_to_postgres_fn",
     srcs = ["WriteDiscoveredStrategiesToPostgresFn.kt"],
     deps = [

--- a/src/main/java/com/verlumen/tradestream/discovery/TemporaryCurrencyPairModule.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/TemporaryCurrencyPairModule.kt
@@ -6,9 +6,9 @@ import com.google.inject.TypeLiteral
 import com.verlumen.tradestream.instruments.CurrencyPair
 import java.util.function.Supplier
 
-internal class TemporaryCurrencyPairModule : AbstractModule() {
+// TODO: delete this module as soon as we remove all remaining dependencies
+class TemporaryCurrencyPairModule : AbstractModule() {
     override fun configure() {
-        // TODO: we need to delete this binding as soon as we remove all remaining dependencies
         bind(object : TypeLiteral<Supplier<java.util.List<CurrencyPair>>>() {}).toInstance(Supplier {
             ImmutableList.of<CurrencyPair>() as java.util.List<CurrencyPair>
         })

--- a/src/main/java/com/verlumen/tradestream/discovery/TemporaryCurrencyPairModule.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/TemporaryCurrencyPairModule.kt
@@ -9,8 +9,10 @@ import java.util.function.Supplier
 // TODO: delete this module as soon as we remove all remaining dependencies
 class TemporaryCurrencyPairModule : AbstractModule() {
     override fun configure() {
-        bind(object : TypeLiteral<Supplier<java.util.List<CurrencyPair>>>() {}).toInstance(Supplier {
-            ImmutableList.of<CurrencyPair>() as java.util.List<CurrencyPair>
-        })
+        bind(object : TypeLiteral<Supplier<java.util.List<CurrencyPair>>>() {}).toInstance(
+            Supplier {
+                ImmutableList.of<CurrencyPair>() as java.util.List<CurrencyPair>
+            },
+        )
     }
 }

--- a/src/main/java/com/verlumen/tradestream/discovery/TemporaryCurrencyPairModule.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/TemporaryCurrencyPairModule.kt
@@ -1,0 +1,16 @@
+package com.verlumen.tradestream.discovery
+
+import com.google.common.collect.ImmutableList
+import com.google.inject.AbstractModule
+import com.google.inject.TypeLiteral
+import com.verlumen.tradestream.instruments.CurrencyPair
+import java.util.function.Supplier
+
+internal class TemporaryCurrencyPairModule : AbstractModule() {
+    override fun configure() {
+        // TODO: we need to delete this binding as soon as we remove all remaining dependencies
+        bind(object : TypeLiteral<Supplier<java.util.List<CurrencyPair>>>() {}).toInstance(Supplier {
+            ImmutableList.of<CurrencyPair>() as java.util.List<CurrencyPair>
+        })
+    }
+}


### PR DESCRIPTION
This patch introduces `TemporaryCurrencyPairModule`, a Guice module that provides a temporary binding for `Supplier<List<CurrencyPair>>`. This module returns an empty `ImmutableList` and is intended to support transitional use cases where the currency pair dependency is still required.

A corresponding `kt_jvm_library` target has been added to the `BUILD` file to support module compilation.

**Note:** This module is marked for future removal once all dependent usages are eliminated.
