### PR TITLE
Enable and Refactor EMA-MACD Strategy Integration

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -87,8 +87,11 @@ kt_jvm_library(
         "//third_party/java:ta4j_core",
 
         # Implementations for each strategy included in the map
-        "//src/main/java/com/verlumen/tradestream/strategies/adxstochastic:spec",
-        # "//src/main/java/com/verlumen/tradestream/strategies/emamacd:spec",
-        "//src/main/java/com/verlumen/tradestream/strategies/smarsi:spec",
+        "//src/main/java/com/verlumen/tradestream/strategies/adxstochastic:param_config",
+        "//src/main/java/com/verlumen/tradestream/strategies/adxstochastic:strategy_factory",
+        "//src/main/java/com/verlumen/tradestream/strategies/emamacd:param_config",
+        "//src/main/java/com/verlumen/tradestream/strategies/emamacd:strategy_factory",
+        "//src/main/java/com/verlumen/tradestream/strategies/smarsi:param_config",
+        "//src/main/java/com/verlumen/tradestream/strategies/smarsi:strategy_factory",
     ],
 )

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategySpecs.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategySpecs.kt
@@ -2,9 +2,6 @@ package com.verlumen.tradestream.strategies
 
 import com.google.protobuf.Any
 import com.google.protobuf.InvalidProtocolBufferException
-import org.ta4j.core.BarSeries
-import org.ta4j.core.Strategy
-
 import com.verlumen.tradestream.strategies.adxstochastic.AdxStochasticParamConfig
 import com.verlumen.tradestream.strategies.adxstochastic.AdxStochasticStrategyFactory
 import com.verlumen.tradestream.strategies.emamacd.EmaMacdParamConfig

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategySpecs.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategySpecs.kt
@@ -28,10 +28,11 @@ private val strategySpecMap: Map<StrategyType, StrategySpec> =
                 paramConfig = SmaRsiParamConfig(),
                 strategyFactory = SmaRsiStrategyFactory(),
             ),
-        StrategyType.EMA_MACD to StrategySpec(
-            paramConfig = EmaMacdParamConfig(),
-            strategyFactory = EmaMacdStrategyFactory()
-        )
+        StrategyType.EMA_MACD to
+            StrategySpec(
+                paramConfig = EmaMacdParamConfig(),
+                strategyFactory = EmaMacdStrategyFactory(),
+            ),
         // To add a new strategy, just add a new entry here.
     )
 

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategySpecs.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategySpecs.kt
@@ -5,8 +5,10 @@ import com.google.protobuf.InvalidProtocolBufferException
 import org.ta4j.core.BarSeries
 import org.ta4j.core.Strategy
 
-import com.verlumen.tradestream.strategies.adxstochastic.*
-// import com.verlumen.tradestream.strategies.emamacd.*
+import com.verlumen.tradestream.strategies.adxstochastic.AdxStochasticParamConfig
+import com.verlumen.tradestream.strategies.adxstochastic.AdxStochasticStrategyFactory
+import com.verlumen.tradestream.strategies.emamacd.EmaMacdParamConfig
+import com.verlumen.tradestream.strategies.emamacd.EmaMacdStrategyFactory
 import com.verlumen.tradestream.strategies.smarsi.SmaRsiParamConfig
 import com.verlumen.tradestream.strategies.smarsi.SmaRsiStrategyFactory
 
@@ -26,10 +28,10 @@ private val strategySpecMap: Map<StrategyType, StrategySpec> =
                 paramConfig = SmaRsiParamConfig(),
                 strategyFactory = SmaRsiStrategyFactory(),
             ),
-        // StrategyType.EMA_MACD to StrategySpec(
-        //     paramConfig = EmaMacdParamConfig.create(),
-        //     strategyFactory = EmaMacdStrategyFactory.create()
-        // )
+        StrategyType.EMA_MACD to StrategySpec(
+            paramConfig = EmaMacdParamConfig(),
+            strategyFactory = EmaMacdStrategyFactory()
+        )
         // To add a new strategy, just add a new entry here.
     )
 

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategySpecs.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategySpecs.kt
@@ -11,6 +11,8 @@ import com.verlumen.tradestream.strategies.emamacd.EmaMacdParamConfig
 import com.verlumen.tradestream.strategies.emamacd.EmaMacdStrategyFactory
 import com.verlumen.tradestream.strategies.smarsi.SmaRsiParamConfig
 import com.verlumen.tradestream.strategies.smarsi.SmaRsiStrategyFactory
