### PR TITLE
Add `TripleEmaCrossoverParamConfig` for strategy parameterization and testing

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/tripleemacrossover/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/tripleemacrossover/BUILD
@@ -1,8 +1,22 @@
 load("@rules_java//java:defs.bzl", "java_library")
 
 package(default_visibility = [
+    "//src/main/java/com/verlumen/tradestream/strategies:__pkg__",
     "//src/test/java/com/verlumen/tradestream/strategies/tripleemacrossover:__pkg__",
 ])
+
+java_library(
+    name = "param_config",
+    srcs = ["TripleEmaCrossoverParamConfig.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/discovery:chromosome_spec",
+        "//src/main/java/com/verlumen/tradestream/discovery:param_config",
+        "//third_party/java:guava",
+        "//third_party/java:jenetics",
+        "//third_party/java:protobuf_java",
+    ],
+)
 
 java_library(
     name = "strategy_factory",

--- a/src/main/java/com/verlumen/tradestream/strategies/tripleemacrossover/TripleEmaCrossoverParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/tripleemacrossover/TripleEmaCrossoverParamConfig.java
@@ -12,7 +12,7 @@ import io.jenetics.NumericChromosome;
 public final class TripleEmaCrossoverParamConfig implements ParamConfig {
   private static final ImmutableList<ChromosomeSpec<?>> SPECS =
       ImmutableList.of(
-          ChromosomeSpec.ofInteger(2, 20),  // Short EMA Period
+          ChromosomeSpec.ofInteger(2, 20), // Short EMA Period
           ChromosomeSpec.ofInteger(10, 50), // Medium EMA Period
           ChromosomeSpec.ofInteger(20, 100) // Long EMA Period
           );

--- a/src/main/java/com/verlumen/tradestream/strategies/tripleemacrossover/TripleEmaCrossoverParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/tripleemacrossover/TripleEmaCrossoverParamConfig.java
@@ -15,7 +15,7 @@ public final class TripleEmaCrossoverParamConfig implements ParamConfig {
           ChromosomeSpec.ofInteger(2, 20),  // Short EMA Period
           ChromosomeSpec.ofInteger(10, 50), // Medium EMA Period
           ChromosomeSpec.ofInteger(20, 100) // Long EMA Period
-      );
+          );
 
   @Override
   public ImmutableList<ChromosomeSpec<?>> getChromosomeSpecs() {

--- a/src/main/java/com/verlumen/tradestream/strategies/tripleemacrossover/TripleEmaCrossoverParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/tripleemacrossover/TripleEmaCrossoverParamConfig.java
@@ -1,0 +1,57 @@
+package com.verlumen.tradestream.strategies.tripleemacrossover;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.verlumen.tradestream.discovery.ChromosomeSpec;
+import com.verlumen.tradestream.discovery.ParamConfig;
+import com.verlumen.tradestream.strategies.StrategyType;
+import com.verlumen.tradestream.strategies.TripleEmaCrossoverParameters;
+import io.jenetics.IntegerChromosome;
+import io.jenetics.NumericChromosome;
+
+public final class TripleEmaCrossoverParamConfig implements ParamConfig {
+  private static final ImmutableList<ChromosomeSpec<?>> SPECS =
+      ImmutableList.of(
+          ChromosomeSpec.ofInteger(2, 20),  // Short EMA Period
+          ChromosomeSpec.ofInteger(10, 50), // Medium EMA Period
+          ChromosomeSpec.ofInteger(20, 100) // Long EMA Period
+      );
+
+  @Override
+  public ImmutableList<ChromosomeSpec<?>> getChromosomeSpecs() {
+    return SPECS;
+  }
+
+  @Override
+  public Any createParameters(ImmutableList<? extends NumericChromosome<?, ?>> chromosomes) {
+    if (chromosomes.size() != SPECS.size()) {
+      throw new IllegalArgumentException(
+          "Expected " + SPECS.size() + " chromosomes but got " + chromosomes.size());
+    }
+
+    IntegerChromosome shortEmaPeriodChrom = (IntegerChromosome) chromosomes.get(0);
+    IntegerChromosome mediumEmaPeriodChrom = (IntegerChromosome) chromosomes.get(1);
+    IntegerChromosome longEmaPeriodChrom = (IntegerChromosome) chromosomes.get(2);
+
+    TripleEmaCrossoverParameters parameters =
+        TripleEmaCrossoverParameters.newBuilder()
+            .setShortEmaPeriod(shortEmaPeriodChrom.gene().allele())
+            .setMediumEmaPeriod(mediumEmaPeriodChrom.gene().allele())
+            .setLongEmaPeriod(longEmaPeriodChrom.gene().allele())
+            .build();
+
+    return Any.pack(parameters);
+  }
+
+  @Override
+  public ImmutableList<? extends NumericChromosome<?, ?>> initialChromosomes() {
+    return SPECS.stream()
+        .map(ChromosomeSpec::createChromosome)
+        .collect(ImmutableList.toImmutableList());
+  }
+
+  @Override
+  public StrategyType getStrategyType() {
+    return StrategyType.TRIPLE_EMA_CROSSOVER;
+  }
+}

--- a/src/test/java/com/verlumen/tradestream/strategies/tripleemacrossover/BUILD
+++ b/src/test/java/com/verlumen/tradestream/strategies/tripleemacrossover/BUILD
@@ -1,6 +1,21 @@
 load("@rules_java//java:defs.bzl", "java_test")
 
 java_test(
+    name = "TripleEmaCrossoverParamConfigTest",
+    srcs = ["TripleEmaCrossoverParamConfigTest.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/discovery:chromosome_spec",
+        "//src/main/java/com/verlumen/tradestream/strategies/tripleemacrossover:param_config",
+        "//third_party/java:guava",
+        "//third_party/java:jenetics",
+        "//third_party/java:junit",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:truth",
+    ],
+)
+
+java_test(
     name = "TripleEmaCrossoverStrategyFactoryTest",
     srcs = ["TripleEmaCrossoverStrategyFactoryTest.java"],
     deps = [

--- a/src/test/java/com/verlumen/tradestream/strategies/tripleemacrossover/TripleEmaCrossoverParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/tripleemacrossover/TripleEmaCrossoverParamConfigTest.java
@@ -1,0 +1,50 @@
+package com.verlumen.tradestream.strategies.tripleemacrossover;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.verlumen.tradestream.discovery.ChromosomeSpec;
+import com.verlumen.tradestream.strategies.StrategyType;
+import com.verlumen.tradestream.strategies.TripleEmaCrossoverParameters;
+import io.jenetics.IntegerChromosome;
+import io.jenetics.NumericChromosome;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TripleEmaCrossoverParamConfigTest {
+  private TripleEmaCrossoverParamConfig config;
+
+  @Before
+  public void setUp() {
+    config = new TripleEmaCrossoverParamConfig();
+  }
+
+  @Test
+  public void testGetChromosomeSpecs_returnsExpectedSpecs() {
+    ImmutableList<ChromosomeSpec<?>> specs = config.getChromosomeSpecs();
+    assertThat(specs).hasSize(3);
+  }
+
+  @Test
+  public void testCreateParameters_validChromosomes_returnsPackedParameters() {
+    List<NumericChromosome<?, ?>> chromosomes =
+        List.of(
+            IntegerChromosome.of(2, 20, 10),   // Short EMA Period
+            IntegerChromosome.of(10, 50, 20),  // Medium EMA Period
+            IntegerChromosome.of(20, 100, 50)  // Long EMA Period
+        );
+
+    Any packedParams = config.createParameters(ImmutableList.copyOf(chromosomes));
+    assertThat(packedParams.is(TripleEmaCrossoverParameters.class)).isTrue();
+  }
+
+  @Test
+  public void testGetStrategyType_returnsExpectedType() {
+    assertThat(config.getStrategyType()).isEqualTo(StrategyType.TRIPLE_EMA_CROSSOVER);
+  }
+}

--- a/src/test/java/com/verlumen/tradestream/strategies/tripleemacrossover/TripleEmaCrossoverParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/tripleemacrossover/TripleEmaCrossoverParamConfigTest.java
@@ -34,10 +34,10 @@ public class TripleEmaCrossoverParamConfigTest {
   public void testCreateParameters_validChromosomes_returnsPackedParameters() {
     List<NumericChromosome<?, ?>> chromosomes =
         List.of(
-            IntegerChromosome.of(2, 20, 10),   // Short EMA Period
-            IntegerChromosome.of(10, 50, 20),  // Medium EMA Period
-            IntegerChromosome.of(20, 100, 50)  // Long EMA Period
-        );
+            IntegerChromosome.of(2, 20, 10), // Short EMA Period
+            IntegerChromosome.of(10, 50, 20), // Medium EMA Period
+            IntegerChromosome.of(20, 100, 50) // Long EMA Period
+            );
 
     Any packedParams = config.createParameters(ImmutableList.copyOf(chromosomes));
     assertThat(packedParams.is(TripleEmaCrossoverParameters.class)).isTrue();


### PR DESCRIPTION
This change introduces a new `TripleEmaCrossoverParamConfig` class implementing `ParamConfig` to define parameterization logic for the Triple EMA Crossover strategy. Key elements include:

* **Chromosome specs** for short, medium, and long EMA periods using `ChromosomeSpec.ofInteger`.
* **Parameter creation** from chromosomes, returning packed `TripleEmaCrossoverParameters`.
* **Integration** in the build system (`BUILD` files) with appropriate dependencies.
* **Unit tests** (`TripleEmaCrossoverParamConfigTest`) validating spec retrieval, parameter creation, and strategy type consistency.

This enhancement enables consistent genetic algorithm configuration for the strategy, laying groundwork for optimized parameter tuning. *(MINOR)*
