### PR TITLE
Add ADX-DMI strategy with parameter configuration and tests (MINOR)

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/adxdmi/AdxDmiParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/adxdmi/AdxDmiParamConfig.java
@@ -1,0 +1,47 @@
+package com.verlumen.tradestream.strategies.adxdmi;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.verlumen.tradestream.discovery.ChromosomeSpec;
+import com.verlumen.tradestream.discovery.ParamConfig;
+import com.verlumen.tradestream.strategies.AdxDmiParameters;
+import io.jenetics.IntegerChromosome;
+import io.jenetics.NumericChromosome;
+
+public class AdxDmiParamConfig implements ParamConfig {
+  private static final ImmutableList<ChromosomeSpec<?>> SPECS =
+      ImmutableList.of(
+          ChromosomeSpec.ofInteger(10, 30), // ADX Period
+          ChromosomeSpec.ofInteger(10, 30) // DI Period
+          );
+
+  @Override
+  public ImmutableList<ChromosomeSpec<?>> getChromosomeSpecs() {
+    return SPECS;
+  }
+
+  @Override
+  public Any createParameters(ImmutableList<? extends NumericChromosome<?, ?>> chromosomes) {
+    if (chromosomes.size() != SPECS.size()) {
+      throw new IllegalArgumentException(
+          "Expected " + SPECS.size() + " chromosomes but got " + chromosomes.size());
+    }
+
+    IntegerChromosome adxPeriodChrom = (IntegerChromosome) chromosomes.get(0);
+    IntegerChromosome diPeriodChrom = (IntegerChromosome) chromosomes.get(1);
+
+    AdxDmiParameters parameters =
+        AdxDmiParameters.newBuilder()
+            .setAdxPeriod(adxPeriodChrom.gene().allele())
+            .setDiPeriod(diPeriodChrom.gene().allele())
+            .build();
+    return Any.pack(parameters);
+  }
+
+  @Override
+  public ImmutableList<? extends NumericChromosome<?, ?>> initialChromosomes() {
+    return SPECS.stream()
+        .map(ChromosomeSpec::createChromosome)
+        .collect(ImmutableList.toImmutableList());
+  }
+}

--- a/src/main/java/com/verlumen/tradestream/strategies/adxdmi/AdxDmiStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/adxdmi/AdxDmiStrategyFactory.java
@@ -1,0 +1,53 @@
+package com.verlumen.tradestream.strategies.adxdmi;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.verlumen.tradestream.strategies.AdxDmiParameters;
+import com.verlumen.tradestream.strategies.StrategyFactory;
+import com.verlumen.tradestream.strategies.StrategyType;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseStrategy;
+import org.ta4j.core.Rule;
+import org.ta4j.core.Strategy;
+import org.ta4j.core.indicators.adx.ADXIndicator;
+import org.ta4j.core.indicators.adx.MinusDIIndicator;
+import org.ta4j.core.indicators.adx.PlusDIIndicator;
+import org.ta4j.core.rules.CrossedDownIndicatorRule;
+import org.ta4j.core.rules.CrossedUpIndicatorRule;
+import org.ta4j.core.rules.OverIndicatorRule;
+
+public class AdxDmiStrategyFactory implements StrategyFactory<AdxDmiParameters> {
+  @Override
+  public Strategy createStrategy(BarSeries series, AdxDmiParameters params) {
+    checkArgument(params.getAdxPeriod() > 0, "ADX period must be positive");
+    checkArgument(params.getDiPeriod() > 0, "DI period must be positive");
+
+    ADXIndicator adx = new ADXIndicator(series, params.getAdxPeriod());
+    PlusDIIndicator plusDI = new PlusDIIndicator(series, params.getDiPeriod());
+    MinusDIIndicator minusDI = new MinusDIIndicator(series, params.getDiPeriod());
+
+    // Entry rule: ADX is above 25 (strong trend) and +DI crosses above -DI
+    Rule entryRule =
+        new OverIndicatorRule(adx, series.numOf(25))
+            .and(new CrossedUpIndicatorRule(plusDI, minusDI));
+
+    // Exit rule: +DI crosses below -DI
+    Rule exitRule = new CrossedDownIndicatorRule(plusDI, minusDI);
+
+    return new BaseStrategy(
+        String.format(
+            "%s (ADX: %d, DI: %d)",
+            StrategyType.ADX_DMI.name(), params.getAdxPeriod(), params.getDiPeriod()),
+        entryRule,
+        exitRule,
+        Math.max(params.getAdxPeriod(), params.getDiPeriod()));
+  }
+
+  @Override
+  public AdxDmiParameters getDefaultParameters() {
+    return AdxDmiParameters.newBuilder()
+        .setAdxPeriod(14) // Standard ADX period
+        .setDiPeriod(14) // Standard DI period
+        .build();
+  }
+}

