### PR TITLE
Make `DataSourceConfig` Serializable

### DIFF
--- a/src/main/java/com/verlumen/tradestream/sql/DataSourceFactory.kt
+++ b/src/main/java/com/verlumen/tradestream/sql/DataSourceFactory.kt
@@ -1,6 +1,5 @@
 package com.verlumen.tradestream.sql
 
-import javax.sql.DataSource
 import java.io.Serializable
 import javax.sql.DataSource
 

--- a/src/main/java/com/verlumen/tradestream/sql/DataSourceFactory.kt
+++ b/src/main/java/com/verlumen/tradestream/sql/DataSourceFactory.kt
@@ -1,6 +1,7 @@
 package com.verlumen.tradestream.sql
 
 import javax.sql.DataSource
+import java.io.Serializable
 
 /**
  * Factory interface for creating DataSource instances.
@@ -29,7 +30,7 @@ data class DataSourceConfig(
     val connectTimeout: Int? = null,
     val socketTimeout: Int? = null,
     val readOnly: Boolean? = null,
-) {
+) : Serializable {
     init {
         require(serverName.isNotBlank()) { "Server name cannot be blank" }
         require(databaseName.isNotBlank()) { "Database name cannot be blank" }

--- a/src/main/java/com/verlumen/tradestream/sql/DataSourceFactory.kt
+++ b/src/main/java/com/verlumen/tradestream/sql/DataSourceFactory.kt
@@ -2,6 +2,7 @@ package com.verlumen.tradestream.sql
 
 import javax.sql.DataSource
 import java.io.Serializable
+import javax.sql.DataSource
 
 /**
  * Factory interface for creating DataSource instances.


### PR DESCRIPTION
This patch makes the `DataSourceConfig` data class implement the `Serializable` interface. This change enables the class to be used in contexts where object serialization is required, such as distributed caching or remote method invocation.

No functional logic is altered; the change is limited to class declaration. This is a patch-level update and does not introduce new features or breaking changes.
