### PR TITLE
Refactor MomentumIndicator to streamline calculation logic

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/MomentumIndicator.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/MomentumIndicator.kt
@@ -15,6 +15,7 @@ class MomentumIndicator(
         else calculatePercentageChange(index)
     
     override fun getUnstableBars(): Int = period
+
     private fun calculatePercentageChange(index: Int): Num {
         // ((Current Price - Price n periods ago) / Price n periods ago) * 100
         val currentClose = closePrice.getValue(index)

--- a/src/main/java/com/verlumen/tradestream/strategies/MomentumIndicator.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/MomentumIndicator.kt
@@ -9,17 +9,17 @@ class MomentumIndicator(
     private val closePrice: ClosePriceIndicator,
     private val period: Int,
 ) : CachedIndicator<Num>(closePrice) {
-    override fun calculate(index: Int): Num {
-        if (index < period) {
-            // Not enough data yet
-            return numOf(0)
-        }
-        // Calculate percentage change:
+    
+    override fun calculate(index: Int): Num = 
+        if (index < period) getBarSeries().numOf(0.0) // Not enough data yet
+        else calculatePercentageChange(index)
+    
+    override fun getCountOfUnstableBars(): Int = period
+    
+    private fun calculatePercentageChange(index: Int): Num {
         // ((Current Price - Price n periods ago) / Price n periods ago) * 100
         val currentClose = closePrice.getValue(index)
         val previousClose = closePrice.getValue(index - period)
-        return currentClose.minus(previousClose).dividedBy(previousClose).multipliedBy(numOf(100))
+        return currentClose.minus(previousClose).dividedBy(previousClose).multipliedBy(getBarSeries().numOf(100))
     }
-
-    override fun getUnstableBars(): Int = period
 }

--- a/src/main/java/com/verlumen/tradestream/strategies/MomentumIndicator.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/MomentumIndicator.kt
@@ -15,7 +15,6 @@ class MomentumIndicator(
         else calculatePercentageChange(index)
     
     override fun getUnstableBars(): Int = period
-    
     private fun calculatePercentageChange(index: Int): Num {
         // ((Current Price - Price n periods ago) / Price n periods ago) * 100
         val currentClose = closePrice.getValue(index)

--- a/src/main/java/com/verlumen/tradestream/strategies/MomentumIndicator.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/MomentumIndicator.kt
@@ -11,7 +11,7 @@ class MomentumIndicator(
 ) : CachedIndicator<Num>(closePrice) {
     
     override fun calculate(index: Int): Num = 
-        if (index < period) getBarSeries().numOf(0.0) // Not enough data yet
+        if (index < period) numOf(0.0) // Not enough data yet
         else calculatePercentageChange(index)
     
     override fun getCountOfUnstableBars(): Int = period

--- a/src/main/java/com/verlumen/tradestream/strategies/MomentumIndicator.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/MomentumIndicator.kt
@@ -14,7 +14,7 @@ class MomentumIndicator(
         if (index < period) numOf(0.0) // Not enough data yet
         else calculatePercentageChange(index)
     
-    override fun getCountOfUnstableBars(): Int = period
+    override fun getUnstableBars(): Int = period
     
     private fun calculatePercentageChange(index: Int): Num {
         // ((Current Price - Price n periods ago) / Price n periods ago) * 100

--- a/src/main/java/com/verlumen/tradestream/strategies/MomentumIndicator.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/MomentumIndicator.kt
@@ -9,11 +9,13 @@ class MomentumIndicator(
     private val closePrice: ClosePriceIndicator,
     private val period: Int,
 ) : CachedIndicator<Num>(closePrice) {
-    
-    override fun calculate(index: Int): Num = 
-        if (index < period) numOf(0.0) // Not enough data yet
-        else calculatePercentageChange(index)
-    
+    override fun calculate(index: Int): Num =
+        if (index < period) {
+            numOf(0.0) // Not enough data yet
+        } else {
+            calculatePercentageChange(index)
+        }
+
     override fun getUnstableBars(): Int = period
 
     private fun calculatePercentageChange(index: Int): Num {


### PR DESCRIPTION
This patch refactors the `MomentumIndicator` class to improve code clarity and maintainability:

* Converts `calculate` from a block body to an expression body for conciseness.
* Extracts percentage change computation into a dedicated private method `calculatePercentageChange`.
* Reorders method definitions to place `getUnstableBars` below the overridden `calculate`.
* Replaces usage of `numOf(100)` with `getBarSeries().numOf(100)` for consistency.

This is a non-functional change that improves readability without altering behavior.