--- a/src/main/java/com/verlumen/tradestream/strategies/adxdmi/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/adxdmi/BUILD
@@ -1,0 +1,33 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
+package(
+    default_visibility = [
+        "//src/main/java/com/verlumen/tradestream/strategies:__pkg__",
+        "//src/test/java/com/verlumen/tradestream/strategies/adxdmi:__pkg__",
+    ],
+)
+
+java_library(
+    name = "param_config",
+    srcs = ["AdxDmiParamConfig.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/discovery:chromosome_spec",
+        "//src/main/java/com/verlumen/tradestream/discovery:param_config",
+        "//third_party/java:guava",
+        "//third_party/java:jenetics",
+        "//third_party/java:protobuf_java",
+    ],
+)
+
+java_library(
+    name = "strategy_factory",
+    srcs = ["AdxDmiStrategyFactory.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/strategies:strategy_factory",
+        "//third_party/java:guava",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:ta4j_core",
+    ],
+)

--- a/src/test/java/com/verlumen/tradestream/strategies/adxdmi/AdxDmiParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/adxdmi/AdxDmiParamConfigTest.java
@@ -1,0 +1,54 @@
+package com.verlumen.tradestream.strategies.adxdmi;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.verlumen.tradestream.discovery.ChromosomeSpec;
+import com.verlumen.tradestream.strategies.AdxDmiParameters;
+import io.jenetics.IntegerChromosome;
+import io.jenetics.NumericChromosome;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AdxDmiParamConfigTest {
+  private AdxDmiParamConfig config;
+
+  @Before
+  public void setUp() {
+    config = new AdxDmiParamConfig();
+  }
+
+  @Test
+  public void testGetChromosomeSpecs() {
+    ImmutableList<ChromosomeSpec<?>> specs = config.getChromosomeSpecs();
+    assertThat(specs).hasSize(2);
+  }
+
+  @Test
+  public void testCreateParameters() {
+    List<NumericChromosome<?, ?>> chromosomes =
+        List.of(
+            IntegerChromosome.of(10, 30, 14), // ADX Period
+            IntegerChromosome.of(10, 30, 14) // DI Period
+            );
+    Any packedParams = config.createParameters(ImmutableList.copyOf(chromosomes));
+    assertThat(packedParams.is(AdxDmiParameters.class)).isTrue();
+  }
+
+  @Test
+  public void testCreateParameters_invalidChromosomeSize_throwsException() {
+    List<NumericChromosome<?, ?>> chromosomes = List.of(IntegerChromosome.of(10, 30, 14));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> config.createParameters(ImmutableList.copyOf(chromosomes)));
+  }
+
+  @Test
+  public void testInitialChromosomes() {
+    ImmutableList<? extends NumericChromosome<?, ?>> chromosomes = config.initialChromosomes();
+    assertThat(chromosomes).hasSize(2);
+  }
+}