+import org.ta4j.core.BarSeries
+import org.ta4j.core.Strategy
 
 /**
  * The single source of truth for all implemented strategy specifications.

--- a/src/main/java/com/verlumen/tradestream/strategies/adxstochastic/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/adxstochastic/BUILD
@@ -2,6 +2,7 @@ load("@rules_java//java:defs.bzl", "java_library")
 
 package(
     default_visibility = [
+        "//src/main/java/com/verlumen/tradestream/strategies:__pkg__",
         "//src/test/java/com/verlumen/tradestream/strategies/adxstochastic:__pkg__",
     ],
 )
@@ -28,14 +29,5 @@ java_library(
         "//third_party/java:guava",
         "//third_party/java:protobuf_java",
         "//third_party/java:ta4j_core",
-    ],
-)
-
-java_library(
-    name = "spec",
-    visibility = ["//src/main/java/com/verlumen/tradestream/strategies:__pkg__"],
-    exports = [
-        ":param_config",
-        ":strategy_factory",
     ],
 )

--- a/src/main/java/com/verlumen/tradestream/strategies/emamacd/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/emamacd/BUILD
@@ -8,7 +8,7 @@ package(
 )
 
 java_library(
-    name = "ema_macd_param_config",
+    name = "param_config",
     srcs = ["EmaMacdParamConfig.java"],
     deps = [
         "//protos:strategies_java_proto",

--- a/src/main/java/com/verlumen/tradestream/strategies/emamacd/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/emamacd/BUILD
@@ -1,5 +1,12 @@
 load("@rules_java//java:defs.bzl", "java_library")
 
+package(
+    default_visibility = [
+        "//src/main/java/com/verlumen/tradestream/strategies:__pkg__",
+        "//src/test/java/com/verlumen/tradestream/strategies/emamacd:__pkg__",
+    ],
+)
+
 java_library(
     name = "ema_macd_param_config",
     srcs = ["EmaMacdParamConfig.java"],
@@ -10,5 +17,17 @@ java_library(
         "//third_party/java:guava",
         "//third_party/java:jenetics",
         "//third_party/java:protobuf_java",
+    ],
+)
+
+java_library(
+    name = "strategy_factory",
+    srcs = ["EmaMacdStrategyFactory.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/strategies:strategy_factory",
+        "//third_party/java:guava",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:ta4j_core",
     ],
 )

--- a/src/main/java/com/verlumen/tradestream/strategies/emamacd/EmaMacdParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/emamacd/EmaMacdParamConfig.java
@@ -9,7 +9,7 @@ import com.verlumen.tradestream.strategies.StrategyType;
 import io.jenetics.IntegerChromosome;
 import io.jenetics.NumericChromosome;
 
-final class EmaMacdParamConfig implements ParamConfig {
+public final class EmaMacdParamConfig implements ParamConfig {
   private static final ImmutableList<ChromosomeSpec<?>> SPECS =
       ImmutableList.of(
           // Integer parameters
@@ -17,12 +17,6 @@ final class EmaMacdParamConfig implements ParamConfig {
           ChromosomeSpec.ofInteger(10, 50), // Long EMA Period
           ChromosomeSpec.ofInteger(5, 20) // Signal Period
           );
-
-  static EmaMacdParamConfig create() {
-    return new EmaMacdParamConfig();
-  }
-
-  private EmaMacdParamConfig() {}
 
   @Override
   public ImmutableList<ChromosomeSpec<?>> getChromosomeSpecs() {

--- a/src/main/java/com/verlumen/tradestream/strategies/emamacd/EmaMacdStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/emamacd/EmaMacdStrategyFactory.java
@@ -16,13 +16,7 @@ import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.rules.CrossedDownIndicatorRule;
 import org.ta4j.core.rules.CrossedUpIndicatorRule;
 
-final class EmaMacdStrategyFactory implements StrategyFactory<EmaMacdParameters> {
-  static EmaMacdStrategyFactory create() {
-    return new EmaMacdStrategyFactory();
-  }
-
-  private EmaMacdStrategyFactory() {}
-
+public final class EmaMacdStrategyFactory implements StrategyFactory<EmaMacdParameters> {
   @Override
   public StrategyType getStrategyType() {
     return StrategyType.EMA_MACD;

--- a/src/main/java/com/verlumen/tradestream/strategies/smarsi/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/smarsi/BUILD
@@ -2,6 +2,7 @@ load("@rules_java//java:defs.bzl", "java_library")
 
 package(
     default_visibility = [
+        "//src/main/java/com/verlumen/tradestream/strategies:__pkg__",
         "//src/test/java/com/verlumen/tradestream/strategies/smarsi:__pkg__",
     ],
 )
@@ -28,14 +29,5 @@ java_library(
         "//third_party/java:guava",
         "//third_party/java:protobuf_java",
         "//third_party/java:ta4j_core",
-    ],
-)
-
-java_library(
-    name = "spec",
-    visibility = ["//src/main/java/com/verlumen/tradestream/strategies:__pkg__"],
-    exports = [
-        ":param_config",
-        ":strategy_factory",
     ],
 )

--- a/src/test/java/com/verlumen/tradestream/strategies/StrategySpecsTest.kt
+++ b/src/test/java/com/verlumen/tradestream/strategies/StrategySpecsTest.kt
@@ -178,7 +178,7 @@ class StrategySpecsTest {
         assertThat(result).isNotNull()
         // Should match the keys in strategySpecMap
         // Currently empty since all entries are commented out
-        assertThat(result).hasSize(2)
+        assertThat(result).hasSize(3)
     }
 
     @Test


### PR DESCRIPTION
This update re-enables the EMA-MACD strategy by fully integrating its configuration and factory components into the strategy spec map. Key changes include:

* Activated `EmaMacdParamConfig` and `EmaMacdStrategyFactory` in `StrategySpecs.kt`.
* Removed deprecated `spec` targets from `BUILD` files for `adxstochastic`, `emamacd`, and `smarsi` strategies.
* Defined explicit `param_config` and `strategy_factory` targets with appropriate visibility settings.
* Adjusted test in `StrategySpecsTest` to reflect the newly included strategy.

These changes enhance modularity and clarity in strategy configuration while expanding the set of active trading strategies.

(MINOR) – introduces new functionality via re-enabled strategy support.
