### PR TITLE
Refactor SmaRsi Config and Factory to Use Public Constructors

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/StrategySpecs.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategySpecs.kt
@@ -6,7 +6,8 @@ import org.ta4j.core.BarSeries
 import org.ta4j.core.Strategy
 
 // import com.verlumen.tradestream.strategies.emamacd.*
-import com.verlumen.tradestream.strategies.smarsi.*
+import com.verlumen.tradestream.strategies.smarsi.SmaRsiParamConfig
+import com.verlumen.tradestream.strategies.smarsi.SmaRsiStrategyFactory
 
 /**
  * The single source of truth for all implemented strategy specifications.

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategySpecs.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategySpecs.kt
@@ -16,8 +16,8 @@ private val strategySpecMap: Map<StrategyType, StrategySpec> =
     mapOf(
         StrategyType.SMA_RSI to
             StrategySpec(
-                paramConfig = SmaRsiParamConfig.create(),
-                strategyFactory = SmaRsiStrategyFactory.create(),
+                paramConfig = SmaRsiParamConfig(),
+                strategyFactory = SmaRsiStrategyFactory(),
             ),
         // StrategyType.EMA_MACD to StrategySpec(
         //     paramConfig = EmaMacdParamConfig.create(),

--- a/src/main/java/com/verlumen/tradestream/strategies/smarsi/SmaRsiParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/smarsi/SmaRsiParamConfig.java
@@ -23,12 +23,6 @@ public final class SmaRsiParamConfig implements ParamConfig {
           ChromosomeSpec.ofDouble(15.0, 40.0) // Oversold Threshold
           );
 
-  public static SmaRsiParamConfig create() {
-    return new SmaRsiParamConfig();
-  }
-
-  private SmaRsiParamConfig() {}
-
   @Override
   public ImmutableList<ChromosomeSpec<?>> getChromosomeSpecs() {
     return SPECS;

--- a/src/main/java/com/verlumen/tradestream/strategies/smarsi/SmaRsiStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/smarsi/SmaRsiStrategyFactory.java
@@ -55,8 +55,6 @@ public final class SmaRsiStrategyFactory implements StrategyFactory<SmaRsiParame
         .build();
   }
 
-  private SmaRsiStrategyFactory() {}
-
   @Override
   public StrategyType getStrategyType() {
     return StrategyType.SMA_RSI;

--- a/src/main/java/com/verlumen/tradestream/strategies/smarsi/SmaRsiStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/smarsi/SmaRsiStrategyFactory.java
@@ -16,10 +16,6 @@ import org.ta4j.core.rules.OverIndicatorRule;
 import org.ta4j.core.rules.UnderIndicatorRule;
 
 public final class SmaRsiStrategyFactory implements StrategyFactory<SmaRsiParameters> {
-  public static SmaRsiStrategyFactory create() {
-    return new SmaRsiStrategyFactory();
-  }
-
   @Override
   public Strategy createStrategy(BarSeries series, SmaRsiParameters params) {
     checkArgument(params.getMovingAveragePeriod() > 0, "Moving average period must be positive");

--- a/src/test/java/com/verlumen/tradestream/strategies/smarsi/SmaRsiParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/smarsi/SmaRsiParamConfigTest.java
@@ -21,7 +21,7 @@ public class SmaRsiParamConfigTest {
 
   @Before
   public void setUp() {
-    config = SmaRsiParamConfig.create();
+    config = SmaRsiParamConfig();
   }
 
   @Test

--- a/src/test/java/com/verlumen/tradestream/strategies/smarsi/SmaRsiParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/smarsi/SmaRsiParamConfigTest.java
@@ -21,7 +21,7 @@ public class SmaRsiParamConfigTest {
 
   @Before
   public void setUp() {
-    config = SmaRsiParamConfig();
+    config = new SmaRsiParamConfig();
   }
 
   @Test

--- a/src/test/java/com/verlumen/tradestream/strategies/smarsi/SmaRsiStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/smarsi/SmaRsiStrategyFactoryTest.java
@@ -38,7 +38,7 @@ public class SmaRsiStrategyFactoryTest {
 
   @Before
   public void setUp() throws InvalidProtocolBufferException {
-    factory = SmaRsiStrategyFactory();
+    factory = new SmaRsiStrategyFactory();
 
     // Standard parameters
     params =

--- a/src/test/java/com/verlumen/tradestream/strategies/smarsi/SmaRsiStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/smarsi/SmaRsiStrategyFactoryTest.java
@@ -38,7 +38,7 @@ public class SmaRsiStrategyFactoryTest {
 
   @Before
   public void setUp() throws InvalidProtocolBufferException {
-    factory = SmaRsiStrategyFactory.create();
+    factory = SmaRsiStrategyFactory();
 
     // Standard parameters
     params =


### PR DESCRIPTION
Refactored the `SmaRsiParamConfig` and `SmaRsiStrategyFactory` classes to use public constructors directly, removing the now-unnecessary static `create()` factory methods and private constructors. This change simplifies instantiation and aligns with common object creation practices.

**Summary of Changes:**

* Removed `create()` static factory methods from `SmaRsiParamConfig` and `SmaRsiStrategyFactory`.
* Made their constructors public.
* Updated all usages across production and test code to instantiate via `new`.

This is a patch-level update with no changes to functionality or behavior.
