### PR TITLE
Add Parabolic SAR strategy support with configurable parameters and tests (MINOR)

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/parabolicsarr/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/parabolicsarr/BUILD
@@ -1,0 +1,33 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
+package(
+    default_visibility = [
+        "//src/main/java/com/verlumen/tradestream/strategies:__pkg__",
+        "//src/test/java/com/verlumen/tradestream/strategies/parabolicsarr:__pkg__",
+    ],
+)
+
+java_library(
+    name = "param_config",
+    srcs = ["ParabolicSarParamConfig.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/discovery:chromosome_spec",
+        "//src/main/java/com/verlumen/tradestream/discovery:param_config",
+        "//third_party/java:guava",
+        "//third_party/java:jenetics",
+        "//third_party/java:protobuf_java",
+    ],
+)
+
+java_library(
+    name = "strategy_factory",
+    srcs = ["ParabolicSarStrategyFactory.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/strategies:strategy_factory",
+        "//third_party/java:guava",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:ta4j_core",
+    ],
+)

--- a/src/main/java/com/verlumen/tradestream/strategies/parabolicsarr/ParabolicSarParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/parabolicsarr/ParabolicSarParamConfig.java
@@ -1,0 +1,66 @@
+package com.verlumen.tradestream.strategies.parabolicsarr;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.verlumen.tradestream.discovery.ChromosomeSpec;
+import com.verlumen.tradestream.discovery.ParamConfig;
+import com.verlumen.tradestream.strategies.ParabolicSarParameters;
+import com.verlumen.tradestream.strategies.StrategyType;
+import io.jenetics.DoubleChromosome;
+import io.jenetics.NumericChromosome;
+
+public final class ParabolicSarParamConfig implements ParamConfig {
+  private static final ImmutableList<ChromosomeSpec<?>> SPECS =
+      ImmutableList.of(
+          ChromosomeSpec.ofDouble(0.01, 0.05),  // Acceleration Factor Start
+          ChromosomeSpec.ofDouble(0.01, 0.05),  // Acceleration Factor Increment
+          ChromosomeSpec.ofDouble(0.1, 0.5)     // Acceleration Factor Max
+      );
+
+  @Override
+  public ImmutableList<ChromosomeSpec<?>> getChromosomeSpecs() {
+    return SPECS;
+  }
+
+  @Override
+  public Any createParameters(ImmutableList<? extends NumericChromosome<?, ?>> chromosomes) {
+    if (chromosomes.size() != SPECS.size()) {
+      throw new IllegalArgumentException(
+          "Expected " + SPECS.size() + " chromosomes but got " + chromosomes.size());
+    }
+
+    DoubleChromosome afStartChrom = (DoubleChromosome) chromosomes.get(0);
+    DoubleChromosome afIncrementChrom = (DoubleChromosome) chromosomes.get(1);
+    DoubleChromosome afMaxChrom = (DoubleChromosome) chromosomes.get(2);
+
+    double afStart = afStartChrom.gene().allele();
+    double afIncrement = afIncrementChrom.gene().allele();
+    double afMax = afMaxChrom.gene().allele();
+
+    // Ensure max >= start
+    if (afMax < afStart) {
+      afMax = afStart;
+    }
+
+    ParabolicSarParameters parameters =
+        ParabolicSarParameters.newBuilder()
+            .setAccelerationFactorStart(afStart)
+            .setAccelerationFactorIncrement(afIncrement)
+            .setAccelerationFactorMax(afMax)
+            .build();
+
+    return Any.pack(parameters);
+  }
+
+  @Override
+  public ImmutableList<? extends NumericChromosome<?, ?>> initialChromosomes() {
+    return SPECS.stream()
+        .map(ChromosomeSpec::createChromosome)
+        .collect(ImmutableList.toImmutableList());
+  }
+
+  @Override
+  public StrategyType getStrategyType() {
+    return StrategyType.PARABOLIC_SAR;
+  }
+}

