### PR TITLE
Make `InfluxDbConfig` Serializable

### DIFF
--- a/src/main/java/com/verlumen/tradestream/influxdb/InfluxDbConfig.kt
+++ b/src/main/java/com/verlumen/tradestream/influxdb/InfluxDbConfig.kt
@@ -2,9 +2,9 @@ package com.verlumen.tradestream.influxdb
 
 import java.io.Serializable
 
-data class InfluxDbConfig:Serializable(
+data class InfluxDbConfig(
     val url: String,
     val token: String,
     val org: String,
-    val bucket: String,
-)
+    val bucket: String
+) : Serializable

--- a/src/main/java/com/verlumen/tradestream/influxdb/InfluxDbConfig.kt
+++ b/src/main/java/com/verlumen/tradestream/influxdb/InfluxDbConfig.kt
@@ -6,5 +6,5 @@ data class InfluxDbConfig(
     val url: String,
     val token: String,
     val org: String,
-    val bucket: String
+    val bucket: String,
 ) : Serializable

--- a/src/main/java/com/verlumen/tradestream/influxdb/InfluxDbConfig.kt
+++ b/src/main/java/com/verlumen/tradestream/influxdb/InfluxDbConfig.kt
@@ -1,6 +1,8 @@
 package com.verlumen.tradestream.influxdb
 
-data class InfluxDbConfig(
+import java.io.Serializable
+
+data class InfluxDbConfig:Serializable(
     val url: String,
     val token: String,
     val org: String,


### PR DESCRIPTION
This change adds `Serializable` to the `InfluxDbConfig` data class. This allows instances of `InfluxDbConfig` to be serialized, enabling scenarios where configuration objects need to be transmitted or persisted, such as distributed systems or caching.

No functional logic has been altered—this is a structural enhancement to support broader usage patterns.
