### PR TITLE
 Add ATR-CCI Strategy Implementation and Configuration

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/atrcci/AtrCciParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/atrcci/AtrCciParamConfig.java
@@ -1,0 +1,54 @@
+package com.verlumen.tradestream.strategies.atrcci;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.verlumen.tradestream.discovery.ChromosomeSpec;
+import com.verlumen.tradestream.discovery.ParamConfig;
+import com.verlumen.tradestream.strategies.AtrCciParameters;
+import com.verlumen.tradestream.strategies.StrategyType;
+import io.jenetics.IntegerChromosome;
+import io.jenetics.NumericChromosome;
+
+public final class AtrCciParamConfig implements ParamConfig {
+  private static final ImmutableList<ChromosomeSpec<?>> SPECS =
+      ImmutableList.of(
+          ChromosomeSpec.ofInteger(5, 30),  // ATR Period
+          ChromosomeSpec.ofInteger(10, 50)  // CCI Period
+      );
+
+  @Override
+  public ImmutableList<ChromosomeSpec<?>> getChromosomeSpecs() {
+    return SPECS;
+  }
+
+  @Override
+  public Any createParameters(ImmutableList<? extends NumericChromosome<?, ?>> chromosomes) {
+    if (chromosomes.size() != SPECS.size()) {
+      throw new IllegalArgumentException(
+          "Expected " + SPECS.size() + " chromosomes but got " + chromosomes.size());
+    }
+
+    IntegerChromosome atrPeriodChrom = (IntegerChromosome) chromosomes.get(0);
+    IntegerChromosome cciPeriodChrom = (IntegerChromosome) chromosomes.get(1);
+
+    AtrCciParameters parameters =
+        AtrCciParameters.newBuilder()
+            .setAtrPeriod(atrPeriodChrom.gene().allele())
+            .setCciPeriod(cciPeriodChrom.gene().allele())
+            .build();
+
+    return Any.pack(parameters);
+  }
+
+  @Override
+  public ImmutableList<? extends NumericChromosome<?, ?>> initialChromosomes() {
+    return SPECS.stream()
+        .map(ChromosomeSpec::createChromosome)
+        .collect(ImmutableList.toImmutableList());
+  }
+
+  @Override
+  public StrategyType getStrategyType() {
+    return StrategyType.ATR_CCI;
+  }
+}

--- a/src/main/java/com/verlumen/tradestream/strategies/atrcci/AtrCciParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/atrcci/AtrCciParamConfig.java
@@ -46,9 +46,4 @@ public final class AtrCciParamConfig implements ParamConfig {
         .map(ChromosomeSpec::createChromosome)
         .collect(ImmutableList.toImmutableList());
   }
-
-  @Override
-  public StrategyType getStrategyType() {
-    return StrategyType.ATR_CCI;
-  }
 }