--- a/src/main/java/com/verlumen/tradestream/strategies/parabolicsarr/ParabolicSarParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/parabolicsarr/ParabolicSarParamConfig.java
@@ -12,10 +12,10 @@ import io.jenetics.NumericChromosome;
 public final class ParabolicSarParamConfig implements ParamConfig {
   private static final ImmutableList<ChromosomeSpec<?>> SPECS =
       ImmutableList.of(
-          ChromosomeSpec.ofDouble(0.01, 0.05),  // Acceleration Factor Start
-          ChromosomeSpec.ofDouble(0.01, 0.05),  // Acceleration Factor Increment
-          ChromosomeSpec.ofDouble(0.1, 0.5)     // Acceleration Factor Max
-      );
+          ChromosomeSpec.ofDouble(0.01, 0.05), // Acceleration Factor Start
+          ChromosomeSpec.ofDouble(0.01, 0.05), // Acceleration Factor Increment
+          ChromosomeSpec.ofDouble(0.1, 0.5) // Acceleration Factor Max
+          );
 
   @Override
   public ImmutableList<ChromosomeSpec<?>> getChromosomeSpecs() {

--- a/src/main/java/com/verlumen/tradestream/strategies/parabolicsarr/ParabolicSarStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/parabolicsarr/ParabolicSarStrategyFactory.java
@@ -1,0 +1,63 @@
+package com.verlumen.tradestream.strategies.parabolicsarr;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.verlumen.tradestream.strategies.ParabolicSarParameters;
+import com.verlumen.tradestream.strategies.StrategyFactory;
+import com.verlumen.tradestream.strategies.StrategyType;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseStrategy;
+import org.ta4j.core.Rule;
+import org.ta4j.core.Strategy;
+import org.ta4j.core.indicators.ParabolicSarIndicator;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.rules.OverIndicatorRule;
+import org.ta4j.core.rules.UnderIndicatorRule;
+
+public final class ParabolicSarStrategyFactory implements StrategyFactory<ParabolicSarParameters> {
+  @Override
+  public Strategy createStrategy(BarSeries series, ParabolicSarParameters params) {
+    checkArgument(params.getAccelerationFactorStart() > 0, "Acceleration factor start must be positive");
+    checkArgument(params.getAccelerationFactorIncrement() > 0, "Acceleration factor increment must be positive");
+    checkArgument(params.getAccelerationFactorMax() > 0, "Acceleration factor max must be positive");
+    checkArgument(
+        params.getAccelerationFactorMax() >= params.getAccelerationFactorStart(),
+        "Acceleration factor max must be >= start");
+
+    ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
+    ParabolicSarIndicator psar = new ParabolicSarIndicator(series,
+        params.getAccelerationFactorStart(),
+        params.getAccelerationFactorIncrement(),
+        params.getAccelerationFactorMax());
+
+    // Entry rule: Buy when price crosses above Parabolic SAR
+    Rule entryRule = new OverIndicatorRule(closePrice, psar);
+
+    // Exit rule: Sell when price crosses below Parabolic SAR
+    Rule exitRule = new UnderIndicatorRule(closePrice, psar);
+
+    return new BaseStrategy(
+        String.format("%s (AF: %.3f-%.3f, Inc: %.3f)",
+            getStrategyType().name(),
+            params.getAccelerationFactorStart(),
+            params.getAccelerationFactorMax(),
+            params.getAccelerationFactorIncrement()),
+        entryRule,
+        exitRule,
+        1); // Minimal unstable period for PSAR
+  }
+
+  @Override
+  public ParabolicSarParameters getDefaultParameters() {
+    return ParabolicSarParameters.newBuilder()
+        .setAccelerationFactorStart(0.02)  // Standard PSAR start
+        .setAccelerationFactorIncrement(0.02)  // Standard increment
+        .setAccelerationFactorMax(0.2)  // Standard max
+        .build();
+  }
+
+  @Override
+  public StrategyType getStrategyType() {
+    return StrategyType.PARABOLIC_SAR;
+  }
+}

--- a/src/main/java/com/verlumen/tradestream/strategies/parabolicsarr/ParabolicSarStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/parabolicsarr/ParabolicSarStrategyFactory.java
@@ -39,7 +39,8 @@ public final class ParabolicSarStrategyFactory implements StrategyFactory<Parabo
     Rule exitRule = new UnderIndicatorRule(closePrice, psar);
 
     return new BaseStrategy(
-        String.format("%s (AF: %.3f-%.3f, Inc: %.3f)",
+        String.format(
+            "%s (AF: %.3f-%.3f, Inc: %.3f)",
             getStrategyType().name(),
             params.getAccelerationFactorStart(),
             params.getAccelerationFactorMax(),

--- a/src/main/java/com/verlumen/tradestream/strategies/parabolicsarr/ParabolicSarStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/parabolicsarr/ParabolicSarStrategyFactory.java
@@ -26,9 +26,9 @@ public final class ParabolicSarStrategyFactory implements StrategyFactory<Parabo
 
     ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
     ParabolicSarIndicator psar = new ParabolicSarIndicator(series,
-        params.getAccelerationFactorStart(),
-        params.getAccelerationFactorIncrement(),
-        params.getAccelerationFactorMax());
+        series.numOf(params.getAccelerationFactorStart()),
+        series.numOf(params.getAccelerationFactorIncrement()),
+        series.numOf(params.getAccelerationFactorMax()));
 
     // Entry rule: Buy when price crosses above Parabolic SAR
     Rule entryRule = new OverIndicatorRule(closePrice, psar);

--- a/src/main/java/com/verlumen/tradestream/strategies/parabolicsarr/ParabolicSarStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/parabolicsarr/ParabolicSarStrategyFactory.java
@@ -25,10 +25,12 @@ public final class ParabolicSarStrategyFactory implements StrategyFactory<Parabo
         "Acceleration factor max must be >= start");
 
     ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
-    ParabolicSarIndicator psar = new ParabolicSarIndicator(series,
-        series.numOf(params.getAccelerationFactorStart()),
-        series.numOf(params.getAccelerationFactorIncrement()),
-        series.numOf(params.getAccelerationFactorMax()));
+    ParabolicSarIndicator psar =
+        new ParabolicSarIndicator(
+            series,
+            series.numOf(params.getAccelerationFactorStart()),
+            series.numOf(params.getAccelerationFactorIncrement()),
+            series.numOf(params.getAccelerationFactorMax()));
 
     // Entry rule: Buy when price crosses above Parabolic SAR
     Rule entryRule = new OverIndicatorRule(closePrice, psar);

--- a/src/main/java/com/verlumen/tradestream/strategies/parabolicsarr/ParabolicSarStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/parabolicsarr/ParabolicSarStrategyFactory.java
@@ -17,9 +17,13 @@ import org.ta4j.core.rules.UnderIndicatorRule;
 public final class ParabolicSarStrategyFactory implements StrategyFactory<ParabolicSarParameters> {
   @Override
   public Strategy createStrategy(BarSeries series, ParabolicSarParameters params) {
-    checkArgument(params.getAccelerationFactorStart() > 0, "Acceleration factor start must be positive");
-    checkArgument(params.getAccelerationFactorIncrement() > 0, "Acceleration factor increment must be positive");
-    checkArgument(params.getAccelerationFactorMax() > 0, "Acceleration factor max must be positive");
+    checkArgument(
+        params.getAccelerationFactorStart() > 0, "Acceleration factor start must be positive");
+    checkArgument(
+        params.getAccelerationFactorIncrement() > 0,
+        "Acceleration factor increment must be positive");
+    checkArgument(
+        params.getAccelerationFactorMax() > 0, "Acceleration factor max must be positive");
     checkArgument(
         params.getAccelerationFactorMax() >= params.getAccelerationFactorStart(),
         "Acceleration factor max must be >= start");

--- a/src/main/java/com/verlumen/tradestream/strategies/parabolicsarr/ParabolicSarStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/parabolicsarr/ParabolicSarStrategyFactory.java
@@ -50,9 +50,9 @@ public final class ParabolicSarStrategyFactory implements StrategyFactory<Parabo
   @Override
   public ParabolicSarParameters getDefaultParameters() {
     return ParabolicSarParameters.newBuilder()
-        .setAccelerationFactorStart(0.02)  // Standard PSAR start
-        .setAccelerationFactorIncrement(0.02)  // Standard increment
-        .setAccelerationFactorMax(0.2)  // Standard max
+        .setAccelerationFactorStart(0.02) // Standard PSAR start
+        .setAccelerationFactorIncrement(0.02) // Standard increment
+        .setAccelerationFactorMax(0.2) // Standard max
         .build();
   }
 

--- a/src/test/java/com/verlumen/tradestream/strategies/parabolicsarr/BUILD
+++ b/src/test/java/com/verlumen/tradestream/strategies/parabolicsarr/BUILD
@@ -1,0 +1,33 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
+java_test(
+    name = "ParabolicSarParamConfigTest",
+    srcs = ["ParabolicSarParamConfigTest.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/discovery:chromosome_spec",
+        "//src/main/java/com/verlumen/tradestream/strategies/parabolicsarr:param_config",
+        "//third_party/java:guava",
+        "//third_party/java:jenetics",
+        "//third_party/java:junit",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:truth",
+    ],
+)
+
+java_test(
+    name = "ParabolicSarStrategyFactoryTest",
+    srcs = ["ParabolicSarStrategyFactoryTest.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/strategies:strategy_factory",
+        "//src/main/java/com/verlumen/tradestream/strategies/parabolicsarr:strategy_factory",
+        "//third_party/java:flogger",
+        "//third_party/java:guava",
+        "//third_party/java:junit",
+        "//third_party/java:mockito_core",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:ta4j_core",
+        "//third_party/java:truth",
+    ],
+)

--- a/src/test/java/com/verlumen/tradestream/strategies/parabolicsarr/ParabolicSarParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/parabolicsarr/ParabolicSarParamConfigTest.java
@@ -34,10 +34,10 @@ public class ParabolicSarParamConfigTest {
   public void testCreateParameters_validChromosomes_returnsPackedParameters() {
     List<NumericChromosome<?, ?>> chromosomes =
         List.of(
-            DoubleChromosome.of(0.01, 0.05),  // AF Start
-            DoubleChromosome.of(0.01, 0.05),  // AF Increment
-            DoubleChromosome.of(0.1, 0.5)     // AF Max
-        );
+            DoubleChromosome.of(0.01, 0.05), // AF Start
+            DoubleChromosome.of(0.01, 0.05), // AF Increment
+            DoubleChromosome.of(0.1, 0.5) // AF Max
+            );
 
     Any packedParams = config.createParameters(ImmutableList.copyOf(chromosomes));
     assertThat(packedParams.is(ParabolicSarParameters.class)).isTrue();

--- a/src/test/java/com/verlumen/tradestream/strategies/parabolicsarr/ParabolicSarParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/parabolicsarr/ParabolicSarParamConfigTest.java
@@ -1,0 +1,50 @@
+package com.verlumen.tradestream.strategies.parabolicsarr;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.verlumen.tradestream.discovery.ChromosomeSpec;
+import com.verlumen.tradestream.strategies.ParabolicSarParameters;
+import com.verlumen.tradestream.strategies.StrategyType;
+import io.jenetics.DoubleChromosome;
+import io.jenetics.NumericChromosome;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ParabolicSarParamConfigTest {
+  private ParabolicSarParamConfig config;
+
+  @Before
+  public void setUp() {
+    config = new ParabolicSarParamConfig();
+  }
+
+  @Test
+  public void testGetChromosomeSpecs_returnsExpectedSpecs() {
+    ImmutableList<ChromosomeSpec<?>> specs = config.getChromosomeSpecs();
+    assertThat(specs).hasSize(3);
+  }
+
+  @Test
+  public void testCreateParameters_validChromosomes_returnsPackedParameters() {
+    List<NumericChromosome<?, ?>> chromosomes =
+        List.of(
+            DoubleChromosome.of(0.01, 0.05),  // AF Start
+            DoubleChromosome.of(0.01, 0.05),  // AF Increment
+            DoubleChromosome.of(0.1, 0.5)     // AF Max
+        );
+
+    Any packedParams = config.createParameters(ImmutableList.copyOf(chromosomes));
+    assertThat(packedParams.is(ParabolicSarParameters.class)).isTrue();
+  }
+
+  @Test
+  public void testGetStrategyType_returnsExpectedType() {
+    assertThat(config.getStrategyType()).isEqualTo(StrategyType.PARABOLIC_SAR);
+  }
+}

--- a/src/test/java/com/verlumen/tradestream/strategies/parabolicsarr/ParabolicSarStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/parabolicsarr/ParabolicSarStrategyFactoryTest.java
@@ -55,11 +55,12 @@ public class ParabolicSarStrategyFactoryTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void validateAccelerationFactorStart() throws InvalidProtocolBufferException {
-    params = ParabolicSarParameters.newBuilder()
-        .setAccelerationFactorStart(-0.01)
-        .setAccelerationFactorIncrement(0.02)
-        .setAccelerationFactorMax(0.2)
-        .build();
+    params =
+        ParabolicSarParameters.newBuilder()
+            .setAccelerationFactorStart(-0.01)
+            .setAccelerationFactorIncrement(0.02)
+            .setAccelerationFactorMax(0.2)
+            .build();
     factory.createStrategy(series, params);
   }
 

--- a/src/test/java/com/verlumen/tradestream/strategies/parabolicsarr/ParabolicSarStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/parabolicsarr/ParabolicSarStrategyFactoryTest.java
@@ -1,0 +1,72 @@
+package com.verlumen.tradestream.strategies.parabolicsarr;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.verlumen.tradestream.strategies.ParabolicSarParameters;
+import com.verlumen.tradestream.strategies.StrategyType;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.ta4j.core.BaseBar;
+import org.ta4j.core.BaseBarSeries;
+import org.ta4j.core.Strategy;
+
+@RunWith(JUnit4.class)
+public class ParabolicSarStrategyFactoryTest {
+  private ParabolicSarStrategyFactory factory;
+  private ParabolicSarParameters params;
+  private BaseBarSeries series;
+
+  @Before
+  public void setUp() throws InvalidProtocolBufferException {
+    factory = new ParabolicSarStrategyFactory();
+    params =
+        ParabolicSarParameters.newBuilder()
+            .setAccelerationFactorStart(0.02)
+            .setAccelerationFactorIncrement(0.02)
+            .setAccelerationFactorMax(0.2)
+            .build();
+
+    series = new BaseBarSeries();
+    ZonedDateTime now = ZonedDateTime.now();
+
+    // Create test data
+    for (int i = 0; i < 50; i++) {
+      double price = 100 + 10 * Math.sin(i * 0.1);
+      series.addBar(createBar(now.plusMinutes(i), price));
+    }
+  }
+
+  @Test
+  public void getStrategyType_returnsParabolicSar() {
+    assertThat(factory.getStrategyType()).isEqualTo(StrategyType.PARABOLIC_SAR);
+  }
+
+  @Test
+  public void createStrategy_returnsValidStrategy() throws InvalidProtocolBufferException {
+    Strategy strategy = factory.createStrategy(series, params);
+    assertThat(strategy).isNotNull();
+    assertThat(strategy.getName()).contains("PARABOLIC_SAR");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void validateAccelerationFactorStart() throws InvalidProtocolBufferException {
+    params = ParabolicSarParameters.newBuilder()
+        .setAccelerationFactorStart(-0.01)
+        .setAccelerationFactorIncrement(0.02)
+        .setAccelerationFactorMax(0.2)
+        .build();
+    factory.createStrategy(series, params);
+  }
+
+  private BaseBar createBar(ZonedDateTime time, double price) {
+    return new BaseBar(
+        Duration.ofMinutes(1),
+        time,
+        price, price, price, price, 100.0);
+  }
+}

--- a/src/test/java/com/verlumen/tradestream/strategies/parabolicsarr/ParabolicSarStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/parabolicsarr/ParabolicSarStrategyFactoryTest.java
@@ -64,9 +64,6 @@ public class ParabolicSarStrategyFactoryTest {
   }
 
   private BaseBar createBar(ZonedDateTime time, double price) {
-    return new BaseBar(
-        Duration.ofMinutes(1),
-        time,
-        price, price, price, price, 100.0);
+    return new BaseBar(Duration.ofMinutes(1), time, price, price, price, price, 100.0);
   }
 }


### PR DESCRIPTION
This pull request introduces a new trading strategy based on the Parabolic SAR indicator. It includes:

* `ParabolicSarParamConfig`: Defines chromosome specifications and parameter creation for PSAR optimization.
* `ParabolicSarStrategyFactory`: Builds TA4J strategies using the PSAR indicator with provided parameters.
* Bazel `BUILD` files for both main and test packages to define new libraries and tests.
* Unit tests for both `ParabolicSarParamConfig` and `ParabolicSarStrategyFactory` to validate correctness and integration.

This update introduces a new strategy module, warranting a (MINOR) version bump due to the addition of new functionality.
