### PR TITLE
Add ATR Trailing Stop strategy with parameter configuration and unit tests (MINOR)

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopParamConfig.java
@@ -13,9 +13,9 @@ import io.jenetics.NumericChromosome;
 public final class AtrTrailingStopParamConfig implements ParamConfig {
   private static final ImmutableList<ChromosomeSpec<?>> SPECS =
       ImmutableList.of(
-          ChromosomeSpec.ofInteger(5, 30),   // ATR Period
-          ChromosomeSpec.ofDouble(1.0, 5.0)  // Multiplier
-      );
+          ChromosomeSpec.ofInteger(5, 30), // ATR Period
+          ChromosomeSpec.ofDouble(1.0, 5.0) // Multiplier
+          );
 
   @Override
   public ImmutableList<ChromosomeSpec<?>> getChromosomeSpecs() {

--- a/src/main/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopParamConfig.java
@@ -1,0 +1,55 @@
+package com.verlumen.tradestream.strategies.atrtrailingstop;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.verlumen.tradestream.discovery.ChromosomeSpec;
+import com.verlumen.tradestream.discovery.ParamConfig;
+import com.verlumen.tradestream.strategies.AtrTrailingStopParameters;
+import com.verlumen.tradestream.strategies.StrategyType;
+import io.jenetics.DoubleChromosome;
+import io.jenetics.IntegerChromosome;
+import io.jenetics.NumericChromosome;
+
+public final class AtrTrailingStopParamConfig implements ParamConfig {
+  private static final ImmutableList<ChromosomeSpec<?>> SPECS =
+      ImmutableList.of(
+          ChromosomeSpec.ofInteger(5, 30),   // ATR Period
+          ChromosomeSpec.ofDouble(1.0, 5.0)  // Multiplier
+      );
+
+  @Override
+  public ImmutableList<ChromosomeSpec<?>> getChromosomeSpecs() {
+    return SPECS;
+  }
+
+  @Override
+  public Any createParameters(ImmutableList<? extends NumericChromosome<?, ?>> chromosomes) {
+    if (chromosomes.size() != SPECS.size()) {
+      throw new IllegalArgumentException(
+          "Expected " + SPECS.size() + " chromosomes but got " + chromosomes.size());
+    }
+
+    IntegerChromosome atrPeriodChrom = (IntegerChromosome) chromosomes.get(0);
+    DoubleChromosome multiplierChrom = (DoubleChromosome) chromosomes.get(1);
+
+    AtrTrailingStopParameters parameters =
+        AtrTrailingStopParameters.newBuilder()
+            .setAtrPeriod(atrPeriodChrom.gene().allele())
+            .setMultiplier(multiplierChrom.gene().allele())
+            .build();
+
+    return Any.pack(parameters);
+  }
+
+  @Override
+  public ImmutableList<? extends NumericChromosome<?, ?>> initialChromosomes() {
+    return SPECS.stream()
+        .map(ChromosomeSpec::createChromosome)
+        .collect(ImmutableList.toImmutableList());
+  }
+
+  @Override
+  public StrategyType getStrategyType() {
+    return StrategyType.ATR_TRAILING_STOP;
+  }
+}

--- a/src/main/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopStrategyFactory.java
@@ -10,13 +10,44 @@ import org.ta4j.core.BaseStrategy;
 import org.ta4j.core.Rule;
 import org.ta4j.core.Strategy;
 import org.ta4j.core.indicators.ATRIndicator;
+import org.ta4j.core.indicators.CachedIndicator;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.indicators.helpers.PreviousValueIndicator;
-import org.ta4j.core.indicators.helpers.TransformIndicator;
+import org.ta4j.core.num.Num;
+import org.ta4j.core.rules.OverIndicatorRule;
 import org.ta4j.core.rules.UnderIndicatorRule;
 
 public final class AtrTrailingStopStrategyFactory
     implements StrategyFactory<AtrTrailingStopParameters> {
+
+  /**
+   * Custom indicator to calculate trailing stop: previousClose - (ATR * multiplier)
+   */
+  private static class TrailingStopIndicator extends CachedIndicator<Num> {
+    private final PreviousValueIndicator previousClose;
+    private final ATRIndicator atr;
+    private final double multiplier;
+
+    public TrailingStopIndicator(ClosePriceIndicator closePrice, ATRIndicator atr, double multiplier) {
+      super(closePrice);
+      this.previousClose = new PreviousValueIndicator(closePrice, 1);
+      this.atr = atr;
+      this.multiplier = multiplier;
+    }
+
+    @Override
+    protected Num calculate(int index) {
+      Num prevClose = previousClose.getValue(index);
+      Num atrValue = atr.getValue(index);
+      return prevClose.minus(atrValue.multipliedBy(numOf(multiplier)));
+    }
+
+    @Override
+    public int getUnstableBars() {
+      return Math.max(previousClose.getUnstableBars(), atr.getUnstableBars());
+    }
+  }
+
   @Override
   public Strategy createStrategy(BarSeries series, AtrTrailingStopParameters params) {
     checkArgument(params.getAtrPeriod() > 0, "ATR period must be positive");
@@ -26,13 +57,11 @@ public final class AtrTrailingStopStrategyFactory
     ATRIndicator atr = new ATRIndicator(series, params.getAtrPeriod());
     PreviousValueIndicator previousClose = new PreviousValueIndicator(closePrice, 1);
 
-    // Calculate trailing stop: previous close - (ATR * multiplier)
-    // In a real implementation, the trailing stop would move only upward for long positions
-    TransformIndicator atrMultiplied = TransformIndicator.multiply(atr, params.getMultiplier());
-    TransformIndicator trailingStop = TransformIndicator.minus(previousClose, atrMultiplied);
+    // Create custom trailing stop indicator
+    TrailingStopIndicator trailingStop = new TrailingStopIndicator(closePrice, atr, params.getMultiplier());
 
     // Entry rule: Simple momentum rule (price above previous close)
-    Rule entryRule = new UnderIndicatorRule(previousClose, closePrice);
+    Rule entryRule = new OverIndicatorRule(closePrice, previousClose);
 
     // Exit rule: Price falls below trailing stop level
     Rule exitRule = new UnderIndicatorRule(closePrice, trailingStop);

--- a/src/main/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopStrategyFactory.java
@@ -49,8 +49,8 @@ public final class AtrTrailingStopStrategyFactory
   @Override
   public AtrTrailingStopParameters getDefaultParameters() {
     return AtrTrailingStopParameters.newBuilder()
-        .setAtrPeriod(14)      // Standard ATR period
-        .setMultiplier(2.0)    // Common multiplier
+        .setAtrPeriod(14) // Standard ATR period
+        .setMultiplier(2.0) // Common multiplier
         .build();
   }
 

--- a/src/main/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopStrategyFactory.java
@@ -20,9 +20,7 @@ import org.ta4j.core.rules.UnderIndicatorRule;
 public final class AtrTrailingStopStrategyFactory
     implements StrategyFactory<AtrTrailingStopParameters> {
 
-  /**
-   * Custom indicator to calculate trailing stop: previousClose - (ATR * multiplier)
-   */
+  /** Custom indicator to calculate trailing stop: previousClose - (ATR * multiplier) */
   private static class TrailingStopIndicator extends CachedIndicator<Num> {
     private final PreviousValueIndicator previousClose;
     private final ATRIndicator atr;

--- a/src/main/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopStrategyFactory.java
@@ -1,0 +1,61 @@
+package com.verlumen.tradestream.strategies.atrtrailingstop;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.verlumen.tradestream.strategies.AtrTrailingStopParameters;
+import com.verlumen.tradestream.strategies.StrategyFactory;
+import com.verlumen.tradestream.strategies.StrategyType;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseStrategy;
+import org.ta4j.core.Rule;
+import org.ta4j.core.Strategy;
+import org.ta4j.core.indicators.ATRIndicator;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.indicators.helpers.PreviousValueIndicator;
+import org.ta4j.core.indicators.helpers.TransformIndicator;
+import org.ta4j.core.rules.UnderIndicatorRule;
+
+public final class AtrTrailingStopStrategyFactory implements StrategyFactory<AtrTrailingStopParameters> {
+  @Override
+  public Strategy createStrategy(BarSeries series, AtrTrailingStopParameters params) {
+    checkArgument(params.getAtrPeriod() > 0, "ATR period must be positive");
+    checkArgument(params.getMultiplier() > 0, "Multiplier must be positive");
+
+    ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
+    ATRIndicator atr = new ATRIndicator(series, params.getAtrPeriod());
+    PreviousValueIndicator previousClose = new PreviousValueIndicator(closePrice, 1);
+
+    // Calculate trailing stop: previous close - (ATR * multiplier)
+    // In a real implementation, the trailing stop would move only upward for long positions
+    TransformIndicator atrMultiplied = TransformIndicator.multiply(atr, params.getMultiplier());
+    TransformIndicator trailingStop = TransformIndicator.minus(previousClose, atrMultiplied);
+
+    // Entry rule: Simple momentum rule (price above previous close)
+    Rule entryRule = new UnderIndicatorRule(previousClose, closePrice);
+
+    // Exit rule: Price falls below trailing stop level
+    Rule exitRule = new UnderIndicatorRule(closePrice, trailingStop);
+
+    return new BaseStrategy(
+        String.format("%s (ATR: %d, Mult: %.2f)",
+            getStrategyType().name(),
+            params.getAtrPeriod(),
+            params.getMultiplier()),
+        entryRule,
+        exitRule,
+        params.getAtrPeriod());
+  }
+
+  @Override
+  public AtrTrailingStopParameters getDefaultParameters() {
+    return AtrTrailingStopParameters.newBuilder()
+        .setAtrPeriod(14)      // Standard ATR period
+        .setMultiplier(2.0)    // Common multiplier
+        .build();
+  }
+
+  @Override
+  public StrategyType getStrategyType() {
+    return StrategyType.ATR_TRAILING_STOP;
+  }
+}

--- a/src/main/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopStrategyFactory.java
@@ -28,7 +28,8 @@ public final class AtrTrailingStopStrategyFactory
     private final ATRIndicator atr;
     private final double multiplier;
 
-    public TrailingStopIndicator(ClosePriceIndicator closePrice, ATRIndicator atr, double multiplier) {
+    public TrailingStopIndicator(
+        ClosePriceIndicator closePrice, ATRIndicator atr, double multiplier) {
       super(closePrice);
       this.previousClose = new PreviousValueIndicator(closePrice, 1);
       this.atr = atr;

--- a/src/main/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopStrategyFactory.java
@@ -58,7 +58,8 @@ public final class AtrTrailingStopStrategyFactory
     PreviousValueIndicator previousClose = new PreviousValueIndicator(closePrice, 1);
 
     // Create custom trailing stop indicator
-    TrailingStopIndicator trailingStop = new TrailingStopIndicator(closePrice, atr, params.getMultiplier());
+    TrailingStopIndicator trailingStop =
+        new TrailingStopIndicator(closePrice, atr, params.getMultiplier());
 
     // Entry rule: Simple momentum rule (price above previous close)
     Rule entryRule = new OverIndicatorRule(closePrice, previousClose);

--- a/src/main/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopStrategyFactory.java
@@ -38,10 +38,9 @@ public final class AtrTrailingStopStrategyFactory
     Rule exitRule = new UnderIndicatorRule(closePrice, trailingStop);
 
     return new BaseStrategy(
-        String.format("%s (ATR: %d, Mult: %.2f)",
-            getStrategyType().name(),
-            params.getAtrPeriod(),
-            params.getMultiplier()),
+        String.format(
+            "%s (ATR: %d, Mult: %.2f)",
+            getStrategyType().name(), params.getAtrPeriod(), params.getMultiplier()),
         entryRule,
         exitRule,
         params.getAtrPeriod());

--- a/src/main/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopStrategyFactory.java
@@ -15,7 +15,8 @@ import org.ta4j.core.indicators.helpers.PreviousValueIndicator;
 import org.ta4j.core.indicators.helpers.TransformIndicator;
 import org.ta4j.core.rules.UnderIndicatorRule;
 
-public final class AtrTrailingStopStrategyFactory implements StrategyFactory<AtrTrailingStopParameters> {
+public final class AtrTrailingStopStrategyFactory
+    implements StrategyFactory<AtrTrailingStopParameters> {
   @Override
   public Strategy createStrategy(BarSeries series, AtrTrailingStopParameters params) {
     checkArgument(params.getAtrPeriod() > 0, "ATR period must be positive");

--- a/src/main/java/com/verlumen/tradestream/strategies/atrtrailingstop/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/atrtrailingstop/BUILD
@@ -1,0 +1,33 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
+package(
+    default_visibility = [
+        "//src/main/java/com/verlumen/tradestream/strategies:__pkg__",
+        "//src/test/java/com/verlumen/tradestream/strategies/atrtrailingstop:__pkg__",
+    ],
+)
+
+java_library(
+    name = "param_config",
+    srcs = ["AtrTrailingStopParamConfig.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/discovery:chromosome_spec",
+        "//src/main/java/com/verlumen/tradestream/discovery:param_config",
+        "//third_party/java:guava",
+        "//third_party/java:jenetics",
+        "//third_party/java:protobuf_java",
+    ],
+)
+
+java_library(
+    name = "strategy_factory",
+    srcs = ["AtrTrailingStopStrategyFactory.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/strategies:strategy_factory",
+        "//third_party/java:guava",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:ta4j_core",
+    ],
+)

--- a/src/test/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopParamConfigTest.java
@@ -96,7 +96,6 @@ public class AtrTrailingStopParamConfigTest {
 
     assertThat(params.getAtrPeriod()).isEqualTo(expectedAtrPeriod);
     assertThat(params.getMultiplier()).isEqualTo(expectedMultiplier);
-    
     // Also verify values are within expected ranges
     assertThat(params.getAtrPeriod()).isAtLeast(5);
     assertThat(params.getAtrPeriod()).isAtMost(30);

--- a/src/test/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopParamConfigTest.java
@@ -33,7 +33,6 @@ public class AtrTrailingStopParamConfigTest {
     // ATR Period: range 5-30
     assertThat(specs.get(0).getRange().lowerEndpoint()).isEqualTo(5);
     assertThat(specs.get(0).getRange().upperEndpoint()).isEqualTo(30);
-    
     // Multiplier: range 1.0-5.0
     assertThat(specs.get(1).getRange().lowerEndpoint()).isEqualTo(1.0);
     assertThat(specs.get(1).getRange().upperEndpoint()).isEqualTo(5.0);

--- a/src/test/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopParamConfigTest.java
@@ -30,7 +30,6 @@ public class AtrTrailingStopParamConfigTest {
   public void testGetChromosomeSpecs_returnsExpectedSpecs() {
     ImmutableList<ChromosomeSpec<?>> specs = config.getChromosomeSpecs();
     assertThat(specs).hasSize(2);
-    
     // ATR Period: range 5-30
     assertThat(specs.get(0).getRange().lowerEndpoint()).isEqualTo(5);
     assertThat(specs.get(0).getRange().upperEndpoint()).isEqualTo(30);

--- a/src/test/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopParamConfigTest.java
@@ -47,7 +47,7 @@ public class AtrTrailingStopParamConfigTest {
         List.of(
             IntegerChromosome.of(5, 30, 1), // ATR Period - single gene
             DoubleChromosome.of(1.0, 5.0) // Multiplier - defaults to single gene
-        );
+            );
 
     Any packedParams = config.createParameters(ImmutableList.copyOf(chromosomes));
     assertThat(packedParams.is(AtrTrailingStopParameters.class)).isTrue();

--- a/src/test/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopParamConfigTest.java
@@ -1,0 +1,96 @@
+package com.verlumen.tradestream.strategies.atrtrailingstop;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.verlumen.tradestream.discovery.ChromosomeSpec;
+import com.verlumen.tradestream.strategies.AtrTrailingStopParameters;
+import com.verlumen.tradestream.strategies.StrategyType;
+import io.jenetics.DoubleChromosome;
+import io.jenetics.IntegerChromosome;
+import io.jenetics.NumericChromosome;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class AtrTrailingStopParamConfigTest {
+  private AtrTrailingStopParamConfig config;
+
+  @Before
+  public void setUp() {
+    config = new AtrTrailingStopParamConfig();
+  }
+
+  @Test
+  public void testGetChromosomeSpecs_returnsExpectedSpecs() {
+    ImmutableList<ChromosomeSpec<?>> specs = config.getChromosomeSpecs();
+    assertThat(specs).hasSize(2);
+    
+    // ATR Period: range 5-30
+    assertThat(specs.get(0).getRange().lowerEndpoint()).isEqualTo(5);
+    assertThat(specs.get(0).getRange().upperEndpoint()).isEqualTo(30);
+    
+    // Multiplier: range 1.0-5.0
+    assertThat(specs.get(1).getRange().lowerEndpoint()).isEqualTo(1.0);
+    assertThat(specs.get(1).getRange().upperEndpoint()).isEqualTo(5.0);
+  }
+
+  @Test
+  public void testCreateParameters_validChromosomes_returnsPackedParameters() {
+    // Create chromosomes with correct parameter order: min, max, value
+    List<NumericChromosome<?, ?>> chromosomes =
+        List.of(
+            IntegerChromosome.of(5, 30, 14), // ATR Period
+            DoubleChromosome.of(1.0, 5.0, 2.0) // Multiplier
+        );
+
+    Any packedParams = config.createParameters(ImmutableList.copyOf(chromosomes));
+    assertThat(packedParams.is(AtrTrailingStopParameters.class)).isTrue();
+  }
+
+  @Test
+  public void testCreateParameters_invalidChromosomeSize_throwsException() {
+    // Create a single chromosome
+    List<NumericChromosome<?, ?>> chromosomes =
+        List.of(IntegerChromosome.of(5, 30, 14)); // Only one chromosome
+
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> config.createParameters(ImmutableList.copyOf(chromosomes)));
+    assertThat(thrown).hasMessageThat().contains("Expected 2 chromosomes but got 1");
+  }
+
+  @Test
+  public void testInitialChromosomes_returnsExpectedSize() {
+    ImmutableList<? extends NumericChromosome<?, ?>> chromosomes = config.initialChromosomes();
+    assertThat(chromosomes).hasSize(2);
+    assertThat(chromosomes.get(0)).isInstanceOf(IntegerChromosome.class);
+    assertThat(chromosomes.get(1)).isInstanceOf(DoubleChromosome.class);
+  }
+
+  @Test
+  public void testGetStrategyType_returnsExpectedType() {
+    assertThat(config.getStrategyType()).isEqualTo(StrategyType.ATR_TRAILING_STOP);
+  }
+
+  @Test
+  public void testCreateParameters_extractsCorrectValues() throws Exception {
+    // Create chromosomes with specific values
+    IntegerChromosome atrPeriodChrom = IntegerChromosome.of(5, 30, 20);
+    DoubleChromosome multiplierChrom = DoubleChromosome.of(1.0, 5.0, 2.5);
+
+    List<NumericChromosome<?, ?>> chromosomes = List.of(atrPeriodChrom, multiplierChrom);
+
+    Any packedParams = config.createParameters(ImmutableList.copyOf(chromosomes));
+    AtrTrailingStopParameters params = packedParams.unpack(AtrTrailingStopParameters.class);
+
+    assertThat(params.getAtrPeriod()).isEqualTo(20);
+    assertThat(params.getMultiplier()).isEqualTo(2.5);
+  }
+}

--- a/src/test/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopStrategyFactoryTest.java
@@ -141,10 +141,7 @@ public class AtrTrailingStopStrategyFactoryTest {
   @Test(expected = IllegalArgumentException.class)
   public void validateAtrPeriod() throws InvalidProtocolBufferException {
     params =
-        AtrTrailingStopParameters.newBuilder()
-            .setAtrPeriod(-1)
-            .setMultiplier(MULTIPLIER)
-            .build();
+        AtrTrailingStopParameters.newBuilder().setAtrPeriod(-1).setMultiplier(MULTIPLIER).build();
     factory.createStrategy(series, params);
   }
 

--- a/src/test/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopStrategyFactoryTest.java
@@ -162,7 +162,6 @@ public class AtrTrailingStopStrategyFactoryTest {
   @Test
   public void createStrategy_withValidParameters_returnsStrategy() throws InvalidProtocolBufferException {
     Strategy result = factory.createStrategy(series, params);
-    
     assertThat(result).isNotNull();
     assertThat(result.getName()).contains("ATR_TRAILING_STOP");
     assertThat(result.getName()).contains("ATR: 14");

--- a/src/test/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopStrategyFactoryTest.java
@@ -122,7 +122,6 @@ public class AtrTrailingStopStrategyFactoryTest {
       double prevClose = previousClose.getValue(i).doubleValue();
       double atr = atrIndicator.getValue(i).doubleValue();
       double trailingStop = prevClose - (atr * MULTIPLIER);
-      
       if (currentPrice < trailingStop) {
         exitIndex = i;
         System.out.printf(

--- a/src/test/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopStrategyFactoryTest.java
@@ -178,6 +178,6 @@ public class AtrTrailingStopStrategyFactoryTest {
         price - 1.0, // low (slightly lower for realistic ATR calculation)
         price, // close
         100.0 // volume
-    );
+        );
   }
 }

--- a/src/test/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopStrategyFactoryTest.java
@@ -1,0 +1,183 @@
+package com.verlumen.tradestream.strategies.atrtrailingstop;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.verlumen.tradestream.strategies.AtrTrailingStopParameters;
+import com.verlumen.tradestream.strategies.StrategyType;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.ta4j.core.BaseBar;
+import org.ta4j.core.BaseBarSeries;
+import org.ta4j.core.Strategy;
+import org.ta4j.core.indicators.ATRIndicator;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.indicators.helpers.PreviousValueIndicator;
+
+@RunWith(JUnit4.class)
+public class AtrTrailingStopStrategyFactoryTest {
+  private static final int ATR_PERIOD = 14;
+  private static final double MULTIPLIER = 2.0;
+
+  private AtrTrailingStopStrategyFactory factory;
+  private AtrTrailingStopParameters params;
+  private BaseBarSeries series;
+  private Strategy strategy;
+
+  // For debugging calculations
+  private ATRIndicator atrIndicator;
+  private ClosePriceIndicator closePrice;
+  private PreviousValueIndicator previousClose;
+
+  @Before
+  public void setUp() throws InvalidProtocolBufferException {
+    factory = new AtrTrailingStopStrategyFactory();
+
+    // Standard parameters
+    params =
+        AtrTrailingStopParameters.newBuilder()
+            .setAtrPeriod(ATR_PERIOD)
+            .setMultiplier(MULTIPLIER)
+            .build();
+
+    // Initialize series
+    series = new BaseBarSeries();
+    ZonedDateTime now = ZonedDateTime.now();
+
+    // Create sample price data with initial uptrend then downtrend
+    // Initial stable period
+    for (int i = 0; i < 10; i++) {
+      series.addBar(createBar(now.plusMinutes(i), 50.0));
+    }
+
+    // Upward movement
+    for (int i = 10; i < 15; i++) {
+      double price = 50.0 + (i - 9) * 2; // Increasing by 2 each bar
+      series.addBar(createBar(now.plusMinutes(i), price));
+    }
+
+    // Sharp downward movement to trigger trailing stop
+    series.addBar(createBar(now.plusMinutes(15), 55.0));
+    series.addBar(createBar(now.plusMinutes(16), 52.0));
+    series.addBar(createBar(now.plusMinutes(17), 48.0));
+    series.addBar(createBar(now.plusMinutes(18), 45.0));
+
+    // Initialize indicators
+    closePrice = new ClosePriceIndicator(series);
+    atrIndicator = new ATRIndicator(series, ATR_PERIOD);
+    previousClose = new PreviousValueIndicator(closePrice, 1);
+
+    // Create strategy
+    strategy = factory.createStrategy(series, params);
+  }
+
+  @Test
+  public void getStrategyType_returnsAtrTrailingStop() {
+    assertThat(factory.getStrategyType()).isEqualTo(StrategyType.ATR_TRAILING_STOP);
+  }
+
+  @Test
+  public void getDefaultParameters_returnsValidDefaults() {
+    AtrTrailingStopParameters defaults = factory.getDefaultParameters();
+    
+    assertThat(defaults.getAtrPeriod()).isEqualTo(14);
+    assertThat(defaults.getMultiplier()).isEqualTo(2.0);
+  }
+
+  @Test
+  public void entryRule_shouldTrigger_whenPriceRisesAbovePreviousClose() {
+    // Entry rule: current price > previous close (simple momentum)
+    // Look for a bar where price is above previous close
+    int entryIndex = -1;
+    for (int i = 1; i < series.getBarCount(); i++) {
+      if (closePrice.getValue(i).doubleValue() > previousClose.getValue(i).doubleValue()) {
+        entryIndex = i;
+        break;
+      }
+    }
+
+    if (entryIndex > 0) {
+      System.out.printf(
+          "Entry at Bar %d - Current Price: %.2f, Previous Close: %.2f%n",
+          entryIndex,
+          closePrice.getValue(entryIndex).doubleValue(),
+          previousClose.getValue(entryIndex).doubleValue());
+      assertThat(strategy.getEntryRule().isSatisfied(entryIndex)).isTrue();
+    } else {
+      System.out.println("No entry signal found with current data and parameters.");
+    }
+  }
+
+  @Test
+  public void exitRule_shouldTrigger_whenPriceFallsBelowTrailingStop() {
+    // Exit rule: price falls below trailing stop (previous close - ATR * multiplier)
+    // Look for a bar where this condition is met
+    int exitIndex = -1;
+    for (int i = ATR_PERIOD; i < series.getBarCount(); i++) {
+      double currentPrice = closePrice.getValue(i).doubleValue();
+      double prevClose = previousClose.getValue(i).doubleValue();
+      double atr = atrIndicator.getValue(i).doubleValue();
+      double trailingStop = prevClose - (atr * MULTIPLIER);
+      
+      if (currentPrice < trailingStop) {
+        exitIndex = i;
+        System.out.printf(
+            "Exit at Bar %d - Price: %.2f, Previous Close: %.2f, ATR: %.2f, Trailing Stop: %.2f%n",
+            exitIndex, currentPrice, prevClose, atr, trailingStop);
+        break;
+      }
+    }
+
+    if (exitIndex > 0) {
+      assertThat(strategy.getExitRule().isSatisfied(exitIndex)).isTrue();
+    } else {
+      System.out.println("No exit signal found with current data and parameters.");
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void validateAtrPeriod() throws InvalidProtocolBufferException {
+    params =
+        AtrTrailingStopParameters.newBuilder()
+            .setAtrPeriod(-1)
+            .setMultiplier(MULTIPLIER)
+            .build();
+    factory.createStrategy(series, params);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void validateMultiplier() throws InvalidProtocolBufferException {
+    params =
+        AtrTrailingStopParameters.newBuilder()
+            .setAtrPeriod(ATR_PERIOD)
+            .setMultiplier(-1.0)
+            .build();
+    factory.createStrategy(series, params);
+  }
+
+  @Test
+  public void createStrategy_withValidParameters_returnsStrategy() throws InvalidProtocolBufferException {
+    Strategy result = factory.createStrategy(series, params);
+    
+    assertThat(result).isNotNull();
+    assertThat(result.getName()).contains("ATR_TRAILING_STOP");
+    assertThat(result.getName()).contains("ATR: 14");
+    assertThat(result.getName()).contains("Mult: 2.00");
+  }
+
+  private BaseBar createBar(ZonedDateTime time, double price) {
+    return new BaseBar(
+        Duration.ofMinutes(1),
+        time,
+        price, // open
+        price + 1.0, // high (slightly higher for realistic ATR calculation)
+        price - 1.0, // low (slightly lower for realistic ATR calculation)
+        price, // close
+        100.0 // volume
+    );
+  }
+}

--- a/src/test/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopStrategyFactoryTest.java
@@ -160,7 +160,8 @@ public class AtrTrailingStopStrategyFactoryTest {
   }
 
   @Test
-  public void createStrategy_withValidParameters_returnsStrategy() throws InvalidProtocolBufferException {
+  public void createStrategy_withValidParameters_returnsStrategy()
+      throws InvalidProtocolBufferException {
     Strategy result = factory.createStrategy(series, params);
     assertThat(result).isNotNull();
     assertThat(result.getName()).contains("ATR_TRAILING_STOP");

--- a/src/test/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopStrategyFactoryTest.java
@@ -152,10 +152,7 @@ public class AtrTrailingStopStrategyFactoryTest {
   @Test(expected = IllegalArgumentException.class)
   public void validateMultiplier() throws InvalidProtocolBufferException {
     params =
-        AtrTrailingStopParameters.newBuilder()
-            .setAtrPeriod(ATR_PERIOD)
-            .setMultiplier(-1.0)
-            .build();
+        AtrTrailingStopParameters.newBuilder().setAtrPeriod(ATR_PERIOD).setMultiplier(-1.0).build();
     factory.createStrategy(series, params);
   }
 

--- a/src/test/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopStrategyFactoryTest.java
@@ -83,7 +83,6 @@ public class AtrTrailingStopStrategyFactoryTest {
   @Test
   public void getDefaultParameters_returnsValidDefaults() {
     AtrTrailingStopParameters defaults = factory.getDefaultParameters();
-    
     assertThat(defaults.getAtrPeriod()).isEqualTo(14);
     assertThat(defaults.getMultiplier()).isEqualTo(2.0);
   }

--- a/src/test/java/com/verlumen/tradestream/strategies/atrtrailingstop/BUILD
+++ b/src/test/java/com/verlumen/tradestream/strategies/atrtrailingstop/BUILD
@@ -1,0 +1,33 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
+java_test(
+    name = "AtrTrailingStopParamConfigTest",
+    srcs = ["AtrTrailingStopParamConfigTest.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/discovery:chromosome_spec",
+        "//src/main/java/com/verlumen/tradestream/strategies/atrtrailingstop:param_config",
+        "//third_party/java:guava",
+        "//third_party/java:jenetics",
+        "//third_party/java:junit",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:truth",
+    ],
+)
+
+java_test(
+    name = "AtrTrailingStopStrategyFactoryTest",
+    srcs = ["AtrTrailingStopStrategyFactoryTest.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/strategies:strategy_factory",
+        "//src/main/java/com/verlumen/tradestream/strategies/atrtrailingstop:strategy_factory",
+        "//third_party/java:flogger",
+        "//third_party/java:guava",
+        "//third_party/java:junit",
+        "//third_party/java:mockito_core",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:ta4j_core",
+        "//third_party/java:truth",
+    ],
+)


### PR DESCRIPTION
This pull request introduces the ATR Trailing Stop strategy implementation within the `tradestream` platform. It includes:

* **Strategy Factory (`AtrTrailingStopStrategyFactory`)**:

  * Implements the logic for the ATR trailing stop strategy.
  * Defines entry and exit rules based on price movements relative to ATR-based trailing stop levels.
  * Includes a custom `TrailingStopIndicator` for dynamic exit logic.
  * Provides default strategy parameters and validation.

* **Parameter Configuration (`AtrTrailingStopParamConfig`)**:

  * Specifies chromosome specs for ATR period (int: 5–30) and multiplier (double: 1.0–5.0).
  * Supports creation and unpacking of strategy parameters using ProtoBuf `Any`.

* **Testing**:

  * Comprehensive JUnit tests for both factory and parameter configuration.
  * Includes validation, default behaviors, and realistic strategy triggering scenarios.

* **Build Files**:

  * Adds appropriate `BUILD` definitions for the new strategy and test classes.

This change introduces a new strategy feature and should be considered a **(MINOR)** version update.