--- a/src/main/java/com/verlumen/tradestream/strategies/atrcci/AtrCciParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/atrcci/AtrCciParamConfig.java
@@ -12,9 +12,9 @@ import io.jenetics.NumericChromosome;
 public final class AtrCciParamConfig implements ParamConfig {
   private static final ImmutableList<ChromosomeSpec<?>> SPECS =
       ImmutableList.of(
-          ChromosomeSpec.ofInteger(5, 30),  // ATR Period
-          ChromosomeSpec.ofInteger(10, 50)  // CCI Period
-      );
+          ChromosomeSpec.ofInteger(5, 30), // ATR Period
+          ChromosomeSpec.ofInteger(10, 50) // CCI Period
+          );
 
   @Override
   public ImmutableList<ChromosomeSpec<?>> getChromosomeSpecs() {

--- a/src/main/java/com/verlumen/tradestream/strategies/atrcci/AtrCciParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/atrcci/AtrCciParamConfig.java
@@ -5,7 +5,6 @@ import com.google.protobuf.Any;
 import com.verlumen.tradestream.discovery.ChromosomeSpec;
 import com.verlumen.tradestream.discovery.ParamConfig;
 import com.verlumen.tradestream.strategies.AtrCciParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import io.jenetics.IntegerChromosome;
 import io.jenetics.NumericChromosome;
 

--- a/src/main/java/com/verlumen/tradestream/strategies/atrcci/AtrCciStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/atrcci/AtrCciStrategyFactory.java
@@ -1,0 +1,58 @@
+package com.verlumen.tradestream.strategies.atrcci;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.verlumen.tradestream.strategies.AtrCciParameters;
+import com.verlumen.tradestream.strategies.StrategyFactory;
+import com.verlumen.tradestream.strategies.StrategyType;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseStrategy;
+import org.ta4j.core.Rule;
+import org.ta4j.core.Strategy;
+import org.ta4j.core.indicators.ATRIndicator;
+import org.ta4j.core.indicators.CCIIndicator;
+import org.ta4j.core.indicators.helpers.PreviousValueIndicator;
+import org.ta4j.core.rules.OverIndicatorRule;
+import org.ta4j.core.rules.UnderIndicatorRule;
+
+public final class AtrCciStrategyFactory implements StrategyFactory<AtrCciParameters> {
+  @Override
+  public Strategy createStrategy(BarSeries series, AtrCciParameters params) {
+    checkArgument(params.getAtrPeriod() > 0, "ATR period must be positive");
+    checkArgument(params.getCciPeriod() > 0, "CCI period must be positive");
+
+    ATRIndicator atr = new ATRIndicator(series, params.getAtrPeriod());
+    CCIIndicator cci = new CCIIndicator(series, params.getCciPeriod());
+    PreviousValueIndicator previousAtr = new PreviousValueIndicator(atr, 1);
+
+    // Entry rule: CCI crosses above -100 AND ATR is increasing (indicating rising volatility)
+    Rule entryRule = new OverIndicatorRule(cci, series.numOf(-100))
+        .and(new OverIndicatorRule(atr, previousAtr));
+
+    // Exit rule: CCI crosses below +100 AND ATR is decreasing (indicating falling volatility)  
+    Rule exitRule = new UnderIndicatorRule(cci, series.numOf(100))
+        .and(new UnderIndicatorRule(atr, previousAtr));
+
+    return new BaseStrategy(
+        String.format("%s (ATR: %d, CCI: %d)",
+            getStrategyType().name(),
+            params.getAtrPeriod(),
+            params.getCciPeriod()),
+        entryRule,
+        exitRule,
+        Math.max(params.getAtrPeriod(), params.getCciPeriod()));
+  }
+
+  @Override
+  public AtrCciParameters getDefaultParameters() {
+    return AtrCciParameters.newBuilder()
+        .setAtrPeriod(14)  // Standard ATR period
+        .setCciPeriod(20)  // Standard CCI period
+        .build();
+  }
+
+  @Override
+  public StrategyType getStrategyType() {
+    return StrategyType.ATR_CCI;
+  }
+}

--- a/src/main/java/com/verlumen/tradestream/strategies/atrcci/AtrCciStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/atrcci/AtrCciStrategyFactory.java
@@ -26,8 +26,8 @@ public final class AtrCciStrategyFactory implements StrategyFactory<AtrCciParame
     PreviousValueIndicator previousAtr = new PreviousValueIndicator(atr, 1);
 
     // Entry rule: CCI crosses above -100 AND ATR is increasing (indicating rising volatility)
-    Rule entryRule = new OverIndicatorRule(cci, series.numOf(-100))
-        .and(new OverIndicatorRule(atr, previousAtr));
+    Rule entryRule =
+        new OverIndicatorRule(cci, series.numOf(-100)).and(new OverIndicatorRule(atr, previousAtr));
 
     // Exit rule: CCI crosses below +100 AND ATR is decreasing (indicating falling volatility)
     Rule exitRule =

--- a/src/main/java/com/verlumen/tradestream/strategies/atrcci/AtrCciStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/atrcci/AtrCciStrategyFactory.java
@@ -37,7 +37,7 @@ public final class AtrCciStrategyFactory implements StrategyFactory<AtrCciParame
     return new BaseStrategy(
         String.format(
             "%s (ATR: %d, CCI: %d)",
-            getStrategyType().name(), params.getAtrPeriod(), params.getCciPeriod()),
+            StrategyType.ATR_CCI.name(), params.getAtrPeriod(), params.getCciPeriod()),
         entryRule,
         exitRule,
         Math.max(params.getAtrPeriod(), params.getCciPeriod()));
@@ -49,10 +49,5 @@ public final class AtrCciStrategyFactory implements StrategyFactory<AtrCciParame
         .setAtrPeriod(14) // Standard ATR period
         .setCciPeriod(20) // Standard CCI period
         .build();
-  }
-
-  @Override
-  public StrategyType getStrategyType() {
-    return StrategyType.ATR_CCI;
   }
 }

--- a/src/main/java/com/verlumen/tradestream/strategies/atrcci/AtrCciStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/atrcci/AtrCciStrategyFactory.java
@@ -46,8 +46,8 @@ public final class AtrCciStrategyFactory implements StrategyFactory<AtrCciParame
   @Override
   public AtrCciParameters getDefaultParameters() {
     return AtrCciParameters.newBuilder()
-        .setAtrPeriod(14)  // Standard ATR period
-        .setCciPeriod(20)  // Standard CCI period
+        .setAtrPeriod(14) // Standard ATR period
+        .setCciPeriod(20) // Standard CCI period
         .build();
   }
 

