### PR TITLE
Remove unused imports and simplify conditional block in backtesting logic

### DIFF
--- a/src/main/java/com/verlumen/tradestream/backtesting/BacktestRunnerImpl.kt
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BacktestRunnerImpl.kt
@@ -93,13 +93,10 @@ class BacktestRunnerImpl
 
             // Skip unstable period at the start
             for (i in strategy.unstableBars until series.barCount) {
-                // Check if we should enter long position
                 if (strategy.shouldEnter(i)) {
                     // Enter with a position size of 1 unit
                     tradingRecord.enter(i, series.getBar(i).closePrice, series.numOf(1))
-                }
-                // Check if we should exit an open position
-                else if (strategy.shouldExit(i) && tradingRecord.currentPosition.isOpened) {
+                } else if (strategy.shouldExit(i) && tradingRecord.currentPosition.isOpened) {
                     tradingRecord.exit(i, series.getBar(i).closePrice, series.numOf(1))
                 }
             }

--- a/src/main/java/com/verlumen/tradestream/discovery/BUILD
+++ b/src/main/java/com/verlumen/tradestream/discovery/BUILD
@@ -87,7 +87,6 @@ kt_jvm_library(
         ":write_discovered_strategies_to_postgres_fn",
         "//protos:discovery_java_proto",
         "//src/main/java/com/verlumen/tradestream/marketdata:market_data_module",
-        "//third_party/java:guava",
         "//third_party/java:guice",
         "//third_party/java:guice_assistedinject",
         "//third_party/java:protobuf_java",

--- a/src/main/java/com/verlumen/tradestream/discovery/DiscoveryModule.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/DiscoveryModule.kt
@@ -1,8 +1,6 @@
 package com.verlumen.tradestream.discovery
 
-import com.google.common.collect.ImmutableList
 import com.google.inject.AbstractModule
-import com.google.inject.TypeLiteral
 import com.google.inject.assistedinject.FactoryModuleBuilder
 
 internal class BaseModule : AbstractModule() {

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.kt
@@ -1,6 +1,5 @@
 package com.verlumen.tradestream.strategies
 
-import com.google.common.collect.ImmutableList
 import com.google.inject.AbstractModule
 
 class StrategiesModule : AbstractModule()

--- a/src/main/java/com/verlumen/tradestream/strategies/adxstochastic/AdxStochasticParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/adxstochastic/AdxStochasticParamConfig.java
@@ -5,7 +5,6 @@ import com.google.protobuf.Any;
 import com.verlumen.tradestream.discovery.ChromosomeSpec;
 import com.verlumen.tradestream.discovery.ParamConfig;
 import com.verlumen.tradestream.strategies.AdxStochasticParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import io.jenetics.IntegerChromosome;
 import io.jenetics.NumericChromosome;
 

--- a/src/main/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopParamConfig.java
@@ -5,7 +5,6 @@ import com.google.protobuf.Any;
 import com.verlumen.tradestream.discovery.ChromosomeSpec;
 import com.verlumen.tradestream.discovery.ParamConfig;
 import com.verlumen.tradestream.strategies.AtrTrailingStopParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import io.jenetics.DoubleChromosome;
 import io.jenetics.IntegerChromosome;
 import io.jenetics.NumericChromosome;

--- a/src/main/java/com/verlumen/tradestream/strategies/donchianbreakout/DonchianBreakoutParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/donchianbreakout/DonchianBreakoutParamConfig.java
@@ -5,7 +5,6 @@ import com.google.protobuf.Any;
 import com.verlumen.tradestream.discovery.ChromosomeSpec;
 import com.verlumen.tradestream.discovery.ParamConfig;
 import com.verlumen.tradestream.strategies.DonchianBreakoutParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import io.jenetics.IntegerChromosome;
 import io.jenetics.NumericChromosome;
 

--- a/src/main/java/com/verlumen/tradestream/strategies/doubleemacrossover/DoubleEmaCrossoverParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/doubleemacrossover/DoubleEmaCrossoverParamConfig.java
@@ -5,7 +5,6 @@ import com.google.protobuf.Any;
 import com.verlumen.tradestream.discovery.ChromosomeSpec;
 import com.verlumen.tradestream.discovery.ParamConfig;
 import com.verlumen.tradestream.strategies.DoubleEmaCrossoverParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import io.jenetics.IntegerChromosome;
 import io.jenetics.NumericChromosome;
 

--- a/src/main/java/com/verlumen/tradestream/strategies/emamacd/EmaMacdParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/emamacd/EmaMacdParamConfig.java
@@ -5,7 +5,6 @@ import com.google.protobuf.Any;
 import com.verlumen.tradestream.discovery.ChromosomeSpec;
 import com.verlumen.tradestream.discovery.ParamConfig;
 import com.verlumen.tradestream.strategies.EmaMacdParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import io.jenetics.IntegerChromosome;
 import io.jenetics.NumericChromosome;
 

--- a/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudParamConfig.java
@@ -5,7 +5,6 @@ import com.google.protobuf.Any;
 import com.verlumen.tradestream.discovery.ChromosomeSpec;
 import com.verlumen.tradestream.discovery.ParamConfig;
 import com.verlumen.tradestream.strategies.IchimokuCloudParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import io.jenetics.IntegerChromosome;
 import io.jenetics.NumericChromosome;
 

--- a/src/main/java/com/verlumen/tradestream/strategies/macdcrossover/MacdCrossoverParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/macdcrossover/MacdCrossoverParamConfig.java
@@ -5,7 +5,6 @@ import com.google.protobuf.Any;
 import com.verlumen.tradestream.discovery.ChromosomeSpec;
 import com.verlumen.tradestream.discovery.ParamConfig;
 import com.verlumen.tradestream.strategies.MacdCrossoverParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import io.jenetics.IntegerChromosome;
 import io.jenetics.NumericChromosome;
 

--- a/src/main/java/com/verlumen/tradestream/strategies/momentumsmacrossover/MomentumSmaCrossoverParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/momentumsmacrossover/MomentumSmaCrossoverParamConfig.java
@@ -5,7 +5,6 @@ import com.google.protobuf.Any;
 import com.verlumen.tradestream.discovery.ChromosomeSpec;
 import com.verlumen.tradestream.discovery.ParamConfig;
 import com.verlumen.tradestream.strategies.MomentumSmaCrossoverParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import io.jenetics.IntegerChromosome;
 import io.jenetics.NumericChromosome;
 

--- a/src/main/java/com/verlumen/tradestream/strategies/parabolicsarr/ParabolicSarParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/parabolicsarr/ParabolicSarParamConfig.java
@@ -5,7 +5,6 @@ import com.google.protobuf.Any;
 import com.verlumen.tradestream.discovery.ChromosomeSpec;
 import com.verlumen.tradestream.discovery.ParamConfig;
 import com.verlumen.tradestream.strategies.ParabolicSarParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import io.jenetics.DoubleChromosome;
 import io.jenetics.NumericChromosome;
 

--- a/src/main/java/com/verlumen/tradestream/strategies/smaemacrossover/SmaEmaCrossoverParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/smaemacrossover/SmaEmaCrossoverParamConfig.java
@@ -5,7 +5,6 @@ import com.google.protobuf.Any;
 import com.verlumen.tradestream.discovery.ChromosomeSpec;
 import com.verlumen.tradestream.discovery.ParamConfig;
 import com.verlumen.tradestream.strategies.SmaEmaCrossoverParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import io.jenetics.IntegerChromosome;
 import io.jenetics.NumericChromosome;
 

--- a/src/main/java/com/verlumen/tradestream/strategies/smarsi/SmaRsiParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/smarsi/SmaRsiParamConfig.java
@@ -5,7 +5,6 @@ import com.google.protobuf.Any;
 import com.verlumen.tradestream.discovery.ChromosomeSpec;
 import com.verlumen.tradestream.discovery.ParamConfig;
 import com.verlumen.tradestream.strategies.SmaRsiParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import io.jenetics.IntegerChromosome;
 import io.jenetics.NumericChromosome;
 import java.util.logging.Logger;

--- a/src/main/java/com/verlumen/tradestream/strategies/stochasticsrsi/StochasticRsiParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/stochasticsrsi/StochasticRsiParamConfig.java
@@ -5,7 +5,6 @@ import com.google.protobuf.Any;
 import com.verlumen.tradestream.discovery.ChromosomeSpec;
 import com.verlumen.tradestream.discovery.ParamConfig;
 import com.verlumen.tradestream.strategies.StochasticRsiParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import io.jenetics.IntegerChromosome;
 import io.jenetics.NumericChromosome;
 

--- a/src/main/java/com/verlumen/tradestream/strategies/tripleemacrossover/TripleEmaCrossoverParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/tripleemacrossover/TripleEmaCrossoverParamConfig.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;
 import com.verlumen.tradestream.discovery.ChromosomeSpec;
 import com.verlumen.tradestream.discovery.ParamConfig;
-import com.verlumen.tradestream.strategies.StrategyType;
 import com.verlumen.tradestream.strategies.TripleEmaCrossoverParameters;
 import io.jenetics.IntegerChromosome;
 import io.jenetics.NumericChromosome;

--- a/src/main/java/com/verlumen/tradestream/strategies/volatilitystop/VolatilityStopParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/volatilitystop/VolatilityStopParamConfig.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;
 import com.verlumen.tradestream.discovery.ChromosomeSpec;
 import com.verlumen.tradestream.discovery.ParamConfig;
-import com.verlumen.tradestream.strategies.StrategyType;
 import com.verlumen.tradestream.strategies.VolatilityStopParameters;
 import io.jenetics.DoubleChromosome;
 import io.jenetics.IntegerChromosome;

--- a/src/test/java/com/verlumen/tradestream/discovery/FitnessFunctionFactoryImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/discovery/FitnessFunctionFactoryImplTest.java
@@ -10,7 +10,6 @@ import com.google.inject.Inject;
 import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import com.google.protobuf.Any;
-import com.google.protobuf.InvalidProtocolBufferException;
 import com.verlumen.tradestream.backtesting.BacktestRequest;
 import com.verlumen.tradestream.backtesting.BacktestRequestFactory;
 import com.verlumen.tradestream.backtesting.BacktestRequestFactoryImpl;

--- a/src/test/java/com/verlumen/tradestream/strategies/adxstochastic/AdxStochasticParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/adxstochastic/AdxStochasticParamConfigTest.java
@@ -7,7 +7,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;
 import com.verlumen.tradestream.discovery.ChromosomeSpec;
 import com.verlumen.tradestream.strategies.AdxStochasticParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import io.jenetics.IntegerChromosome;
 import io.jenetics.NumericChromosome;
 import java.util.List;

--- a/src/test/java/com/verlumen/tradestream/strategies/adxstochastic/AdxStochasticStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/adxstochastic/AdxStochasticStrategyFactoryTest.java
@@ -4,7 +4,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.verlumen.tradestream.strategies.AdxStochasticParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import org.junit.Before;

--- a/src/test/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopParamConfigTest.java
@@ -7,7 +7,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;
 import com.verlumen.tradestream.discovery.ChromosomeSpec;
 import com.verlumen.tradestream.strategies.AtrTrailingStopParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import io.jenetics.DoubleChromosome;
 import io.jenetics.IntegerChromosome;
 import io.jenetics.NumericChromosome;

--- a/src/test/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/atrtrailingstop/AtrTrailingStopStrategyFactoryTest.java
@@ -4,7 +4,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.verlumen.tradestream.strategies.AtrTrailingStopParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import org.junit.Before;

--- a/src/test/java/com/verlumen/tradestream/strategies/donchianbreakout/DonchianBreakoutParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/donchianbreakout/DonchianBreakoutParamConfigTest.java
@@ -6,7 +6,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;
 import com.verlumen.tradestream.discovery.ChromosomeSpec;
 import com.verlumen.tradestream.strategies.DonchianBreakoutParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import io.jenetics.IntegerChromosome;
 import io.jenetics.NumericChromosome;
 import java.util.List;

--- a/src/test/java/com/verlumen/tradestream/strategies/donchianbreakout/DonchianBreakoutStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/donchianbreakout/DonchianBreakoutStrategyFactoryTest.java
@@ -1,10 +1,8 @@
 package com.verlumen.tradestream.strategies.donchianbreakout;
 
-import static com.google.common.truth.Truth.assertThat;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.verlumen.tradestream.strategies.DonchianBreakoutParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import org.junit.Before;
@@ -13,7 +11,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.ta4j.core.BaseBar;
 import org.ta4j.core.BaseBarSeries;
-import org.ta4j.core.Strategy;
 
 @RunWith(JUnit4.class)
 public class DonchianBreakoutStrategyFactoryTest {

--- a/src/test/java/com/verlumen/tradestream/strategies/donchianbreakout/DonchianBreakoutStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/donchianbreakout/DonchianBreakoutStrategyFactoryTest.java
@@ -1,6 +1,5 @@
 package com.verlumen.tradestream.strategies.donchianbreakout;
 
-
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.verlumen.tradestream.strategies.DonchianBreakoutParameters;
 import java.time.Duration;

--- a/src/test/java/com/verlumen/tradestream/strategies/doubleemacrossover/DoubleEmaCrossoverParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/doubleemacrossover/DoubleEmaCrossoverParamConfigTest.java
@@ -7,7 +7,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;
 import com.verlumen.tradestream.discovery.ChromosomeSpec;
 import com.verlumen.tradestream.strategies.DoubleEmaCrossoverParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import io.jenetics.IntegerChromosome;
 import io.jenetics.NumericChromosome;
 import java.util.List;

--- a/src/test/java/com/verlumen/tradestream/strategies/doubleemacrossover/DoubleEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/doubleemacrossover/DoubleEmaCrossoverStrategyFactoryTest.java
@@ -4,7 +4,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.verlumen.tradestream.strategies.DoubleEmaCrossoverParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import org.junit.Before;

--- a/src/test/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudParamConfigTest.java
@@ -6,7 +6,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;
 import com.verlumen.tradestream.discovery.ChromosomeSpec;
 import com.verlumen.tradestream.strategies.IchimokuCloudParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import io.jenetics.IntegerChromosome;
 import io.jenetics.NumericChromosome;
 import java.util.List;

--- a/src/test/java/com/verlumen/tradestream/strategies/macdcrossover/MacdCrossoverParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/macdcrossover/MacdCrossoverParamConfigTest.java
@@ -6,7 +6,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;
 import com.verlumen.tradestream.discovery.ChromosomeSpec;
 import com.verlumen.tradestream.strategies.MacdCrossoverParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import io.jenetics.IntegerChromosome;
 import io.jenetics.NumericChromosome;
 import java.util.List;

--- a/src/test/java/com/verlumen/tradestream/strategies/macdcrossover/MacdCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/macdcrossover/MacdCrossoverStrategyFactoryTest.java
@@ -4,7 +4,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.verlumen.tradestream.strategies.MacdCrossoverParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import org.junit.Before;

--- a/src/test/java/com/verlumen/tradestream/strategies/momentumsmacrossover/MomentumSmaCrossoverParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/momentumsmacrossover/MomentumSmaCrossoverParamConfigTest.java
@@ -6,7 +6,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;
 import com.verlumen.tradestream.discovery.ChromosomeSpec;
 import com.verlumen.tradestream.strategies.MomentumSmaCrossoverParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import io.jenetics.IntegerChromosome;
 import io.jenetics.NumericChromosome;
 import java.util.List;

--- a/src/test/java/com/verlumen/tradestream/strategies/momentumsmacrossover/MomentumSmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/momentumsmacrossover/MomentumSmaCrossoverStrategyFactoryTest.java
@@ -5,7 +5,6 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.verlumen.tradestream.strategies.MomentumIndicator;
 import com.verlumen.tradestream.strategies.MomentumSmaCrossoverParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import org.junit.Before;

--- a/src/test/java/com/verlumen/tradestream/strategies/parabolicsarr/ParabolicSarParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/parabolicsarr/ParabolicSarParamConfigTest.java
@@ -6,7 +6,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;
 import com.verlumen.tradestream.discovery.ChromosomeSpec;
 import com.verlumen.tradestream.strategies.ParabolicSarParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import io.jenetics.DoubleChromosome;
 import io.jenetics.NumericChromosome;
 import java.util.List;

--- a/src/test/java/com/verlumen/tradestream/strategies/parabolicsarr/ParabolicSarStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/parabolicsarr/ParabolicSarStrategyFactoryTest.java
@@ -4,7 +4,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.verlumen.tradestream.strategies.ParabolicSarParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import org.junit.Before;

--- a/src/test/java/com/verlumen/tradestream/strategies/smaemacrossover/SmaEmaCrossoverParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/smaemacrossover/SmaEmaCrossoverParamConfigTest.java
@@ -6,7 +6,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;
 import com.verlumen.tradestream.discovery.ChromosomeSpec;
 import com.verlumen.tradestream.strategies.SmaEmaCrossoverParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import io.jenetics.IntegerChromosome;
 import io.jenetics.NumericChromosome;
 import java.util.List;

--- a/src/test/java/com/verlumen/tradestream/strategies/smaemacrossover/SmaEmaCrossoverStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/smaemacrossover/SmaEmaCrossoverStrategyFactoryTest.java
@@ -4,7 +4,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.verlumen.tradestream.strategies.SmaEmaCrossoverParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import org.junit.Before;

--- a/src/test/java/com/verlumen/tradestream/strategies/smarsi/SmaRsiStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/smarsi/SmaRsiStrategyFactoryTest.java
@@ -4,7 +4,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.verlumen.tradestream.strategies.SmaRsiParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import org.junit.Before;

--- a/src/test/java/com/verlumen/tradestream/strategies/stochasticsrsi/StochasticRsiParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/stochasticsrsi/StochasticRsiParamConfigTest.java
@@ -7,7 +7,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;
 import com.verlumen.tradestream.discovery.ChromosomeSpec;
 import com.verlumen.tradestream.strategies.StochasticRsiParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import io.jenetics.IntegerChromosome;
 import io.jenetics.NumericChromosome;
 import java.util.List;

--- a/src/test/java/com/verlumen/tradestream/strategies/stochasticsrsi/StochasticRsiStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/stochasticsrsi/StochasticRsiStrategyFactoryTest.java
@@ -4,7 +4,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.verlumen.tradestream.strategies.StochasticRsiParameters;
-import com.verlumen.tradestream.strategies.StrategyType;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import org.junit.Before;


### PR DESCRIPTION
This pull request includes minor code quality improvements across several files:

* **Backtest Logic:** Simplified conditional structure in `BacktestRunnerImpl.kt` by collapsing the mutually exclusive `if`/`else if` blocks for entering and exiting positions, improving readability.
* **Code Cleanup:** Removed unused imports such as `StrategyType` and other redundant references from various strategy configuration and test classes.
* **Dependency Cleanup:** Eliminated unnecessary Guava and protobuf imports from modules and tests, reducing potential maintenance overhead and improving build hygiene.

These changes do not alter runtime behavior and are intended strictly for code clarity and maintainability.
