### PR TITLE
Refactor Strategy Sink to Use Abstract Interface and Add Dry-Run Implementation (MINOR)

### DIFF
--- a/src/main/java/com/verlumen/tradestream/discovery/BUILD
+++ b/src/main/java/com/verlumen/tradestream/discovery/BUILD
@@ -68,7 +68,9 @@ kt_jvm_library(
         "//src/main/java/com/verlumen/tradestream/pipeline:__pkg__",
     ],
     deps = [
+        ":discovered_strategy_sink",
         ":discovery_request_source",
+        ":dry_run_discovered_strategy_sink",
         ":dry_run_discovery_request_source",
         ":fitness_function_factory",
         ":fitness_function_factory_impl",
@@ -392,11 +394,11 @@ kt_jvm_library(
         "StrategyDiscoveryPipeline.kt",
     ],
     deps = [
+        ":discovered_strategy_sink",
         ":discovery_request_source",
         ":extract_discovered_strategies_fn",
         ":run_ga_discovery_fn",
         ":strategy_discovery_pipeline_options",
-        ":write_discovered_strategies_to_postgres_fn",
         "//protos:strategies_java_proto",
         "//src/main/java/com/verlumen/tradestream/sql:data_source_factory",
         "//third_party/java:beam_sdks_java_core",
@@ -451,6 +453,7 @@ kt_jvm_library(
     name = "write_discovered_strategies_to_postgres_fn",
     srcs = ["WriteDiscoveredStrategiesToPostgresFn.kt"],
     deps = [
+        ":discovered_strategy_sink",
         "//protos:discovery_java_proto",
         "//protos:strategies_java_proto",
         "//src/main/java/com/verlumen/tradestream/marketdata:candle_fetcher",

--- a/src/main/java/com/verlumen/tradestream/discovery/BUILD
+++ b/src/main/java/com/verlumen/tradestream/discovery/BUILD
@@ -104,6 +104,18 @@ kt_jvm_library(
 )
 
 kt_jvm_library(
+    name = "dry_run_discovered_strategy_sink",
+    srcs = ["DryRunDiscoveredStrategySink.kt"],
+    deps = [
+        ":discovered_strategy_sink",
+        "//src/main/java/com/verlumen/tradestream/sql:data_source_factory",
+        "//third_party/java:flogger",
+        "//third_party/java:guice",
+        "//third_party/java:guice_assistedinject",
+    ],
+)
+
+kt_jvm_library(
     name = "dry_run_discovery_request_source",
     srcs = ["DryRunDiscoveryRequestSource.kt"],
     deps = [

--- a/src/main/java/com/verlumen/tradestream/discovery/BUILD
+++ b/src/main/java/com/verlumen/tradestream/discovery/BUILD
@@ -52,6 +52,15 @@ kt_jvm_library(
 )
 
 kt_jvm_library(
+    name = "discovered_strategy_sink",
+    srcs = ["DiscoveredStrategySink.kt"],
+    deps = [
+        "//src/main/java/com/verlumen/tradestream/sql:data_source_factory",
+        "//third_party/java:beam_sdks_java_core",
+    ],
+)
+
+kt_jvm_library(
     name = "discovery_module",
     srcs = ["DiscoveryModule.kt"],
     visibility = [

--- a/src/main/java/com/verlumen/tradestream/discovery/DiscoveredStrategySink.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/DiscoveredStrategySink.kt
@@ -1,0 +1,18 @@
+package com.verlumen.tradestream.discovery
+
+import com.verlumen.tradestream.sql.DataSourceConfig
+import org.apache.beam.sdk.transforms.DoFn
+
+/**
+ * Abstract base class for writing discovered strategies to a sink.
+ *
+ * This abstraction allows for different sink implementations (e.g., PostgreSQL, dry-run).
+ */
+abstract class DiscoveredStrategySink : DoFn<DiscoveredStrategy, Void>()
+
+/**
+ * Factory for creating [DiscoveredStrategySink] instances.
+ */
+interface DiscoveredStrategySinkFactory {
+  fun create(dataSourceConfig: DataSourceConfig): DiscoveredStrategySink
+}

--- a/src/main/java/com/verlumen/tradestream/discovery/DiscoveryModule.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/DiscoveryModule.kt
@@ -18,14 +18,6 @@ internal class BaseModule : AbstractModule() {
                 .implement(RunGADiscoveryFn::class.java, RunGADiscoveryFn::class.java)
                 .build(RunGADiscoveryFnFactory::class.java),
         )
-
-        install(
-            FactoryModuleBuilder()
-                .implement(
-                    WriteDiscoveredStrategiesToPostgresFn::class.java,
-                    WriteDiscoveredStrategiesToPostgresFn::class.java,
-                ).build(WriteDiscoveredStrategiesToPostgresFnFactory::class.java),
-        )
     }
 }
 
@@ -39,6 +31,13 @@ class DiscoveryModule : AbstractModule() {
                     KafkaDiscoveryRequestSource::class.java,
                 ).build(DiscoveryRequestSourceFactory::class.java),
         )
+        install(
+            FactoryModuleBuilder()
+                .implement(
+                    DiscoveredStrategySink::class.java,
+                    WriteDiscoveredStrategiesToPostgresFn::class.java,
+                ).build(DiscoveredStrategySinkFactory::class.java),
+        )
     }
 }
 
@@ -51,6 +50,13 @@ class DryRunDiscoveryModule : AbstractModule() {
                     DiscoveryRequestSource::class.java,
                     DryRunDiscoveryRequestSource::class.java,
                 ).build(DiscoveryRequestSourceFactory::class.java),
+        )
+        install(
+            FactoryModuleBuilder()
+                .implement(
+                    DiscoveredStrategySink::class.java,
+                    DryRunDiscoveredStrategySink::class.java,
+                ).build(DiscoveredStrategySinkFactory::class.java),
         )
     }
 }

