### PR TITLE
Add COMPOSITE strategy type with configurable logical operators (MINOR)

### DIFF
--- a/protos/strategies.proto
+++ b/protos/strategies.proto
@@ -929,6 +929,31 @@ enum StrategyType {
   //  - minPeriod (int): Minimum period for the EMA
   //  - maxPeriod (int): Maximum period for the EMA
   VARIABLE_PERIOD_EMA = 60;
+
+  // Composite Strategy
+  //
+  // Combines two strategies using logical operators for entry and exit rules.
+  // This allows for complex strategy combinations without pre-defining every possible combination.
+  //
+  // Indicators:
+  //   - All indicators from the two constituent strategies
+  //
+  // Entry Condition:
+  //   - Determined by entry_operator applied to the entry rules of both strategies
+  //   - AND: Both strategies must signal entry
+  //   - OR: Either strategy can signal entry
+  //
+  // Exit Condition:
+  //   - Determined by exit_operator applied to the exit rules of both strategies
+  //   - AND: Both strategies must signal exit
+  //   - OR: Either strategy can signal exit
+  //
+  // Parameters:
+  //   - left_strategy: The first strategy to combine
+  //   - right_strategy: The second strategy to combine
+  //   - entry_operator: Logical operator for entry rules (AND/OR)
+  //   - exit_operator: Logical operator for exit rules (AND/OR)
+  COMPOSITE = 61;
 }
 
 message SmaRsiParameters {

--- a/protos/strategies.proto
+++ b/protos/strategies.proto
@@ -1263,3 +1263,16 @@ message VariablePeriodEmaParameters {
   int32 minPeriod = 1;
   int32 maxPeriod = 2;
 }
+
+message CompositeStrategyParameters {
+  Strategy left_strategy = 1;
+  Strategy right_strategy = 2;
+  
+  enum LogicalOperator {
+    AND = 0;
+    OR = 1;
+  }
+  
+  LogicalOperator entry_operator = 3;
+  LogicalOperator exit_operator = 4;
+}


### PR DESCRIPTION
This update introduces a new `COMPOSITE` strategy type to the `StrategyType` enum, enabling composition of two existing strategies using logical operators for entry and exit rules. The corresponding `CompositeStrategyParameters` message defines:

* `left_strategy` and `right_strategy`: The two strategies to be combined.
* `entry_operator` and `exit_operator`: Enum-based logical operators (`AND`, `OR`) for determining composite entry and exit conditions.

This enhancement allows for greater flexibility and reusability in strategy design by enabling complex strategy combinations without hardcoding each variant.

(MINOR) – Introduces a new feature with backward-compatible schema additions.
