### PR TITLE
Remove unused `StrategiesModule` and associated build targets

### DIFF
--- a/src/main/java/com/verlumen/tradestream/discovery/BUILD
+++ b/src/main/java/com/verlumen/tradestream/discovery/BUILD
@@ -391,7 +391,6 @@ kt_jvm_library(
         "//src/main/java/com/verlumen/tradestream/http:http_module",
         "//src/main/java/com/verlumen/tradestream/influxdb:influx_db_module",
         "//src/main/java/com/verlumen/tradestream/postgres:postgres_module",
-        "//src/main/java/com/verlumen/tradestream/strategies:strategies_module",
         "//src/main/java/com/verlumen/tradestream/ta4j:ta4j_module",
         "//third_party/java:beam_runners_direct_java",
         "//third_party/java:beam_sdks_java_core",

--- a/src/main/java/com/verlumen/tradestream/discovery/StrategyDiscoveryPipelineRunner.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/StrategyDiscoveryPipelineRunner.kt
@@ -7,7 +7,6 @@ import com.verlumen.tradestream.http.HttpModule
 import com.verlumen.tradestream.influxdb.InfluxDbModule
 import com.verlumen.tradestream.marketdata.MarketDataModule
 import com.verlumen.tradestream.postgres.PostgresModule
-import com.verlumen.tradestream.strategies.StrategiesModule
 import com.verlumen.tradestream.ta4j.Ta4jModule
 import org.apache.beam.sdk.options.PipelineOptionsFactory
 
@@ -66,7 +65,6 @@ class StrategyDiscoveryPipelineRunner {
                     InfluxDbModule(),
                     MarketDataModule.create(),
                     PostgresModule(),
-                    StrategiesModule(),
                     Ta4jModule.create(),
                     TemporaryCurrencyPairModule(), // Remove when nothing depends on it
                 )

--- a/src/main/java/com/verlumen/tradestream/pipeline/BUILD
+++ b/src/main/java/com/verlumen/tradestream/pipeline/BUILD
@@ -107,7 +107,6 @@ java_library(
         "//src/main/java/com/verlumen/tradestream/marketdata:trade_to_candle",
         "//src/main/java/com/verlumen/tradestream/postgres:postgres_module",
         "//src/main/java/com/verlumen/tradestream/signals:signals_module",
-        "//src/main/java/com/verlumen/tradestream/strategies:strategies_module",
         "//src/main/java/com/verlumen/tradestream/ta4j:ta4j_module",
         "//third_party/java:auto_value",
         "//third_party/java:guava",

--- a/src/main/java/com/verlumen/tradestream/pipeline/PipelineModule.java
+++ b/src/main/java/com/verlumen/tradestream/pipeline/PipelineModule.java
@@ -26,7 +26,6 @@ import com.verlumen.tradestream.marketdata.TradeSource;
 import com.verlumen.tradestream.marketdata.TradeToCandle;
 import com.verlumen.tradestream.postgres.PostgresModule;
 import com.verlumen.tradestream.signals.SignalsModule;
-import com.verlumen.tradestream.strategies.StrategiesModule;
 import com.verlumen.tradestream.ta4j.Ta4jModule;
 import org.joda.time.Duration;
 
@@ -99,7 +98,6 @@ abstract class PipelineModule extends AbstractModule {
     install(MarketDataModule.create());
     install(new PostgresModule());
     install(SignalsModule.create(signalTopic()));
-    install(new StrategiesModule());
     install(Ta4jModule.create());
   }
 

--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -12,16 +12,6 @@ kt_jvm_library(
 )
 
 kt_jvm_library(
-    name = "strategies_module",
-    srcs = ["StrategiesModule.kt"],
-    deps = [
-        ":strategy_factory",
-        "//third_party/java:guava",
-        "//third_party/java:guice",
-    ],
-)
-
-kt_jvm_library(
     name = "strategy_constants",
     srcs = ["StrategyConstants.kt"],
     deps = [

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategiesModule.kt
@@ -1,5 +1,0 @@
-package com.verlumen.tradestream.strategies
-
-import com.google.inject.AbstractModule
-
-class StrategiesModule : AbstractModule()


### PR DESCRIPTION
This change removes the unused `StrategiesModule` and its associated references from the codebase. The following updates were made:

* Deleted `StrategiesModule.kt`.
* Removed the `strategies_module` target from the `strategies/BUILD` file.
* Cleaned up dependencies and module installations in:

  * `StrategyDiscoveryPipelineRunner.kt`
  * `PipelineModule.java`
  * Corresponding BUILD files under `discovery` and `pipeline`.

No functional changes were introduced. This is a cleanup to reduce dead code and simplify the dependency graph.
