### PR TITLE
Add `StrategySpec` and `StrategySpecManager` for Encapsulating Strategy Configuration and Access

### DIFF
--- a/src/main/java/com/verlumen/tradestream/discovery/BUILD
+++ b/src/main/java/com/verlumen/tradestream/discovery/BUILD
@@ -309,8 +309,10 @@ java_library(
     srcs = ["ParamConfig.java"],
     visibility = [
         "//src/main/java/com/verlumen/tradestream/backtesting:__subpackages__",
+        "//src/main/java/com/verlumen/tradestream/strategies:__subpackages__",
         "//src/test/java/com/verlumen/tradestream/backtesting:__pkg__",
         "//src/test/java/com/verlumen/tradestream/discovery:__pkg__",
+        "//src/test/java/com/verlumen/tradestream/strategies:__subpackages__",
     ],
     deps = [
         ":chromosome_spec",

--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -71,3 +71,16 @@ java_library(
         "//third_party/java:ta4j_core",
     ],
 )
+
+kt_jvm_library(
+    name = "strategy_spec",
+    srcs = [
+        "StrategySpec.kt",
+        "StrategySpecManager.kt",
+    ],
+    deps = [
+        ":strategy_factory",
+        "//src/main/java/com/verlumen/tradestream/discovery:param_config",
+        "//third_party/java:guice",
+    ],
+)

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategySpec.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategySpec.kt
@@ -11,5 +11,5 @@ import com.verlumen.tradestream.strategies.StrategyFactory
  */
 data class StrategySpec(
     val paramConfig: ParamConfig,
-    val strategyFactory: StrategyFactory
+    val strategyFactory: StrategyFactory,
 )

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategySpec.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategySpec.kt
@@ -1,0 +1,15 @@
+package com.verlumen.tradestream.strategyspecs
+
+import com.verlumen.tradestream.discovery.ParamConfig
+import com.verlumen.tradestream.strategies.StrategyFactory
+
+/**
+ * A specification that encapsulates all components related to a trading strategy.
+ *
+ * @property paramConfig The configuration for the strategy's parameters, used for genetic optimization.
+ * @property strategyFactory A factory for creating executable ta4j strategy instances.
+ */
+data class StrategySpec(
+    val paramConfig: ParamConfig,
+    val strategyFactory: StrategyFactory
+)

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategySpec.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategySpec.kt
@@ -1,7 +1,6 @@
 package com.verlumen.tradestream.strategies
 
 import com.verlumen.tradestream.discovery.ParamConfig
-import com.verlumen.tradestream.strategies.StrategyFactory
 
 /**
  * A specification that encapsulates all components related to a trading strategy.
@@ -11,5 +10,5 @@ import com.verlumen.tradestream.strategies.StrategyFactory
  */
 data class StrategySpec(
     val paramConfig: ParamConfig,
-    val strategyFactory: StrategyFactory,
+    val strategyFactory: StrategyFactory<*>,
 )

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategySpec.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategySpec.kt
@@ -1,4 +1,4 @@
-package com.verlumen.tradestream.strategyspecs
+package com.verlumen.tradestream.strategies
 
 import com.verlumen.tradestream.discovery.ParamConfig
 import com.verlumen.tradestream.strategies.StrategyFactory

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategySpecManager.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategySpecManager.kt
@@ -5,13 +5,14 @@ import com.google.inject.Inject
 /**
  * Manages and provides StrategySpec instances for different strategy types.
  */
-class StrategySpecManager @Inject constructor(
-    private val specs: Map<StrategyType, StrategySpec>
-) {
-    fun getSpec(strategyType: StrategyType): StrategySpec {
-        return specs[strategyType]
-            ?: throw IllegalArgumentException("No spec found for strategy type: $strategyType")
-    }
+class StrategySpecManager
+    @Inject
+    constructor(
+        private val specs: Map<StrategyType, StrategySpec>,
+    ) {
+        fun getSpec(strategyType: StrategyType): StrategySpec =
+            specs[strategyType]
+                ?: throw IllegalArgumentException("No spec found for strategy type: $strategyType")
 
         fun getSupportedTypes(): Set<StrategyType> = specs.keys
     }

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategySpecManager.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategySpecManager.kt
@@ -1,6 +1,6 @@
 package com.verlumen.tradestream.strategies
 
-import javax.inject.Inject
+import com.google.inject.Inject
 
 /**
  * Manages and provides StrategySpec instances for different strategy types.

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategySpecManager.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategySpecManager.kt
@@ -1,16 +1,19 @@
-package com.verlumen.tradestream.strategyspecs
+package com.verlumen.tradestream.strategies
 
-import com.google.inject.Inject
+import javax.inject.Inject
 
 /**
  * Manages and provides StrategySpec instances for different strategy types.
  */
-class StrategySpecManager
-    @Inject
-    constructor(
-        private val specs: Map<StrategyType, StrategySpec>,
-    ) {
-        fun getSpec(strategyType: StrategyType): StrategySpec =
-            specs[strategyType]
-                ?: throw IllegalArgumentException("No spec found for strategy type: $strategyType")
+class StrategySpecManager @Inject constructor(
+    private val specs: Map<StrategyType, StrategySpec>
+) {
+    fun getSpec(strategyType: StrategyType): StrategySpec {
+        return specs[strategyType]
+            ?: throw IllegalArgumentException("No spec found for strategy type: $strategyType")
     }
+
+    fun getSupportedTypes(): Set<StrategyType> {
+        return specs.keys
+    }
+}

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategySpecManager.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategySpecManager.kt
@@ -1,0 +1,16 @@
+package com.verlumen.tradestream.strategyspecs
+
+import com.google.inject.Inject
+
+/**
+ * Manages and provides StrategySpec instances for different strategy types.
+ */
+class StrategySpecManager
+    @Inject
+    constructor(
+        private val specs: Map<StrategyType, StrategySpec>,
+    ) {
+        fun getSpec(strategyType: StrategyType): StrategySpec =
+            specs[strategyType]
+                ?: throw IllegalArgumentException("No spec found for strategy type: $strategyType")
+    }

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategySpecManager.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategySpecManager.kt
@@ -16,4 +16,3 @@ class StrategySpecManager @Inject constructor(
     fun getSupportedTypes(): Set<StrategyType> {
         return specs.keys
     }
-}

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategySpecManager.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategySpecManager.kt
@@ -13,6 +13,5 @@ class StrategySpecManager @Inject constructor(
             ?: throw IllegalArgumentException("No spec found for strategy type: $strategyType")
     }
 
-    fun getSupportedTypes(): Set<StrategyType> {
-        return specs.keys
+        fun getSupportedTypes(): Set<StrategyType> = specs.keys
     }


### PR DESCRIPTION
This pull request introduces two new Kotlin classes to the `tradestream.strategies` package:

* **`StrategySpec`**: Encapsulates the configuration (`ParamConfig`) and factory for constructing ta4j strategy instances. It provides a cohesive specification model for individual strategies.
* **`StrategySpecManager`**: A manager class injected with a map of `StrategyType` to `StrategySpec`. It enables runtime lookup and validation of supported strategy types, improving modularity and access to strategy configurations.

Additional changes:

* Added a new `kt_jvm_library` target `strategy_spec` to the `BUILD` file under `strategies`, including dependencies on `strategy_factory`, `param_config`, and `guice`.
* Extended visibility of `param_config` in the discovery BUILD file to allow access from the strategies and corresponding test packages.

This update lays the groundwork for more scalable and maintainable strategy management.
(MINOR) – introduces new functionality with no breaking changes.
