### PR TITLE
Refactor DoubleEmaCrossoverStrategy to Dedicated Package

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/doubleemacrossover/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/doubleemacrossover/BUILD
@@ -1,0 +1,12 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
+java_library(
+  name = "DoubleEmaCrossoverStrategyFactory",
+  srcs = ["DoubleEmaCrossoverStrategyFactory.java"],
+  deps = [
+    "//protos:strategies_java_proto",
+    "//src/main/java/com/verlumen/tradestream/strategies:strategy_factory",
+    "//third_party/java:protobuf_java",
+    "//third_party/java:ta4j_core",
+  ]
+)

--- a/src/main/java/com/verlumen/tradestream/strategies/doubleemacrossover/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/doubleemacrossover/BUILD
@@ -1,6 +1,6 @@
 load("@rules_java//java:defs.bzl", "java_library")
 
-package(default_visibility=[
+package(default_visibility = [
     "//src/main/java/com/verlumen/tradestream/strategies:__pkg__",
     "//src/test/java/com/verlumen/tradestream/strategies/doubleemacrossover:__pkg__",
 ])

--- a/src/main/java/com/verlumen/tradestream/strategies/doubleemacrossover/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/doubleemacrossover/BUILD
@@ -6,12 +6,12 @@ package(default_visibility=[
 ])
 
 java_library(
-  name = "strategy_factory",
-  srcs = ["DoubleEmaCrossoverStrategyFactory.java"],
-  deps = [
-    "//protos:strategies_java_proto",
-    "//src/main/java/com/verlumen/tradestream/strategies:strategy_factory",
-    "//third_party/java:protobuf_java",
-    "//third_party/java:ta4j_core",
-  ]
+    name = "strategy_factory",
+    srcs = ["DoubleEmaCrossoverStrategyFactory.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/strategies:strategy_factory",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:ta4j_core",
+    ],
 )

--- a/src/main/java/com/verlumen/tradestream/strategies/doubleemacrossover/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/doubleemacrossover/BUILD
@@ -1,7 +1,12 @@
 load("@rules_java//java:defs.bzl", "java_library")
 
+package(default_visibility=[
+    "//src/main/java/com/verlumen/tradestream/strategies:__pkg__",
+      "//src/test/java/com/verlumen/tradestream/strategies/doubleemacrossover:__pkg__",
+])
+
 java_library(
-  name = "DoubleEmaCrossoverStrategyFactory",
+  name = "strategy_factory",
   srcs = ["DoubleEmaCrossoverStrategyFactory.java"],
   deps = [
     "//protos:strategies_java_proto",

--- a/src/main/java/com/verlumen/tradestream/strategies/doubleemacrossover/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/doubleemacrossover/BUILD
@@ -11,6 +11,7 @@ java_library(
     deps = [
         "//protos:strategies_java_proto",
         "//src/main/java/com/verlumen/tradestream/strategies:strategy_factory",
+        "//third_party/java:guava",
         "//third_party/java:protobuf_java",
         "//third_party/java:ta4j_core",
     ],

--- a/src/main/java/com/verlumen/tradestream/strategies/doubleemacrossover/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/doubleemacrossover/BUILD
@@ -2,7 +2,7 @@ load("@rules_java//java:defs.bzl", "java_library")
 
 package(default_visibility=[
     "//src/main/java/com/verlumen/tradestream/strategies:__pkg__",
-      "//src/test/java/com/verlumen/tradestream/strategies/doubleemacrossover:__pkg__",
+    "//src/test/java/com/verlumen/tradestream/strategies/doubleemacrossover:__pkg__",
 ])
 
 java_library(

--- a/src/main/java/com/verlumen/tradestream/strategies/doubleemacrossover/DoubleEmaCrossoverStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/doubleemacrossover/DoubleEmaCrossoverStrategyFactory.java
@@ -15,12 +15,8 @@ import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.rules.CrossedDownIndicatorRule;
 import org.ta4j.core.rules.CrossedUpIndicatorRule;
 
-final class DoubleEmaCrossoverStrategyFactory
+public final class DoubleEmaCrossoverStrategyFactory
     implements StrategyFactory<DoubleEmaCrossoverParameters> {
-  static DoubleEmaCrossoverStrategyFactory create() {
-    return new DoubleEmaCrossoverStrategyFactory();
-  }
-
   @Override
   public Strategy createStrategy(BarSeries series, DoubleEmaCrossoverParameters params)
       throws InvalidProtocolBufferException {
@@ -62,6 +58,4 @@ final class DoubleEmaCrossoverStrategyFactory
   public StrategyType getStrategyType() {
     return StrategyType.DOUBLE_EMA_CROSSOVER;
   }
-
-  private DoubleEmaCrossoverStrategyFactory() {}
 }

--- a/src/main/java/com/verlumen/tradestream/strategies/doubleemacrossover/DoubleEmaCrossoverStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/doubleemacrossover/DoubleEmaCrossoverStrategyFactory.java
@@ -1,4 +1,4 @@
-package com.verlumen.tradestream.strategies.movingaverages;
+package com.verlumen.tradestream.strategies.doubleemacrossover;
 
 import static com.google.common.base.Preconditions.checkArgument;
 

--- a/src/main/java/com/verlumen/tradestream/strategies/movingaverages/MovingAverageStrategies.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/movingaverages/MovingAverageStrategies.java
@@ -11,7 +11,6 @@ public final class MovingAverageStrategies {
   /** An immutable list of all moving average strategy factories. */
   public static final ImmutableList<StrategyFactory<?>> ALL_FACTORIES =
       ImmutableList.of(
-          DoubleEmaCrossoverStrategyFactory.create(),
           MomentumSmaCrossoverStrategyFactory.create(),
           SmaEmaCrossoverStrategyFactory.create(),
           TripleEmaCrossoverStrategyFactory.create());

--- a/src/test/java/com/verlumen/tradestream/strategies/doubleemacrossover/BUILD
+++ b/src/test/java/com/verlumen/tradestream/strategies/doubleemacrossover/BUILD
@@ -1,0 +1,19 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
+java_test(
+    name = "DoubleEmaCrossoverStrategyFactoryTest",
+    srcs = ["DoubleEmaCrossoverStrategyFactoryTest.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/strategies:strategy_factory",
+        "//src/main/java/com/verlumen/tradestream/strategies/movingaverages:movingaverages_lib",
+        "//third_party/java:flogger",
+        "//third_party/java:guava",
+        "//third_party/java:guice",
+        "//third_party/java:junit",
+        "//third_party/java:mockito_core",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:ta4j_core",
+        "//third_party/java:truth",
+    ],
+)

--- a/src/test/java/com/verlumen/tradestream/strategies/doubleemacrossover/BUILD
+++ b/src/test/java/com/verlumen/tradestream/strategies/doubleemacrossover/BUILD
@@ -6,7 +6,7 @@ java_test(
     deps = [
         "//protos:strategies_java_proto",
         "//src/main/java/com/verlumen/tradestream/strategies:strategy_factory",
-        "//src/main/java/com/verlumen/tradestream/strategies/movingaverages:movingaverages_lib",
+        "//src/main/java/com/verlumen/tradestream/strategies/doubleemacrossover:strategy_factory",
         "//third_party/java:flogger",
         "//third_party/java:guava",
         "//third_party/java:guice",

--- a/src/test/java/com/verlumen/tradestream/strategies/doubleemacrossover/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/doubleemacrossover/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -1,4 +1,4 @@
-package com.verlumen.tradestream.strategies.movingaverages;
+package com.verlumen.tradestream.strategies.doubleemacrossover;
 
 import static com.google.common.truth.Truth.assertThat;
 

--- a/src/test/java/com/verlumen/tradestream/strategies/doubleemacrossover/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/doubleemacrossover/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -35,7 +35,7 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
 
   @Before
   public void setUp() throws InvalidProtocolBufferException {
-    factory = DoubleEmaCrossoverStrategyFactory();
+    factory = new DoubleEmaCrossoverStrategyFactory();
 
     // Standard parameters
     params =

--- a/src/test/java/com/verlumen/tradestream/strategies/doubleemacrossover/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/doubleemacrossover/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -35,7 +35,7 @@ public class DoubleEmaCrossoverStrategyFactoryTest {
 
   @Before
   public void setUp() throws InvalidProtocolBufferException {
-    factory = DoubleEmaCrossoverStrategyFactory.create();
+    factory = DoubleEmaCrossoverStrategyFactory();
 
     // Standard parameters
     params =

--- a/src/test/java/com/verlumen/tradestream/strategies/movingaverages/BUILD
+++ b/src/test/java/com/verlumen/tradestream/strategies/movingaverages/BUILD
@@ -1,24 +1,6 @@
 load("@rules_java//java:defs.bzl", "java_test")
 
 java_test(
-    name = "DoubleEmaCrossoverStrategyFactoryTest",
-    srcs = ["DoubleEmaCrossoverStrategyFactoryTest.java"],
-    deps = [
-        "//protos:strategies_java_proto",
-        "//src/main/java/com/verlumen/tradestream/strategies:strategy_factory",
-        "//src/main/java/com/verlumen/tradestream/strategies/movingaverages:movingaverages_lib",
-        "//third_party/java:flogger",
-        "//third_party/java:guava",
-        "//third_party/java:guice",
-        "//third_party/java:junit",
-        "//third_party/java:mockito_core",
-        "//third_party/java:protobuf_java",
-        "//third_party/java:ta4j_core",
-        "//third_party/java:truth",
-    ],
-)
-
-java_test(
     name = "MomentumSmaCrossoverStrategyFactoryTest",
     srcs = ["MomentumSmaCrossoverStrategyFactoryTest.java"],
     deps = [


### PR DESCRIPTION
This patch relocates the `DoubleEmaCrossoverStrategyFactory` and its corresponding test from the `movingaverages` package to a new `doubleemacrossover` package. The change improves modularity by organizing strategy implementations into distinct, strategy-specific packages.

### Summary of Changes:

* Moved `DoubleEmaCrossoverStrategyFactory.java` and its test to `doubleemacrossover` package.
* Updated package declarations accordingly.
* Added new Bazel `BUILD` files for the `doubleemacrossover` main and test directories.
* Removed the strategy and its test from the `movingaverages` package and associated `BUILD` targets.
* Removed `DoubleEmaCrossoverStrategyFactory.create()` from the `MovingAverageStrategies.ALL_FACTORIES` list.

This is a structural refactor with no functional impact, intended to improve code organization and maintainability.