--- a/src/test/java/com/verlumen/tradestream/strategies/adxdmi/AdxDmiStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/adxdmi/AdxDmiStrategyFactoryTest.java
@@ -1,0 +1,42 @@
+package com.verlumen.tradestream.strategies.adxdmi;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.verlumen.tradestream.strategies.AdxDmiParameters;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
+import org.ta4j.core.BaseBarSeries;
+import org.ta4j.core.Strategy;
+
+public class AdxDmiStrategyFactoryTest {
+  private AdxDmiStrategyFactory factory;
+  private BarSeries series;
+
+  @Before
+  public void setUp() {
+    factory = new AdxDmiStrategyFactory();
+    series = new BaseBarSeries();
+    for (int i = 0; i < 50; i++) {
+      series.addBar(
+          new BaseBar(
+              Duration.ofDays(1), ZonedDateTime.now().plusDays(i), 100 + i, 100 + i, 100 + i, 100 + i, 100));
+    }
+  }
+
+  @Test
+  public void testCreateStrategy() {
+    AdxDmiParameters params = AdxDmiParameters.newBuilder().setAdxPeriod(14).setDiPeriod(14).build();
+    Strategy strategy = factory.createStrategy(series, params);
+    assertThat(strategy).isNotNull();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCreateStrategy_negativeAdxPeriod() {
+    AdxDmiParameters params = AdxDmiParameters.newBuilder().setAdxPeriod(-1).setDiPeriod(14).build();
+    factory.createStrategy(series, params);
+  }
+}

--- a/src/test/java/com/verlumen/tradestream/strategies/adxdmi/AdxDmiStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/adxdmi/AdxDmiStrategyFactoryTest.java
@@ -23,7 +23,13 @@ public class AdxDmiStrategyFactoryTest {
     for (int i = 0; i < 50; i++) {
       series.addBar(
           new BaseBar(
-              Duration.ofDays(1), ZonedDateTime.now().plusDays(i), 100 + i, 100 + i, 100 + i, 100 + i, 100));
+              Duration.ofDays(1),
+              ZonedDateTime.now().plusDays(i),
+              100 + i,
+              100 + i,
+              100 + i,
+              100 + i,
+              100));
     }
   }
 

--- a/src/test/java/com/verlumen/tradestream/strategies/adxdmi/AdxDmiStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/adxdmi/AdxDmiStrategyFactoryTest.java
@@ -36,7 +36,8 @@ public class AdxDmiStrategyFactoryTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testCreateStrategy_negativeAdxPeriod() {
-    AdxDmiParameters params = AdxDmiParameters.newBuilder().setAdxPeriod(-1).setDiPeriod(14).build();
+    AdxDmiParameters params =
+        AdxDmiParameters.newBuilder().setAdxPeriod(-1).setDiPeriod(14).build();
     factory.createStrategy(series, params);
   }
 }

--- a/src/test/java/com/verlumen/tradestream/strategies/adxdmi/AdxDmiStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/adxdmi/AdxDmiStrategyFactoryTest.java
@@ -29,7 +29,8 @@ public class AdxDmiStrategyFactoryTest {
 
   @Test
   public void testCreateStrategy() {
-    AdxDmiParameters params = AdxDmiParameters.newBuilder().setAdxPeriod(14).setDiPeriod(14).build();
+    AdxDmiParameters params =
+        AdxDmiParameters.newBuilder().setAdxPeriod(14).setDiPeriod(14).build();
     Strategy strategy = factory.createStrategy(series, params);
     assertThat(strategy).isNotNull();
   }

--- a/src/test/java/com/verlumen/tradestream/strategies/adxdmi/BUILD
+++ b/src/test/java/com/verlumen/tradestream/strategies/adxdmi/BUILD
@@ -1,0 +1,29 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
+java_test(
+    name = "AdxDmiParamConfigTest",
+    srcs = ["AdxDmiParamConfigTest.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/discovery:chromosome_spec",
+        "//src/main/java/com/verlumen/tradestream/strategies/adxdmi:param_config",
+        "//third_party/java:guava",
+        "//third_party/java:jenetics",
+        "//third_party/java:junit",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:truth",
+    ],
+)
+
+java_test(
+    name = "AdxDmiStrategyFactoryTest",
+    srcs = ["AdxDmiStrategyFactoryTest.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/strategies/adxdmi:strategy_factory",
+        "//third_party/java:junit",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:ta4j_core",
+        "//third_party/java:truth",
+    ],
+)


### PR DESCRIPTION
This PR introduces a new technical trading strategy based on the ADX (Average Directional Index) and DMI (Directional Movement Index) indicators. Key components include:

* **`AdxDmiParamConfig`**: Defines the parameter space for the ADX and DI periods using `ChromosomeSpec`. Provides serialization via Protobuf.
* **`AdxDmiStrategyFactory`**: Implements the strategy logic using TA4J indicators and rules. It constructs buy/sell signals based on trend strength and DI crossovers.
* **Tests**: Unit tests for both parameter configuration and strategy factory ensure correctness of behavior and robustness against invalid input.
* **Build files**: Includes Bazel targets for building and testing the new components.

This update introduces new strategy functionality and integration into the system, qualifying as a (MINOR) version increment.