--- a/src/main/java/com/verlumen/tradestream/strategies/atrcci/AtrCciStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/atrcci/AtrCciStrategyFactory.java
@@ -34,10 +34,9 @@ public final class AtrCciStrategyFactory implements StrategyFactory<AtrCciParame
         .and(new UnderIndicatorRule(atr, previousAtr));
 
     return new BaseStrategy(
-        String.format("%s (ATR: %d, CCI: %d)",
-            getStrategyType().name(),
-            params.getAtrPeriod(),
-            params.getCciPeriod()),
+        String.format(
+            "%s (ATR: %d, CCI: %d)",
+            getStrategyType().name(), params.getAtrPeriod(), params.getCciPeriod()),
         entryRule,
         exitRule,
         Math.max(params.getAtrPeriod(), params.getCciPeriod()));

--- a/src/main/java/com/verlumen/tradestream/strategies/atrcci/AtrCciStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/atrcci/AtrCciStrategyFactory.java
@@ -29,9 +29,10 @@ public final class AtrCciStrategyFactory implements StrategyFactory<AtrCciParame
     Rule entryRule = new OverIndicatorRule(cci, series.numOf(-100))
         .and(new OverIndicatorRule(atr, previousAtr));
 
-    // Exit rule: CCI crosses below +100 AND ATR is decreasing (indicating falling volatility)  
-    Rule exitRule = new UnderIndicatorRule(cci, series.numOf(100))
-        .and(new UnderIndicatorRule(atr, previousAtr));
+    // Exit rule: CCI crosses below +100 AND ATR is decreasing (indicating falling volatility)
+    Rule exitRule =
+        new UnderIndicatorRule(cci, series.numOf(100))
+            .and(new UnderIndicatorRule(atr, previousAtr));
 
     return new BaseStrategy(
         String.format(

--- a/src/main/java/com/verlumen/tradestream/strategies/atrcci/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/atrcci/BUILD
@@ -1,0 +1,33 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
+package(
+    default_visibility = [
+        "//src/main/java/com/verlumen/tradestream/strategies:__pkg__",
+        "//src/test/java/com/verlumen/tradestream/strategies/atrcci:__pkg__",
+    ],
+)
+
+java_library(
+    name = "param_config",
+    srcs = ["AtrCciParamConfig.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/discovery:chromosome_spec",
+        "//src/main/java/com/verlumen/tradestream/discovery:param_config",
+        "//third_party/java:guava",
+        "//third_party/java:jenetics",
+        "//third_party/java:protobuf_java",
+    ],
+)
+
+java_library(
+    name = "strategy_factory",
+    srcs = ["AtrCciStrategyFactory.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/strategies:strategy_factory",
+        "//third_party/java:guava",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:ta4j_core",
+    ],
+)

--- a/src/main/java/com/verlumen/tradestream/strategies/atrtrailingstop/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/atrtrailingstop/BUILD
@@ -1,0 +1,33 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
+package(
+    default_visibility = [
+        "//src/main/java/com/verlumen/tradestream/strategies:__pkg__",
+        "//src/test/java/com/verlumen/tradestream/strategies/atrtrailingstop:__pkg__",
+    ],
+)
+
+java_library(
+    name = "param_config",
+    srcs = ["AtrTrailingStopParamConfig.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/discovery:chromosome_spec",
+        "//src/main/java/com/verlumen/tradestream/discovery:param_config",
+        "//third_party/java:guava",
+        "//third_party/java:jenetics",
+        "//third_party/java:protobuf_java",
+    ],
+)
+
+java_library(
+    name = "strategy_factory",
+    srcs = ["AtrTrailingStopStrategyFactory.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/strategies:strategy_factory",
+        "//third_party/java:guava",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:ta4j_core",
+    ],
+)

--- a/src/main/java/com/verlumen/tradestream/strategies/atrtrailingstop/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/atrtrailingstop/BUILD
@@ -1,4 +1,4 @@
-load("@rules_java//java:defs.bzl", "java_library")
+load("@rules_java//java:defs.bzl", "java_library") 
 
 package(
     default_visibility = [

--- a/src/test/java/com/verlumen/tradestream/strategies/atrcci/AtrCciParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/atrcci/AtrCciParamConfigTest.java
@@ -7,7 +7,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;
 import com.verlumen.tradestream.discovery.ChromosomeSpec;
 import com.verlumen.tradestream.strategies.AtrCciParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import io.jenetics.IntegerChromosome;
 import io.jenetics.NumericChromosome;
 import java.util.List;

--- a/src/test/java/com/verlumen/tradestream/strategies/atrcci/AtrCciParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/atrcci/AtrCciParamConfigTest.java
@@ -33,7 +33,6 @@ public class AtrCciParamConfigTest {
     // ATR Period: range 5-30
     assertThat(specs.get(0).getRange().lowerEndpoint()).isEqualTo(5);
     assertThat(specs.get(0).getRange().upperEndpoint()).isEqualTo(30);
-    
     // CCI Period: range 10-50
     assertThat(specs.get(1).getRange().lowerEndpoint()).isEqualTo(10);
     assertThat(specs.get(1).getRange().upperEndpoint()).isEqualTo(50);

--- a/src/test/java/com/verlumen/tradestream/strategies/atrcci/AtrCciParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/atrcci/AtrCciParamConfigTest.java
@@ -70,11 +70,6 @@ public class AtrCciParamConfigTest {
   }
 
   @Test
-  public void testGetStrategyType_returnsExpectedType() {
-    assertThat(config.getStrategyType()).isEqualTo(StrategyType.ATR_CCI);
-  }
-
-  @Test
   public void testCreateParameters_extractsValuesInCorrectRanges() throws Exception {
     // Create chromosomes and extract their actual values for testing
     IntegerChromosome atrPeriodChrom = IntegerChromosome.of(5, 30, 1);

--- a/src/test/java/com/verlumen/tradestream/strategies/atrcci/AtrCciParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/atrcci/AtrCciParamConfigTest.java
@@ -1,0 +1,103 @@
+package com.verlumen.tradestream.strategies.atrcci;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.verlumen.tradestream.discovery.ChromosomeSpec;
+import com.verlumen.tradestream.strategies.AtrCciParameters;
+import com.verlumen.tradestream.strategies.StrategyType;
+import io.jenetics.IntegerChromosome;
+import io.jenetics.NumericChromosome;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class AtrCciParamConfigTest {
+  private AtrCciParamConfig config;
+
+  @Before
+  public void setUp() {
+    config = new AtrCciParamConfig();
+  }
+
+  @Test
+  public void testGetChromosomeSpecs_returnsExpectedSpecs() {
+    ImmutableList<ChromosomeSpec<?>> specs = config.getChromosomeSpecs();
+    assertThat(specs).hasSize(2);
+    
+    // ATR Period: range 5-30
+    assertThat(specs.get(0).getRange().lowerEndpoint()).isEqualTo(5);
+    assertThat(specs.get(0).getRange().upperEndpoint()).isEqualTo(30);
+    
+    // CCI Period: range 10-50
+    assertThat(specs.get(1).getRange().lowerEndpoint()).isEqualTo(10);
+    assertThat(specs.get(1).getRange().upperEndpoint()).isEqualTo(50);
+  }
+
+  @Test
+  public void testCreateParameters_validChromosomes_returnsPackedParameters() {
+    List<NumericChromosome<?, ?>> chromosomes =
+        List.of(
+            IntegerChromosome.of(5, 30, 14), // ATR Period
+            IntegerChromosome.of(10, 50, 20) // CCI Period
+            );
+
+    Any packedParams = config.createParameters(ImmutableList.copyOf(chromosomes));
+    assertThat(packedParams.is(AtrCciParameters.class)).isTrue();
+  }
+
+  @Test
+  public void testCreateParameters_invalidChromosomeSize_throwsException() {
+    List<NumericChromosome<?, ?>> chromosomes =
+        List.of(IntegerChromosome.of(5, 30, 14)); // Only one chromosome
+
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> config.createParameters(ImmutableList.copyOf(chromosomes)));
+    assertThat(thrown).hasMessageThat().contains("Expected 2 chromosomes but got 1");
+  }
+
+  @Test
+  public void testInitialChromosomes_returnsExpectedSize() {
+    ImmutableList<? extends NumericChromosome<?, ?>> chromosomes = config.initialChromosomes();
+    assertThat(chromosomes).hasSize(2);
+    assertThat(chromosomes.get(0)).isInstanceOf(IntegerChromosome.class);
+    assertThat(chromosomes.get(1)).isInstanceOf(IntegerChromosome.class);
+  }
+
+  @Test
+  public void testGetStrategyType_returnsExpectedType() {
+    assertThat(config.getStrategyType()).isEqualTo(StrategyType.ATR_CCI);
+  }
+
+  @Test
+  public void testCreateParameters_extractsValuesInCorrectRanges() throws Exception {
+    // Create chromosomes and extract their actual values for testing
+    IntegerChromosome atrPeriodChrom = IntegerChromosome.of(5, 30, 1);
+    IntegerChromosome cciPeriodChrom = IntegerChromosome.of(10, 50, 1);
+
+    List<NumericChromosome<?, ?>> chromosomes = List.of(atrPeriodChrom, cciPeriodChrom);
+
+    Any packedParams = config.createParameters(ImmutableList.copyOf(chromosomes));
+    AtrCciParameters params = packedParams.unpack(AtrCciParameters.class);
+
+    // Extract the actual values from chromosomes
+    int expectedAtrPeriod = atrPeriodChrom.gene().allele();
+    int expectedCciPeriod = cciPeriodChrom.gene().allele();
+
+    assertThat(params.getAtrPeriod()).isEqualTo(expectedAtrPeriod);
+    assertThat(params.getCciPeriod()).isEqualTo(expectedCciPeriod);
+    
+    // Also verify values are within expected ranges
+    assertThat(params.getAtrPeriod()).isAtLeast(5);
+    assertThat(params.getAtrPeriod()).isAtMost(30);
+    assertThat(params.getCciPeriod()).isAtLeast(10);
+    assertThat(params.getCciPeriod()).isAtMost(50);
+  }
+}

--- a/src/test/java/com/verlumen/tradestream/strategies/atrcci/AtrCciParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/atrcci/AtrCciParamConfigTest.java
@@ -29,7 +29,6 @@ public class AtrCciParamConfigTest {
   public void testGetChromosomeSpecs_returnsExpectedSpecs() {
     ImmutableList<ChromosomeSpec<?>> specs = config.getChromosomeSpecs();
     assertThat(specs).hasSize(2);
-    
     // ATR Period: range 5-30
     assertThat(specs.get(0).getRange().lowerEndpoint()).isEqualTo(5);
     assertThat(specs.get(0).getRange().upperEndpoint()).isEqualTo(30);

--- a/src/test/java/com/verlumen/tradestream/strategies/atrcci/AtrCciParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/atrcci/AtrCciParamConfigTest.java
@@ -93,7 +93,6 @@ public class AtrCciParamConfigTest {
 
     assertThat(params.getAtrPeriod()).isEqualTo(expectedAtrPeriod);
     assertThat(params.getCciPeriod()).isEqualTo(expectedCciPeriod);
-    
     // Also verify values are within expected ranges
     assertThat(params.getAtrPeriod()).isAtLeast(5);
     assertThat(params.getAtrPeriod()).isAtMost(30);

--- a/src/test/java/com/verlumen/tradestream/strategies/atrcci/AtrCciStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/atrcci/AtrCciStrategyFactoryTest.java
@@ -136,7 +136,6 @@ public class AtrCciStrategyFactoryTest {
       double cci = cciIndicator.getValue(i).doubleValue();
       double atr = atrIndicator.getValue(i).doubleValue();
       double prevAtr = previousAtr.getValue(i).doubleValue();
-      
       if (cci < 100 && atr < prevAtr) {
         exitIndex = i;
         break;

--- a/src/test/java/com/verlumen/tradestream/strategies/atrcci/AtrCciStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/atrcci/AtrCciStrategyFactoryTest.java
@@ -201,7 +201,7 @@ public class AtrCciStrategyFactoryTest {
         high,  // high
         low,   // low
         price, // close
-        100.0  // volume
+        100.0 // volume
         );
   }
 }

--- a/src/test/java/com/verlumen/tradestream/strategies/atrcci/AtrCciStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/atrcci/AtrCciStrategyFactoryTest.java
@@ -104,7 +104,6 @@ public class AtrCciStrategyFactoryTest {
       double cci = cciIndicator.getValue(i).doubleValue();
       double atr = atrIndicator.getValue(i).doubleValue();
       double prevAtr = previousAtr.getValue(i).doubleValue();
-      
       if (cci > -100 && atr > prevAtr) {
         entryIndex = i;
         break;

--- a/src/test/java/com/verlumen/tradestream/strategies/atrcci/AtrCciStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/atrcci/AtrCciStrategyFactoryTest.java
@@ -83,11 +83,6 @@ public class AtrCciStrategyFactoryTest {
   }
 
   @Test
-  public void getStrategyType_returnsAtrCci() {
-    assertThat(factory.getStrategyType()).isEqualTo(StrategyType.ATR_CCI);
-  }
-
-  @Test
   public void getDefaultParameters_returnsValidDefaults() {
     AtrCciParameters defaults = factory.getDefaultParameters();
     assertThat(defaults.getAtrPeriod()).isEqualTo(14);

--- a/src/test/java/com/verlumen/tradestream/strategies/atrcci/AtrCciStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/atrcci/AtrCciStrategyFactoryTest.java
@@ -1,0 +1,207 @@
+package com.verlumen.tradestream.strategies.atrcci;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.verlumen.tradestream.strategies.AtrCciParameters;
+import com.verlumen.tradestream.strategies.StrategyType;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.ta4j.core.BaseBar;
+import org.ta4j.core.BaseBarSeries;
+import org.ta4j.core.Strategy;
+import org.ta4j.core.indicators.ATRIndicator;
+import org.ta4j.core.indicators.CCIIndicator;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.indicators.helpers.PreviousValueIndicator;
+
+@RunWith(JUnit4.class)
+public class AtrCciStrategyFactoryTest {
+  private static final int ATR_PERIOD = 14;
+  private static final int CCI_PERIOD = 20;
+
+  private AtrCciStrategyFactory factory;
+  private AtrCciParameters params;
+  private BaseBarSeries series;
+  private Strategy strategy;
+
+  // For debugging ATR and CCI calculations
+  private ATRIndicator atrIndicator;
+  private CCIIndicator cciIndicator;
+  private PreviousValueIndicator previousAtr;
+  private ClosePriceIndicator closePrice;
+
+  @Before
+  public void setUp() throws InvalidProtocolBufferException {
+    factory = new AtrCciStrategyFactory();
+
+    // Standard parameters
+    params =
+        AtrCciParameters.newBuilder()
+            .setAtrPeriod(ATR_PERIOD)
+            .setCciPeriod(CCI_PERIOD)
+            .build();
+
+    // Initialize series
+    series = new BaseBarSeries();
+    ZonedDateTime now = ZonedDateTime.now();
+
+    // Create sample price data with volatility changes and CCI patterns
+    // Initial stable period
+    for (int i = 0; i < 10; i++) {
+      series.addBar(createBar(now.plusMinutes(i), 100.0, 1.0)); // Low volatility
+    }
+
+    // Period with declining prices and low CCI (below -100)
+    for (int i = 10; i < 15; i++) {
+      double price = 100.0 - (i - 9) * 3; // Declining prices
+      series.addBar(createBar(now.plusMinutes(i), price, 2.0)); // Increasing volatility
+    }
+
+    // Strong upward movement with increasing volatility and high CCI
+    for (int i = 15; i < 20; i++) {
+      double price = 85.0 + (i - 14) * 8; // Strong upward movement
+      series.addBar(createBar(now.plusMinutes(i), price, 4.0)); // High volatility
+    }
+
+    // Period with high prices and high CCI (above +100), then decreasing volatility
+    for (int i = 20; i < 25; i++) {
+      double price = 125.0 + (i - 19) * 2; // Continued upward but slower
+      series.addBar(createBar(now.plusMinutes(i), price, 3.0 - (i - 20) * 0.5)); // Decreasing volatility
+    }
+
+    // Initialize indicators
+    closePrice = new ClosePriceIndicator(series);
+    atrIndicator = new ATRIndicator(series, ATR_PERIOD);
+    cciIndicator = new CCIIndicator(series, CCI_PERIOD);
+    previousAtr = new PreviousValueIndicator(atrIndicator, 1);
+
+    // Create strategy
+    strategy = factory.createStrategy(series, params);
+  }
+
+  @Test
+  public void getStrategyType_returnsAtrCci() {
+    assertThat(factory.getStrategyType()).isEqualTo(StrategyType.ATR_CCI);
+  }
+
+  @Test
+  public void getDefaultParameters_returnsValidDefaults() {
+    AtrCciParameters defaults = factory.getDefaultParameters();
+    assertThat(defaults.getAtrPeriod()).isEqualTo(14);
+    assertThat(defaults.getCciPeriod()).isEqualTo(20);
+  }
+
+  @Test
+  public void entryRule_shouldTrigger_whenCciAboveMinus100AndAtrIncreasing() {
+    // Find a bar index where CCI is above -100 and ATR is increasing
+    int entryIndex = -1;
+    for (int i = Math.max(ATR_PERIOD, CCI_PERIOD); i < series.getBarCount(); i++) {
+      double cci = cciIndicator.getValue(i).doubleValue();
+      double atr = atrIndicator.getValue(i).doubleValue();
+      double prevAtr = previousAtr.getValue(i).doubleValue();
+      
+      if (cci > -100 && atr > prevAtr) {
+        entryIndex = i;
+        break;
+      }
+    }
+
+    // Log values for debugging
+    if (entryIndex > 0) {
+      System.out.printf(
+          "Entry at Bar %d - Price: %.2f, CCI: %.2f, ATR: %.2f, Prev ATR: %.2f%n",
+          entryIndex,
+          closePrice.getValue(entryIndex).doubleValue(),
+          cciIndicator.getValue(entryIndex).doubleValue(),
+          atrIndicator.getValue(entryIndex).doubleValue(),
+          previousAtr.getValue(entryIndex).doubleValue());
+      assertThat(strategy.getEntryRule().isSatisfied(entryIndex)).isTrue();
+    } else {
+      System.out.println("No entry signal found with current data and parameters.");
+      // Still verify the strategy was created successfully
+      assertThat(strategy).isNotNull();
+    }
+  }
+
+  @Test
+  public void exitRule_shouldTrigger_whenCciBelow100AndAtrDecreasing() {
+    // Find a bar index where CCI is below 100 and ATR is decreasing
+    int exitIndex = -1;
+    for (int i = Math.max(ATR_PERIOD, CCI_PERIOD); i < series.getBarCount(); i++) {
+      double cci = cciIndicator.getValue(i).doubleValue();
+      double atr = atrIndicator.getValue(i).doubleValue();
+      double prevAtr = previousAtr.getValue(i).doubleValue();
+      
+      if (cci < 100 && atr < prevAtr) {
+        exitIndex = i;
+        break;
+      }
+    }
+
+    // Log values for debugging
+    if (exitIndex > 0) {
+      System.out.printf(
+          "Exit at Bar %d - Price: %.2f, CCI: %.2f, ATR: %.2f, Prev ATR: %.2f%n",
+          exitIndex,
+          closePrice.getValue(exitIndex).doubleValue(),
+          cciIndicator.getValue(exitIndex).doubleValue(),
+          atrIndicator.getValue(exitIndex).doubleValue(),
+          previousAtr.getValue(exitIndex).doubleValue());
+      assertThat(strategy.getExitRule().isSatisfied(exitIndex)).isTrue();
+    } else {
+      System.out.println("No exit signal found with current data and parameters.");
+      // Still verify the strategy was created successfully
+      assertThat(strategy).isNotNull();
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void validateAtrPeriod() throws InvalidProtocolBufferException {
+    params =
+        AtrCciParameters.newBuilder()
+            .setAtrPeriod(-1)
+            .setCciPeriod(CCI_PERIOD)
+            .build();
+    factory.createStrategy(series, params);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void validateCciPeriod() throws InvalidProtocolBufferException {
+    params =
+        AtrCciParameters.newBuilder()
+            .setAtrPeriod(ATR_PERIOD)
+            .setCciPeriod(-1)
+            .build();
+    factory.createStrategy(series, params);
+  }
+
+  @Test
+  public void createStrategy_withValidParameters_returnsStrategy()
+      throws InvalidProtocolBufferException {
+    Strategy result = factory.createStrategy(series, params);
+    assertThat(result).isNotNull();
+    assertThat(result.getName()).contains("ATR_CCI");
+    assertThat(result.getName()).contains("ATR: 14");
+    assertThat(result.getName()).contains("CCI: 20");
+  }
+
+  private BaseBar createBar(ZonedDateTime time, double price, double volatility) {
+    // Create bars with varying high/low based on volatility for realistic ATR calculation
+    double high = price + volatility;
+    double low = price - volatility;
+    return new BaseBar(
+        Duration.ofMinutes(1),
+        time,
+        price, // open
+        high,  // high
+        low,   // low
+        price, // close
+        100.0  // volume
+        );
+  }
+}

--- a/src/test/java/com/verlumen/tradestream/strategies/atrcci/AtrCciStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/atrcci/AtrCciStrategyFactoryTest.java
@@ -162,11 +162,7 @@ public class AtrCciStrategyFactoryTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void validateAtrPeriod() throws InvalidProtocolBufferException {
-    params =
-        AtrCciParameters.newBuilder()
-            .setAtrPeriod(-1)
-            .setCciPeriod(CCI_PERIOD)
-            .build();
+    params = AtrCciParameters.newBuilder().setAtrPeriod(-1).setCciPeriod(CCI_PERIOD).build();
     factory.createStrategy(series, params);
   }
 

--- a/src/test/java/com/verlumen/tradestream/strategies/atrcci/AtrCciStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/atrcci/AtrCciStrategyFactoryTest.java
@@ -198,8 +198,8 @@ public class AtrCciStrategyFactoryTest {
         Duration.ofMinutes(1),
         time,
         price, // open
-        high,  // high
-        low,   // low
+        high, // high
+        low, // low
         price, // close
         100.0 // volume
         );

--- a/src/test/java/com/verlumen/tradestream/strategies/atrcci/AtrCciStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/atrcci/AtrCciStrategyFactoryTest.java
@@ -172,11 +172,7 @@ public class AtrCciStrategyFactoryTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void validateCciPeriod() throws InvalidProtocolBufferException {
-    params =
-        AtrCciParameters.newBuilder()
-            .setAtrPeriod(ATR_PERIOD)
-            .setCciPeriod(-1)
-            .build();
+    params = AtrCciParameters.newBuilder().setAtrPeriod(ATR_PERIOD).setCciPeriod(-1).build();
     factory.createStrategy(series, params);
   }
 

--- a/src/test/java/com/verlumen/tradestream/strategies/atrcci/AtrCciStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/atrcci/AtrCciStrategyFactoryTest.java
@@ -41,10 +41,7 @@ public class AtrCciStrategyFactoryTest {
 
     // Standard parameters
     params =
-        AtrCciParameters.newBuilder()
-            .setAtrPeriod(ATR_PERIOD)
-            .setCciPeriod(CCI_PERIOD)
-            .build();
+        AtrCciParameters.newBuilder().setAtrPeriod(ATR_PERIOD).setCciPeriod(CCI_PERIOD).build();
 
     // Initialize series
     series = new BaseBarSeries();

--- a/src/test/java/com/verlumen/tradestream/strategies/atrcci/AtrCciStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/atrcci/AtrCciStrategyFactoryTest.java
@@ -71,7 +71,8 @@ public class AtrCciStrategyFactoryTest {
     // Period with high prices and high CCI (above +100), then decreasing volatility
     for (int i = 20; i < 25; i++) {
       double price = 125.0 + (i - 19) * 2; // Continued upward but slower
-      series.addBar(createBar(now.plusMinutes(i), price, 3.0 - (i - 20) * 0.5)); // Decreasing volatility
+      series.addBar(
+          createBar(now.plusMinutes(i), price, 3.0 - (i - 20) * 0.5)); // Decreasing volatility
     }
 
     // Initialize indicators

--- a/src/test/java/com/verlumen/tradestream/strategies/atrcci/AtrCciStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/atrcci/AtrCciStrategyFactoryTest.java
@@ -4,7 +4,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.verlumen.tradestream.strategies.AtrCciParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import org.junit.Before;

--- a/src/test/java/com/verlumen/tradestream/strategies/atrcci/BUILD
+++ b/src/test/java/com/verlumen/tradestream/strategies/atrcci/BUILD
@@ -1,0 +1,33 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
+java_test(
+    name = "AtrCciParamConfigTest",
+    srcs = ["AtrCciParamConfigTest.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/discovery:chromosome_spec",
+        "//src/main/java/com/verlumen/tradestream/strategies/atrcci:param_config",
+        "//third_party/java:guava",
+        "//third_party/java:jenetics",
+        "//third_party/java:junit",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:truth",
+    ],
+)
+
+java_test(
+    name = "AtrCciStrategyFactoryTest",
+    srcs = ["AtrCciStrategyFactoryTest.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/strategies:strategy_factory",
+        "//src/main/java/com/verlumen/tradestream/strategies/atrcci:strategy_factory",
+        "//third_party/java:flogger",
+        "//third_party/java:guava",
+        "//third_party/java:junit",
+        "//third_party/java:mockito_core",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:ta4j_core",
+        "//third_party/java:truth",
+    ],
+)


### PR DESCRIPTION
This PR introduces a new trading strategy implementation based on the Average True Range (ATR) and Commodity Channel Index (CCI) indicators. It includes both the parameter configuration and strategy logic, as well as corresponding unit tests and Bazel build files.

### Summary of Changes

* **Strategy Implementation:**

  * `AtrCciStrategyFactory`: Defines a strategy where:

    * Entry signal triggers when CCI crosses above -100 and ATR is increasing.
    * Exit signal triggers when CCI crosses below +100 and ATR is decreasing.
  * Default parameters set to ATR period = 14, CCI period = 20.

* **Parameter Configuration:**

  * `AtrCciParamConfig`: Defines chromosome specs for the ATR and CCI periods using integer ranges (ATR: 5–30, CCI: 10–50).
  * Generates initial chromosomes and packs/unpacks parameters using Protobuf.

* **Tests:**

  * Unit tests for both parameter config and strategy factory verify spec definitions, parameter validation, rule behavior, and strategy construction logic.

* **Build Support:**

  * Bazel `BUILD` files added for compiling and testing both the implementation and tests.

This PR introduces a **new strategy** and associated configuration, qualifying it as a **(MINOR)** version update.
