### PR TITLE
Add DryRunDiscoveredStrategySink for logging strategy outputs during dry runs (MINOR)

### DIFF
--- a/src/main/java/com/verlumen/tradestream/discovery/BUILD
+++ b/src/main/java/com/verlumen/tradestream/discovery/BUILD
@@ -104,6 +104,18 @@ kt_jvm_library(
 )
 
 kt_jvm_library(
+    name = "dry_run_discovered_strategy_sink",
+    srcs = ["DryRunDiscoveredStrategySink.kt"],
+    deps = [
+        ":discovered_strategy_sink",
+        "//src/main/java/com/verlumen/tradestream/sql:data_source_factory",
+        "//third_party/java:flogger",
+        "//third_party/java:guice",
+        "//third_party/java:guice_assistedinject",
+    ],
+)
+
+kt_jvm_library(
     name = "dry_run_discovery_request_source",
     srcs = ["DryRunDiscoveryRequestSource.kt"],
     deps = [

--- a/src/main/java/com/verlumen/tradestream/discovery/BUILD
+++ b/src/main/java/com/verlumen/tradestream/discovery/BUILD
@@ -52,6 +52,15 @@ kt_jvm_library(
 )
 
 kt_jvm_library(
+    name = "discovered_strategy_sink",
+    srcs = ["DiscoveredStrategySink.kt"],
+    deps = [
+        "//src/main/java/com/verlumen/tradestream/sql:data_source_factory",
+        "//third_party/java:beam_sdks_java_core",
+    ],
+)
+
+kt_jvm_library(
     name = "discovery_module",
     srcs = ["DiscoveryModule.kt"],
     visibility = [

--- a/src/main/java/com/verlumen/tradestream/discovery/DiscoveredStrategySink.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/DiscoveredStrategySink.kt
@@ -1,0 +1,18 @@
+package com.verlumen.tradestream.discovery
+
+import com.verlumen.tradestream.sql.DataSourceConfig
+import org.apache.beam.sdk.transforms.DoFn
+
+/**
+ * Abstract base class for writing discovered strategies to a sink.
+ *
+ * This abstraction allows for different sink implementations (e.g., PostgreSQL, dry-run).
+ */
+abstract class DiscoveredStrategySink : DoFn<DiscoveredStrategy, Void>()
+
+/**
+ * Factory for creating [DiscoveredStrategySink] instances.
+ */
+interface DiscoveredStrategySinkFactory {
+  fun create(dataSourceConfig: DataSourceConfig): DiscoveredStrategySink
+}

--- a/src/main/java/com/verlumen/tradestream/discovery/DryRunDiscoveredStrategySink.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/DryRunDiscoveredStrategySink.kt
@@ -9,14 +9,16 @@ import com.verlumen.tradestream.sql.DataSourceConfig
  * A dry-run implementation of [DiscoveredStrategySink] that logs the strategies
  * instead of writing them to a persistent store.
  */
-class DryRunDiscoveredStrategySink @Inject constructor(
-    @Assisted private val dataSourceConfig: DataSourceConfig,
-) : DiscoveredStrategySink() {
-    @ProcessElement
-    fun processElement(context: ProcessContext) {
-        val strategy = context.element()
-        logger.atInfo().log("Dry Run Sink: Would write strategy for symbol '%s' with score %f", strategy.symbol, strategy.score)
-    }
+class DryRunDiscoveredStrategySink
+    @Inject
+    constructor(
+        @Assisted private val dataSourceConfig: DataSourceConfig,
+    ) : DiscoveredStrategySink() {
+        @ProcessElement
+        fun processElement(context: ProcessContext) {
+            val strategy = context.element()
+            logger.atInfo().log("Dry Run Sink: Would write strategy for symbol '%s' with score %f", strategy.symbol, strategy.score)
+        }
 
         companion object {
             private val logger = FluentLogger.forEnclosingClass()

--- a/src/main/java/com/verlumen/tradestream/discovery/DryRunDiscoveredStrategySink.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/DryRunDiscoveredStrategySink.kt
@@ -1,0 +1,24 @@
+package com.verlumen.tradestream.discovery
+
+import com.google.common.flogger.FluentLogger
+import com.google.inject.Inject
+import com.google.inject.assistedinject.Assisted
+import com.verlumen.tradestream.sql.DataSourceConfig
+
+/**
+ * A dry-run implementation of [DiscoveredStrategySink] that logs the strategies
+ * instead of writing them to a persistent store.
+ */
+class DryRunDiscoveredStrategySink @Inject constructor(
+    @Assisted private val dataSourceConfig: DataSourceConfig,
+) : DiscoveredStrategySink() {
+    @ProcessElement
+    fun processElement(context: ProcessContext) {
+        val strategy = context.element()
+        logger.atInfo().log("Dry Run Sink: Would write strategy for symbol '%s' with score %f", strategy.symbol, strategy.score)
+    }
+
+    companion object {
+        private val logger = FluentLogger.forEnclosingClass()
+    }
+}

--- a/src/main/java/com/verlumen/tradestream/discovery/DryRunDiscoveredStrategySink.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/DryRunDiscoveredStrategySink.kt
@@ -21,4 +21,3 @@ class DryRunDiscoveredStrategySink @Inject constructor(
     companion object {
         private val logger = FluentLogger.forEnclosingClass()
     }
-}

--- a/src/main/java/com/verlumen/tradestream/discovery/DryRunDiscoveredStrategySink.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/DryRunDiscoveredStrategySink.kt
@@ -18,6 +18,7 @@ class DryRunDiscoveredStrategySink @Inject constructor(
         logger.atInfo().log("Dry Run Sink: Would write strategy for symbol '%s' with score %f", strategy.symbol, strategy.score)
     }
 
-    companion object {
-        private val logger = FluentLogger.forEnclosingClass()
+        companion object {
+            private val logger = FluentLogger.forEnclosingClass()
+        }
     }


### PR DESCRIPTION
This change introduces a new `DryRunDiscoveredStrategySink` class, which provides a dry-run implementation of `DiscoveredStrategySink`. Instead of persisting discovered strategies, it logs their symbol and score using Flogger. This is useful for testing and validation without affecting the persistent store.

The corresponding Bazel target `dry_run_discovered_strategy_sink` has also been added to the `BUILD` file, including all necessary dependencies.

This change introduces new functionality without altering existing behavior, and is therefore marked as (MINOR).