--- a/src/main/java/com/verlumen/tradestream/discovery/DryRunDiscoveredStrategySink.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/DryRunDiscoveredStrategySink.kt
@@ -9,14 +9,16 @@ import com.verlumen.tradestream.sql.DataSourceConfig
  * A dry-run implementation of [DiscoveredStrategySink] that logs the strategies
  * instead of writing them to a persistent store.
  */
-class DryRunDiscoveredStrategySink @Inject constructor(
-    @Assisted private val dataSourceConfig: DataSourceConfig,
-) : DiscoveredStrategySink() {
-    @ProcessElement
-    fun processElement(context: ProcessContext) {
-        val strategy = context.element()
-        logger.atInfo().log("Dry Run Sink: Would write strategy for symbol '%s' with score %f", strategy.symbol, strategy.score)
-    }
+class DryRunDiscoveredStrategySink
+    @Inject
+    constructor(
+        @Assisted private val dataSourceConfig: DataSourceConfig,
+    ) : DiscoveredStrategySink() {
+        @ProcessElement
+        fun processElement(context: ProcessContext) {
+            val strategy = context.element()
+            logger.atInfo().log("Dry Run Sink: Would write strategy for symbol '%s' with score %f", strategy.symbol, strategy.score)
+        }
 
         companion object {
             private val logger = FluentLogger.forEnclosingClass()

--- a/src/main/java/com/verlumen/tradestream/discovery/DryRunDiscoveredStrategySink.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/DryRunDiscoveredStrategySink.kt
@@ -1,0 +1,24 @@
+package com.verlumen.tradestream.discovery
+
+import com.google.common.flogger.FluentLogger
+import com.google.inject.Inject
+import com.google.inject.assistedinject.Assisted
+import com.verlumen.tradestream.sql.DataSourceConfig
+
+/**
+ * A dry-run implementation of [DiscoveredStrategySink] that logs the strategies
+ * instead of writing them to a persistent store.
+ */
+class DryRunDiscoveredStrategySink @Inject constructor(
+    @Assisted private val dataSourceConfig: DataSourceConfig,
+) : DiscoveredStrategySink() {
+    @ProcessElement
+    fun processElement(context: ProcessContext) {
+        val strategy = context.element()
+        logger.atInfo().log("Dry Run Sink: Would write strategy for symbol '%s' with score %f", strategy.symbol, strategy.score)
+    }
+
+    companion object {
+        private val logger = FluentLogger.forEnclosingClass()
+    }
+}

--- a/src/main/java/com/verlumen/tradestream/discovery/DryRunDiscoveredStrategySink.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/DryRunDiscoveredStrategySink.kt
@@ -21,4 +21,3 @@ class DryRunDiscoveredStrategySink @Inject constructor(
     companion object {
         private val logger = FluentLogger.forEnclosingClass()
     }
-}

--- a/src/main/java/com/verlumen/tradestream/discovery/DryRunDiscoveredStrategySink.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/DryRunDiscoveredStrategySink.kt
@@ -18,6 +18,7 @@ class DryRunDiscoveredStrategySink @Inject constructor(
         logger.atInfo().log("Dry Run Sink: Would write strategy for symbol '%s' with score %f", strategy.symbol, strategy.score)
     }
 
-    companion object {
-        private val logger = FluentLogger.forEnclosingClass()
+        companion object {
+            private val logger = FluentLogger.forEnclosingClass()
+        }
     }

--- a/src/main/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFn.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFn.kt
@@ -38,7 +38,7 @@ class WriteDiscoveredStrategiesToPostgresFn
             private val logger = FluentLogger.forEnclosingClass()
             private const val BATCH_SIZE = 100
             private const val MAX_RETRIES = 3
-    }
+        }
 
         @Transient
         private var dataSource: DataSource? = null

--- a/src/main/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFn.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFn.kt
@@ -8,7 +8,6 @@ import com.google.protobuf.util.JsonFormat
 import com.verlumen.tradestream.sql.BulkCopierFactory
 import com.verlumen.tradestream.sql.DataSourceConfig
 import com.verlumen.tradestream.sql.DataSourceFactory
-import org.apache.beam.sdk.transforms.DoFn
 import java.io.StringReader
 import java.security.MessageDigest
 import java.sql.Connection
@@ -34,12 +33,12 @@ class WriteDiscoveredStrategiesToPostgresFn
         private val bulkCopierFactory: BulkCopierFactory,
         private val dataSourceFactory: DataSourceFactory,
         @Assisted private val dataSourceConfig: DataSourceConfig,
-    ) : DoFn<DiscoveredStrategy, Void>() {
-        companion object {
+    ) : DiscoveredStrategySink() {
+    companion object {
             private val logger = FluentLogger.forEnclosingClass()
             private const val BATCH_SIZE = 100
             private const val MAX_RETRIES = 3
-        }
+    }
 
         @Transient
         private var dataSource: DataSource? = null
@@ -154,7 +153,6 @@ class WriteDiscoveredStrategiesToPostgresFn
                     discovery_end_time TIMESTAMP
                 ) ON COMMIT DROP
                 """.trimIndent()
-
             conn.prepareStatement(createTempTableSql).use { it.execute() }
 
             // Bulk insert into temp table using COPY
@@ -184,7 +182,6 @@ class WriteDiscoveredStrategiesToPostgresFn
                     current_score = EXCLUDED.current_score,
                     last_evaluated_at = NOW()
                 """.trimIndent()
