### PR TITLE
Add `SmaEmaCrossoverParamConfig` for parameterized SMA-EMA crossover strategy support

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/smaemacrossover/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/smaemacrossover/BUILD
@@ -1,9 +1,24 @@
 load("@rules_java//java:defs.bzl", "java_library")
 
-package(default_visibility = [
-    "//src/main/java/com/verlumen/tradestream/strategies:__pkg__",
-    "//src/test/java/com/verlumen/tradestream/strategies/smaemacrossover:__pkg__",
-])
+package(
+    default_visibility = [
+        "//src/main/java/com/verlumen/tradestream/strategies:__pkg__",
+        "//src/test/java/com/verlumen/tradestream/strategies/smaemacrossover:__pkg__",
+    ],
+)
+
+java_library(
+    name = "param_config",
+    srcs = ["SmaEmaCrossoverParamConfig.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/discovery:chromosome_spec",
+        "//src/main/java/com/verlumen/tradestream/discovery:param_config",
+        "//third_party/java:guava",
+        "//third_party/java:jenetics",
+        "//third_party/java:protobuf_java",
+    ],
+)
 
 java_library(
     name = "strategy_factory",

--- a/src/main/java/com/verlumen/tradestream/strategies/smaemacrossover/SmaEmaCrossoverParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/smaemacrossover/SmaEmaCrossoverParamConfig.java
@@ -1,0 +1,54 @@
+package com.verlumen.tradestream.strategies.smaemacrossover;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.verlumen.tradestream.discovery.ChromosomeSpec;
+import com.verlumen.tradestream.discovery.ParamConfig;
+import com.verlumen.tradestream.strategies.SmaEmaCrossoverParameters;
+import com.verlumen.tradestream.strategies.StrategyType;
+import io.jenetics.IntegerChromosome;
+import io.jenetics.NumericChromosome;
+
+public final class SmaEmaCrossoverParamConfig implements ParamConfig {
+  private static final ImmutableList<ChromosomeSpec<?>> SPECS =
+      ImmutableList.of(
+          ChromosomeSpec.ofInteger(5, 50), // SMA Period
+          ChromosomeSpec.ofInteger(5, 50)  // EMA Period
+      );
+
+  @Override
+  public ImmutableList<ChromosomeSpec<?>> getChromosomeSpecs() {
+    return SPECS;
+  }
+
+  @Override
+  public Any createParameters(ImmutableList<? extends NumericChromosome<?, ?>> chromosomes) {
+    if (chromosomes.size() != SPECS.size()) {
+      throw new IllegalArgumentException(
+          "Expected " + SPECS.size() + " chromosomes but got " + chromosomes.size());
+    }
+
+    IntegerChromosome smaPeriodChrom = (IntegerChromosome) chromosomes.get(0);
+    IntegerChromosome emaPeriodChrom = (IntegerChromosome) chromosomes.get(1);
+
+    SmaEmaCrossoverParameters parameters =
+        SmaEmaCrossoverParameters.newBuilder()
+            .setSmaPeriod(smaPeriodChrom.gene().allele())
+            .setEmaPeriod(emaPeriodChrom.gene().allele())
+            .build();
+
+    return Any.pack(parameters);
+  }
+
+  @Override
+  public ImmutableList<? extends NumericChromosome<?, ?>> initialChromosomes() {
+    return SPECS.stream()
+        .map(ChromosomeSpec::createChromosome)
+        .collect(ImmutableList.toImmutableList());
+  }
+
+  @Override
+  public StrategyType getStrategyType() {
+    return StrategyType.SMA_EMA_CROSSOVER;
+  }
+}

--- a/src/main/java/com/verlumen/tradestream/strategies/smaemacrossover/SmaEmaCrossoverParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/smaemacrossover/SmaEmaCrossoverParamConfig.java
@@ -13,8 +13,8 @@ public final class SmaEmaCrossoverParamConfig implements ParamConfig {
   private static final ImmutableList<ChromosomeSpec<?>> SPECS =
       ImmutableList.of(
           ChromosomeSpec.ofInteger(5, 50), // SMA Period
-          ChromosomeSpec.ofInteger(5, 50)  // EMA Period
-      );
+          ChromosomeSpec.ofInteger(5, 50) // EMA Period
+          );
 
   @Override
   public ImmutableList<ChromosomeSpec<?>> getChromosomeSpecs() {

--- a/src/test/java/com/verlumen/tradestream/strategies/smaemacrossover/BUILD
+++ b/src/test/java/com/verlumen/tradestream/strategies/smaemacrossover/BUILD
@@ -1,6 +1,21 @@
 load("@rules_java//java:defs.bzl", "java_test")
 
 java_test(
+    name = "SmaEmaCrossoverParamConfigTest",
+    srcs = ["SmaEmaCrossoverParamConfigTest.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/discovery:chromosome_spec",
+        "//src/main/java/com/verlumen/tradestream/strategies/smaemacrossover:param_config",
+        "//third_party/java:guava",
+        "//third_party/java:jenetics",
+        "//third_party/java:junit",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:truth",
+    ],
+)
+
+java_test(
     name = "SmaEmaCrossoverStrategyFactoryTest",
     srcs = ["SmaEmaCrossoverStrategyFactoryTest.java"],
     deps = [

--- a/src/test/java/com/verlumen/tradestream/strategies/smaemacrossover/SmaEmaCrossoverParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/smaemacrossover/SmaEmaCrossoverParamConfigTest.java
@@ -36,8 +36,8 @@ public class SmaEmaCrossoverParamConfigTest {
     List<NumericChromosome<?, ?>> chromosomes =
         List.of(
             IntegerChromosome.of(5, 50, 20), // SMA Period
-            IntegerChromosome.of(5, 50, 14)  // EMA Period
-        );
+            IntegerChromosome.of(5, 50, 14) // EMA Period
+            );
 
     Any packedParams = config.createParameters(ImmutableList.copyOf(chromosomes));
     assertThat(packedParams.is(SmaEmaCrossoverParameters.class)).isTrue();

--- a/src/test/java/com/verlumen/tradestream/strategies/smaemacrossover/SmaEmaCrossoverParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/smaemacrossover/SmaEmaCrossoverParamConfigTest.java
@@ -1,7 +1,6 @@
 package com.verlumen.tradestream.strategies.smaemacrossover;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;

--- a/src/test/java/com/verlumen/tradestream/strategies/smaemacrossover/SmaEmaCrossoverParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/smaemacrossover/SmaEmaCrossoverParamConfigTest.java
@@ -1,0 +1,50 @@
+package com.verlumen.tradestream.strategies.smaemacrossover;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.verlumen.tradestream.discovery.ChromosomeSpec;
+import com.verlumen.tradestream.strategies.SmaEmaCrossoverParameters;
+import com.verlumen.tradestream.strategies.StrategyType;
+import io.jenetics.IntegerChromosome;
+import io.jenetics.NumericChromosome;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class SmaEmaCrossoverParamConfigTest {
+  private SmaEmaCrossoverParamConfig config;
+
+  @Before
+  public void setUp() {
+    config = new SmaEmaCrossoverParamConfig();
+  }
+
+  @Test
+  public void testGetChromosomeSpecs_returnsExpectedSpecs() {
+    ImmutableList<ChromosomeSpec<?>> specs = config.getChromosomeSpecs();
+    assertThat(specs).hasSize(2);
+  }
+
+  @Test
+  public void testCreateParameters_validChromosomes_returnsPackedParameters() {
+    List<NumericChromosome<?, ?>> chromosomes =
+        List.of(
+            IntegerChromosome.of(5, 50, 20), // SMA Period
+            IntegerChromosome.of(5, 50, 14)  // EMA Period
+        );
+
+    Any packedParams = config.createParameters(ImmutableList.copyOf(chromosomes));
+    assertThat(packedParams.is(SmaEmaCrossoverParameters.class)).isTrue();
+  }
+
+  @Test
+  public void testGetStrategyType_returnsExpectedType() {
+    assertThat(config.getStrategyType()).isEqualTo(StrategyType.SMA_EMA_CROSSOVER);
+  }
+}


### PR DESCRIPTION
This PR introduces the `SmaEmaCrossoverParamConfig` class to support parameterized configuration for the SMA-EMA crossover strategy. The new configuration enables genetic algorithm-based optimization by specifying chromosome specifications for SMA and EMA periods.

### Summary of Changes:

* Added `SmaEmaCrossoverParamConfig.java` implementing `ParamConfig` for SMA-EMA strategies.
* Defined chromosome specs for two integer parameters (SMA and EMA periods).
* Included logic to convert chromosomes to `SmaEmaCrossoverParameters` proto.
* Registered the param config in the strategy's Bazel `BUILD` file.
* Added `SmaEmaCrossoverParamConfigTest.java` with unit tests for:

  * Chromosome spec generation.
  * Parameter creation from chromosomes.
  * Strategy type validation.
* Updated the test `BUILD` file to include the new test target.

This update enables dynamic parameter tuning and enhances strategy experimentation capabilities.

**Tag:** (MINOR) – introduces a new strategy configuration feature.
