### PR TITLE
Add `Serializable` support to `InfluxDbClientFactoryImpl`

### DIFF
--- a/src/main/java/com/verlumen/tradestream/influxdb/InfluxDbClientFactory.kt
+++ b/src/main/java/com/verlumen/tradestream/influxdb/InfluxDbClientFactory.kt
@@ -2,12 +2,15 @@ package com.verlumen.tradestream.influxdb
 
 import com.influxdb.client.InfluxDBClient
 import com.influxdb.client.InfluxDBClientFactory
+import java.io.Serializable
 
 interface InfluxDbClientFactory {
     fun create(config: InfluxDbConfig): InfluxDBClient
 }
 
-class InfluxDbClientFactoryImpl : InfluxDbClientFactory {
+class InfluxDbClientFactoryImpl :
+    InfluxDbClientFactory,
+    Serializable {
     override fun create(config: InfluxDbConfig): InfluxDBClient =
         com.influxdb.client.InfluxDBClientFactory.create(
             config.url,
@@ -15,4 +18,8 @@ class InfluxDbClientFactoryImpl : InfluxDbClientFactory {
             config.org,
             config.bucket,
         )
+
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
 }


### PR DESCRIPTION
This update modifies the `InfluxDbClientFactoryImpl` class to implement the `Serializable` interface. A `serialVersionUID` is defined to ensure serialization compatibility.

**Summary of Changes:**

* Implemented `Serializable` in `InfluxDbClientFactoryImpl`.
* Added `serialVersionUID` with a value of `1L`.

This change enables the factory implementation to be safely serialized, which may be necessary for certain distributed or cached application contexts. No functional logic has been modified.