-
             conn.prepareStatement(upsertSql).use { it.execute() }
         }
 
@@ -239,11 +236,3 @@ class WriteDiscoveredStrategiesToPostgresFn
             return digest.joinToString("") { "%02x".format(it) }
         }
     }
-
-/**
- * Factory interface for creating WriteDiscoveredStrategiesToPostgresFn instances
- * with runtime-provided database configuration parameters.
- */
-interface WriteDiscoveredStrategiesToPostgresFnFactory {
-    fun create(dataSourceConfig: DataSourceConfig): WriteDiscoveredStrategiesToPostgresFn
-}

--- a/src/main/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFn.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFn.kt
@@ -34,7 +34,7 @@ class WriteDiscoveredStrategiesToPostgresFn
         private val dataSourceFactory: DataSourceFactory,
         @Assisted private val dataSourceConfig: DataSourceConfig,
     ) : DiscoveredStrategySink() {
-    companion object {
+        companion object {
             private val logger = FluentLogger.forEnclosingClass()
             private const val BATCH_SIZE = 100
             private const val MAX_RETRIES = 3

--- a/src/test/java/com/verlumen/tradestream/discovery/BUILD
+++ b/src/test/java/com/verlumen/tradestream/discovery/BUILD
@@ -188,7 +188,6 @@ kt_jvm_test(
         "//src/main/java/com/verlumen/tradestream/backtesting:backtest_request_factory",
         "//src/main/java/com/verlumen/tradestream/backtesting:backtest_runner",
         "//src/main/java/com/verlumen/tradestream/discovery:deserialize_strategy_discovery_request_fn",
-        "//src/main/java/com/verlumen/tradestream/discovery:extract_discovered_strategies_fn",
         "//src/main/java/com/verlumen/tradestream/discovery:discovered_strategy_sink",
         "//src/main/java/com/verlumen/tradestream/discovery:extract_discovered_strategies_fn",
         "//src/main/java/com/verlumen/tradestream/discovery:strategy_discovery_pipeline",

--- a/src/test/java/com/verlumen/tradestream/discovery/BUILD
+++ b/src/test/java/com/verlumen/tradestream/discovery/BUILD
@@ -190,6 +190,7 @@ kt_jvm_test(
         "//src/main/java/com/verlumen/tradestream/discovery:deserialize_strategy_discovery_request_fn",
         "//src/main/java/com/verlumen/tradestream/discovery:extract_discovered_strategies_fn",
         "//src/main/java/com/verlumen/tradestream/discovery:discovered_strategy_sink",
+        "//src/main/java/com/verlumen/tradestream/discovery:extract_discovered_strategies_fn",
         "//src/main/java/com/verlumen/tradestream/discovery:strategy_discovery_pipeline",
         "//src/main/java/com/verlumen/tradestream/discovery:write_discovered_strategies_to_postgres_fn",
         "//third_party/java:beam_sdks_java_core",

--- a/src/test/java/com/verlumen/tradestream/discovery/BUILD
+++ b/src/test/java/com/verlumen/tradestream/discovery/BUILD
@@ -189,6 +189,7 @@ kt_jvm_test(
         "//src/main/java/com/verlumen/tradestream/backtesting:backtest_runner",
         "//src/main/java/com/verlumen/tradestream/discovery:deserialize_strategy_discovery_request_fn",
         "//src/main/java/com/verlumen/tradestream/discovery:extract_discovered_strategies_fn",
+        "//src/main/java/com/verlumen/tradestream/discovery:discovered_strategy_sink",
         "//src/main/java/com/verlumen/tradestream/discovery:strategy_discovery_pipeline",
         "//src/main/java/com/verlumen/tradestream/discovery:write_discovered_strategies_to_postgres_fn",
         "//third_party/java:beam_sdks_java_core",

--- a/src/test/java/com/verlumen/tradestream/discovery/StrategyDiscoveryPipelineTest.kt
+++ b/src/test/java/com/verlumen/tradestream/discovery/StrategyDiscoveryPipelineTest.kt
@@ -43,14 +43,14 @@ class StrategyDiscoveryPipelineTest {
     lateinit var mockExtractFn: ExtractDiscoveredStrategiesFn
 
     @Bind @Mock
-    lateinit var mockWriteFnFactory: WriteDiscoveredStrategiesToPostgresFnFactory
+    lateinit var mockStrategySinkFactory: DiscoveredStrategySinkFactory
 
     @Bind @Mock
     lateinit var mockDiscoveryRequestSourceFactory: DiscoveryRequestSourceFactory
 
     // Additional mocks for testing
     @Mock
-    lateinit var mockWriteFn: WriteDiscoveredStrategiesToPostgresFn
+    lateinit var mockStrategySink: DiscoveredStrategySink
 
     @Mock
     lateinit var mockDiscoveryRequestSource: DiscoveryRequestSource
@@ -84,7 +84,7 @@ class StrategyDiscoveryPipelineTest {
 
         // Create a simple mock source that doesn't try to build complex transforms
         whenever(mockDiscoveryRequestSourceFactory.create(any())).thenReturn(mockDiscoveryRequestSource)
-        whenever(mockWriteFnFactory.create(any())).thenReturn(mockWriteFn)
+        whenever(mockStrategySinkFactory.create(any())).thenReturn(mockStrategySink)
     }
 
     @Test
@@ -219,8 +219,8 @@ class StrategyDiscoveryPipelineTest {
 
         // Create factories as the pipeline would
         val discoveryRequestSource = mockDiscoveryRequestSourceFactory.create(options)
-        val writeFn =
-            mockWriteFnFactory.create(
+        val strategySink =
+            mockStrategySinkFactory.create(
                 DataSourceConfig(
                     serverName = options.dbServerName,
                     databaseName = options.dbDatabaseName,
@@ -235,8 +235,8 @@ class StrategyDiscoveryPipelineTest {
             )
 
         // Verify factories return expected objects
-        assertThat(discoveryRequestSource).isEqualTo(mockDiscoveryRequestSource)
-        assertThat(writeFn).isEqualTo(mockWriteFn)
+        assertThat(discoveryRequestSource).isSameInstanceAs(mockDiscoveryRequestSource)
+        assertThat(strategySink).isSameInstanceAs(mockStrategySink)
     }
 
     @Test
@@ -245,8 +245,8 @@ class StrategyDiscoveryPipelineTest {
         assertThat(strategyDiscoveryPipeline).isNotNull()
         // Test that we can create the necessary components
         val requestSource = mockDiscoveryRequestSourceFactory.create(options)
-        val writeFn =
-            mockWriteFnFactory.create(
+        val strategySink =
+            mockStrategySinkFactory.create(
                 DataSourceConfig(
                     serverName = options.dbServerName,
                     databaseName = options.dbDatabaseName,
@@ -260,8 +260,8 @@ class StrategyDiscoveryPipelineTest {
                 ),
             )
 
-        assertThat(requestSource).isNotNull()
-        assertThat(writeFn).isNotNull()
+        assertThat(requestSource as Any?).isNotNull()
+        assertThat(strategySink as Any?).isNotNull()
     }
 
     @Test
@@ -298,13 +298,13 @@ class StrategyDiscoveryPipelineTest {
     }
 
     @Test
-    fun testErrorPropagationFromWriteFnFactory() {
+    fun testErrorPropagationFromStrategySinkFactory() {
         // Setup write function factory to throw exception
-        whenever(mockWriteFnFactory.create(any())).thenThrow(RuntimeException("Write factory error"))
+        whenever(mockStrategySinkFactory.create(any())).thenThrow(RuntimeException("Write factory error"))
 
         // Verify exception is propagated when factory is called
         try {
-            mockWriteFnFactory.create(
+            mockStrategySinkFactory.create(
                 DataSourceConfig(
                     serverName = "test",
                     databaseName = "test",
@@ -356,12 +356,12 @@ class StrategyDiscoveryPipelineTest {
 
         // Test factory calls
         val requestSource = mockDiscoveryRequestSourceFactory.create(realOptions)
-        val writeFn = mockWriteFnFactory.create(dataSourceConfig)
+        val strategySink = mockStrategySinkFactory.create(dataSourceConfig)
 
         // Verify configuration and factory interactions
         assertThat(dataSourceConfig.serverName).isEqualTo("integration_host")
         assertThat(dataSourceConfig.databaseName).isEqualTo("integration_db")
-        assertThat(requestSource).isNotNull()
-        assertThat(writeFn).isNotNull()
+        assertThat(requestSource as Any?).isNotNull()
+        assertThat(strategySink as Any?).isNotNull()
     }
 }


### PR DESCRIPTION
This pull request introduces a new abstraction for writing discovered strategies by replacing direct usage of `WriteDiscoveredStrategiesToPostgresFn` with a more flexible `DiscoveredStrategySink` interface. Key changes include:

* Introduced `DiscoveredStrategySink` as a common base class.
* Refactored `WriteDiscoveredStrategiesToPostgresFn` to extend `DiscoveredStrategySink`.
* Created `DryRunDiscoveredStrategySink`, a new implementation of `DiscoveredStrategySink` that logs strategies instead of persisting them.
* Replaced the factory `WriteDiscoveredStrategiesToPostgresFnFactory` with `DiscoveredStrategySinkFactory` to accommodate both implementations.
* Updated `StrategyDiscoveryPipeline` and corresponding tests to utilize the new factory and abstraction.
* Modified module bindings in `DiscoveryModule` and `DryRunDiscoveryModule` to install the appropriate sink implementations.

These changes enhance testability, promote code reuse, and enable safer dry-run executions of the strategy discovery pipeline.

Tagging as (MINOR) due to the addition of new, non-breaking functionality.
