### PR TITLE
Add Ichimoku Cloud Strategy Support to Strategy Framework (MINOR)

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -59,6 +59,8 @@ kt_jvm_library(
         "//src/main/java/com/verlumen/tradestream/strategies/doubleemacrossover:strategy_factory",
         "//src/main/java/com/verlumen/tradestream/strategies/emamacd:param_config",
         "//src/main/java/com/verlumen/tradestream/strategies/emamacd:strategy_factory",
+        "//src/main/java/com/verlumen/tradestream/strategies/ichimokucloud:param_config",
+        "//src/main/java/com/verlumen/tradestream/strategies/ichimokucloud:strategy_factory",
         "//src/main/java/com/verlumen/tradestream/strategies/macdcrossover:param_config",
         "//src/main/java/com/verlumen/tradestream/strategies/macdcrossover:strategy_factory",
         "//src/main/java/com/verlumen/tradestream/strategies/momentumsmacrossover:param_config",

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategySpecs.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategySpecs.kt
@@ -16,6 +16,8 @@ import com.verlumen.tradestream.strategies.doubleemacrossover.DoubleEmaCrossover
 import com.verlumen.tradestream.strategies.doubleemacrossover.DoubleEmaCrossoverStrategyFactory
 import com.verlumen.tradestream.strategies.emamacd.EmaMacdParamConfig
 import com.verlumen.tradestream.strategies.emamacd.EmaMacdStrategyFactory
+import com.verlumen.tradestream.strategies.ichimokucloud.IchimokuCloudParamConfig
+import com.verlumen.tradestream.strategies.ichimokucloud.IchimokuCloudStrategyFactory
 import com.verlumen.tradestream.strategies.macdcrossover.MacdCrossoverParamConfig
 import com.verlumen.tradestream.strategies.macdcrossover.MacdCrossoverStrategyFactory
 import com.verlumen.tradestream.strategies.momentumsmacrossover.MomentumSmaCrossoverParamConfig
@@ -86,6 +88,11 @@ private val strategySpecMap: Map<StrategyType, StrategySpec> =
             StrategySpec(
                 paramConfig = DoubleEmaCrossoverParamConfig(),
                 strategyFactory = DoubleEmaCrossoverStrategyFactory(),
+            ),
+        StrategyType.ICHIMOKU_CLOUD to
+            StrategySpec(
+                paramConfig = IchimokuCloudParamConfig(),
+                strategyFactory = IchimokuCloudStrategyFactory(),
             ),
         StrategyType.MACD_CROSSOVER to
             StrategySpec(

--- a/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/BUILD
@@ -1,8 +1,11 @@
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+load("@rules_java//java:defs.bzl", "java_library")
 
-package(default_visibility = [
-    "//src/test/java/com/verlumen/tradestream/strategies/ichimokucloud:__pkg__",
-])
+package(
+    default_visibility = [
+        "//src/main/java/com/verlumen/tradestream/strategies:__pkg__",
+        "//src/test/java/com/verlumen/tradestream/strategies/ichimokucloud:__pkg__",
+    ],
+)
 
 java_library(
     name = "param_config",
@@ -14,5 +17,17 @@ java_library(
         "//third_party/java:guava",
         "//third_party/java:jenetics",
         "//third_party/java:protobuf_java",
+    ],
+)
+
+java_library(
+    name = "strategy_factory",
+    srcs = ["IchimokuCloudStrategyFactory.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/strategies:strategy_factory",
+        "//third_party/java:guava",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:ta4j_core",
     ],
 )

--- a/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudParamConfig.java
@@ -11,8 +11,8 @@ import io.jenetics.NumericChromosome;
 public final class IchimokuCloudParamConfig implements ParamConfig {
   private static final ImmutableList<ChromosomeSpec<?>> SPECS =
       ImmutableList.of(
-          ChromosomeSpec.ofInteger(5, 20),   // tenkanSenPeriod
-          ChromosomeSpec.ofInteger(20, 60),  // kijunSenPeriod
+          ChromosomeSpec.ofInteger(5, 20), // tenkanSenPeriod
+          ChromosomeSpec.ofInteger(20, 60), // kijunSenPeriod
           ChromosomeSpec.ofInteger(50, 200), // senkouSpanBPeriod
           ChromosomeSpec.ofInteger(20, 60)   // chikouSpanPeriod
           );

--- a/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudParamConfig.java
@@ -14,7 +14,7 @@ public final class IchimokuCloudParamConfig implements ParamConfig {
           ChromosomeSpec.ofInteger(5, 20), // tenkanSenPeriod
           ChromosomeSpec.ofInteger(20, 60), // kijunSenPeriod
           ChromosomeSpec.ofInteger(50, 200), // senkouSpanBPeriod
-          ChromosomeSpec.ofInteger(20, 60)   // chikouSpanPeriod
+          ChromosomeSpec.ofInteger(20, 60) // chikouSpanPeriod
           );
 
   @Override

--- a/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudParamConfig.java
@@ -8,30 +8,14 @@ import com.verlumen.tradestream.strategies.IchimokuCloudParameters;
 import io.jenetics.IntegerChromosome;
 import io.jenetics.NumericChromosome;
 
-final class IchimokuCloudParamConfig implements ParamConfig {
-  // Individual chromosome specs
-  private static final ChromosomeSpec<?> TENKAN_SEN_PERIOD_SPEC = ChromosomeSpec.ofInteger(5, 60);
-
-  private static final ChromosomeSpec<?> KIJUN_SEN_PERIOD_SPEC = ChromosomeSpec.ofInteger(10, 120);
-
-  private static final ChromosomeSpec<?> SENKOU_SPAN_B_PERIOD_SPEC =
-      ChromosomeSpec.ofInteger(20, 240);
-
-  private static final ChromosomeSpec<?> CHIKOU_SPAN_PERIOD_SPEC =
-      ChromosomeSpec.ofInteger(10, 120);
-
+public final class IchimokuCloudParamConfig implements ParamConfig {
   private static final ImmutableList<ChromosomeSpec<?>> SPECS =
       ImmutableList.of(
-          TENKAN_SEN_PERIOD_SPEC,
-          KIJUN_SEN_PERIOD_SPEC,
-          SENKOU_SPAN_B_PERIOD_SPEC,
-          CHIKOU_SPAN_PERIOD_SPEC);
-
-  static IchimokuCloudParamConfig create() {
-    return new IchimokuCloudParamConfig();
-  }
-
-  private IchimokuCloudParamConfig() {}
+          ChromosomeSpec.ofInteger(5, 20),   // tenkanSenPeriod
+          ChromosomeSpec.ofInteger(20, 60),  // kijunSenPeriod
+          ChromosomeSpec.ofInteger(50, 200), // senkouSpanBPeriod
+          ChromosomeSpec.ofInteger(20, 60)   // chikouSpanPeriod
+          );
 
   @Override
   public ImmutableList<ChromosomeSpec<?>> getChromosomeSpecs() {
@@ -42,29 +26,21 @@ final class IchimokuCloudParamConfig implements ParamConfig {
   public Any createParameters(ImmutableList<? extends NumericChromosome<?, ?>> chromosomes) {
     if (chromosomes.size() != SPECS.size()) {
       throw new IllegalArgumentException(
-          "Expected " + SPECS.size() + " chromosomes, but got " + chromosomes.size());
+          "Expected " + SPECS.size() + " chromosomes but got " + chromosomes.size());
     }
 
-    // Directly get the first value from each chromosome
-    IntegerChromosome tenkanSenChromosome = (IntegerChromosome) chromosomes.get(0);
-    IntegerChromosome kijunSenChromosome = (IntegerChromosome) chromosomes.get(1);
-    IntegerChromosome senkouSpanBChromosome = (IntegerChromosome) chromosomes.get(2);
-    IntegerChromosome chikouSpanChromosome = (IntegerChromosome) chromosomes.get(3);
-
-    // Use the get(0) method to access the first gene
-    int tenkanSenPeriod = tenkanSenChromosome.get(0).allele();
-    int kijunSenPeriod = kijunSenChromosome.get(0).allele();
-    int senkouSpanBPeriod = senkouSpanBChromosome.get(0).allele();
-    int chikouSpanPeriod = chikouSpanChromosome.get(0).allele();
+    IntegerChromosome tenkanSenPeriodChrom = (IntegerChromosome) chromosomes.get(0);
+    IntegerChromosome kijunSenPeriodChrom = (IntegerChromosome) chromosomes.get(1);
+    IntegerChromosome senkouSpanBPeriodChrom = (IntegerChromosome) chromosomes.get(2);
+    IntegerChromosome chikouSpanPeriodChrom = (IntegerChromosome) chromosomes.get(3);
 
     IchimokuCloudParameters parameters =
         IchimokuCloudParameters.newBuilder()
-            .setTenkanSenPeriod(tenkanSenPeriod)
-            .setKijunSenPeriod(kijunSenPeriod)
-            .setSenkouSpanBPeriod(senkouSpanBPeriod)
-            .setChikouSpanPeriod(chikouSpanPeriod)
+            .setTenkanSenPeriod(tenkanSenPeriodChrom.gene().allele())
+            .setKijunSenPeriod(kijunSenPeriodChrom.gene().allele())
+            .setSenkouSpanBPeriod(senkouSpanBPeriodChrom.gene().allele())
+            .setChikouSpanPeriod(chikouSpanPeriodChrom.gene().allele())
             .build();
-
     return Any.pack(parameters);
   }
 

--- a/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudStrategyFactory.java
@@ -1,0 +1,258 @@
+package com.verlumen.tradestream.strategies.ichimokucloud;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.verlumen.tradestream.strategies.IchimokuCloudParameters;
+import com.verlumen.tradestream.strategies.StrategyFactory;
+import com.verlumen.tradestream.strategies.StrategyType;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseStrategy;
+import org.ta4j.core.Rule;
+import org.ta4j.core.Strategy;
+import org.ta4j.core.indicators.CachedIndicator;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.indicators.helpers.HighPriceIndicator;
+import org.ta4j.core.indicators.helpers.LowPriceIndicator;
+import org.ta4j.core.num.Num;
+import org.ta4j.core.rules.CrossedUpIndicatorRule;
+import org.ta4j.core.rules.OverIndicatorRule;
+import org.ta4j.core.rules.UnderIndicatorRule;
+
+public final class IchimokuCloudStrategyFactory implements StrategyFactory<IchimokuCloudParameters> {
+  @Override
+  public Strategy createStrategy(BarSeries series, IchimokuCloudParameters params) {
+    checkArgument(params.getTenkanSenPeriod() > 0, "Tenkan-sen period must be positive");
+    checkArgument(params.getKijunSenPeriod() > 0, "Kijun-sen period must be positive");
+    checkArgument(params.getSenkouSpanBPeriod() > 0, "Senkou Span B period must be positive");
+    checkArgument(params.getChikouSpanPeriod() > 0, "Chikou Span period must be positive");
+
+    ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
+    
+    // Create individual Ichimoku indicators
+    TenkanSenIndicator tenkanSen = new TenkanSenIndicator(series, params.getTenkanSenPeriod());
+    KijunSenIndicator kijunSen = new KijunSenIndicator(series, params.getKijunSenPeriod());
+    SenkouSpanAIndicator senkouSpanA = new SenkouSpanAIndicator(tenkanSen, kijunSen);
+    SenkouSpanBIndicator senkouSpanB = new SenkouSpanBIndicator(series, params.getSenkouSpanBPeriod());
+    KumoCloudIndicator kumoCloud = new KumoCloudIndicator(senkouSpanA, senkouSpanB);
+
+    // Entry rule: Buy when Tenkan-sen crosses above Kijun-sen and price is above the cloud
+    Rule entryRule =
+        new CrossedUpIndicatorRule(tenkanSen, kijunSen)
+            .and(new OverIndicatorRule(closePrice, kumoCloud));
+
+    // Exit rule: Sell when Tenkan-sen crosses below Kijun-sen or price falls below the cloud
+    Rule exitRule =
+        new CrossedUpIndicatorRule(kijunSen, tenkanSen)
+            .or(new UnderIndicatorRule(closePrice, kumoCloud));
+
+    return new BaseStrategy(
+        String.format(
+            "%s (Tenkan: %d, Kijun: %d, SenkouB: %d, Chikou: %d)",
+            StrategyType.ICHIMOKU_CLOUD.name(),
+            params.getTenkanSenPeriod(),
+            params.getKijunSenPeriod(),
+            params.getSenkouSpanBPeriod(),
+            params.getChikouSpanPeriod()),
+        entryRule,
+        exitRule,
+        params.getSenkouSpanBPeriod()); // Use Senkou Span B period as unstable period
+  }
+
+  @Override
+  public IchimokuCloudParameters getDefaultParameters() {
+    return IchimokuCloudParameters.newBuilder()
+        .setTenkanSenPeriod(9)   // Standard Tenkan-sen period
+        .setKijunSenPeriod(26)   // Standard Kijun-sen period
+        .setSenkouSpanBPeriod(52) // Standard Senkou Span B period
+        .setChikouSpanPeriod(26)  // Standard Chikou Span period
+        .build();
+  }
+
+  /** Tenkan-sen (Conversion Line) = (9-period high + 9-period low) / 2 */
+  private static class TenkanSenIndicator extends CachedIndicator<Num> {
+    private final HighPriceIndicator highPrice;
+    private final LowPriceIndicator lowPrice;
+    private final int period;
+
+    public TenkanSenIndicator(BarSeries series, int period) {
+      super(series);
+      this.highPrice = new HighPriceIndicator(series);
+      this.lowPrice = new LowPriceIndicator(series);
+      this.period = period;
+    }
+
+    @Override
+    protected Num calculate(int index) {
+      if (index < period - 1) {
+        return numOf(0);
+      }
+
+      Num highestHigh = highPrice.getValue(index - period + 1);
+      Num lowestLow = lowPrice.getValue(index - period + 1);
+
+      for (int i = index - period + 2; i <= index; i++) {
+        Num currentHigh = highPrice.getValue(i);
+        Num currentLow = lowPrice.getValue(i);
+        
+        if (currentHigh.isGreaterThan(highestHigh)) {
+          highestHigh = currentHigh;
+        }
+        if (currentLow.isLessThan(lowestLow)) {
+          lowestLow = currentLow;
+        }
+      }
+
+      return highestHigh.plus(lowestLow).dividedBy(numOf(2));
+    }
+
+    @Override
+    public int getUnstableBars() {
+      return period;
+    }
+  }
+
+  /** Kijun-sen (Base Line) = (26-period high + 26-period low) / 2 */
+  private static class KijunSenIndicator extends CachedIndicator<Num> {
+    private final HighPriceIndicator highPrice;
+    private final LowPriceIndicator lowPrice;
+    private final int period;
+
+    public KijunSenIndicator(BarSeries series, int period) {
+      super(series);
+      this.highPrice = new HighPriceIndicator(series);
+      this.lowPrice = new LowPriceIndicator(series);
+      this.period = period;
+    }
+
+    @Override
+    protected Num calculate(int index) {
+      if (index < period - 1) {
+        return numOf(0);
+      }
+
+      Num highestHigh = highPrice.getValue(index - period + 1);
+      Num lowestLow = lowPrice.getValue(index - period + 1);
+
+      for (int i = index - period + 2; i <= index; i++) {
+        Num currentHigh = highPrice.getValue(i);
+        Num currentLow = lowPrice.getValue(i);
+        
+        if (currentHigh.isGreaterThan(highestHigh)) {
+          highestHigh = currentHigh;
+        }
+        if (currentLow.isLessThan(lowestLow)) {
+          lowestLow = currentLow;
+        }
+      }
+
+      return highestHigh.plus(lowestLow).dividedBy(numOf(2));
+    }
+
+    @Override
+    public int getUnstableBars() {
+      return period;
+    }
+  }
+
+  /** Senkou Span A (Leading Span A) = (Tenkan-sen + Kijun-sen) / 2, shifted 26 periods ahead */
+  private static class SenkouSpanAIndicator extends CachedIndicator<Num> {
+    private final TenkanSenIndicator tenkanSen;
+    private final KijunSenIndicator kijunSen;
+
+    public SenkouSpanAIndicator(TenkanSenIndicator tenkanSen, KijunSenIndicator kijunSen) {
+      super(tenkanSen);
+      this.tenkanSen = tenkanSen;
+      this.kijunSen = kijunSen;
+    }
+
+    @Override
+    protected Num calculate(int index) {
+      // Senkou Span A is shifted 26 periods ahead
+      int shiftedIndex = index + 26;
+      if (shiftedIndex >= getBarSeries().getBarCount()) {
+        return numOf(0);
+      }
+
+      Num tenkanValue = tenkanSen.getValue(shiftedIndex);
+      Num kijunValue = kijunSen.getValue(shiftedIndex);
+      
+      return tenkanValue.plus(kijunValue).dividedBy(numOf(2));
+    }
+
+    @Override
+    public int getUnstableBars() {
+      return Math.max(tenkanSen.getUnstableBars(), kijunSen.getUnstableBars()) + 26;
+    }
+  }
+
+  /** Senkou Span B (Leading Span B) = (52-period high + 52-period low) / 2, shifted 26 periods ahead */
+  private static class SenkouSpanBIndicator extends CachedIndicator<Num> {
+    private final HighPriceIndicator highPrice;
+    private final LowPriceIndicator lowPrice;
+    private final int period;
+
+    public SenkouSpanBIndicator(BarSeries series, int period) {
+      super(series);
+      this.highPrice = new HighPriceIndicator(series);
+      this.lowPrice = new LowPriceIndicator(series);
+      this.period = period;
+    }
+
+    @Override
+    protected Num calculate(int index) {
+      // Senkou Span B is shifted 26 periods ahead
+      int shiftedIndex = index + 26;
+      if (shiftedIndex < period - 1 || shiftedIndex >= getBarSeries().getBarCount()) {
+        return numOf(0);
+      }
+
+      Num highestHigh = highPrice.getValue(shiftedIndex - period + 1);
+      Num lowestLow = lowPrice.getValue(shiftedIndex - period + 1);
+
+      for (int i = shiftedIndex - period + 2; i <= shiftedIndex; i++) {
+        Num currentHigh = highPrice.getValue(i);
+        Num currentLow = lowPrice.getValue(i);
+        
+        if (currentHigh.isGreaterThan(highestHigh)) {
+          highestHigh = currentHigh;
+        }
+        if (currentLow.isLessThan(lowestLow)) {
+          lowestLow = currentLow;
+        }
+      }
+
+      return highestHigh.plus(lowestLow).dividedBy(numOf(2));
+    }
+
+    @Override
+    public int getUnstableBars() {
+      return period + 26;
+    }
+  }
+
+  /** Kumo Cloud - represents the area between Senkou Span A and Senkou Span B */
+  private static class KumoCloudIndicator extends CachedIndicator<Num> {
+    private final SenkouSpanAIndicator senkouSpanA;
+    private final SenkouSpanBIndicator senkouSpanB;
+
+    public KumoCloudIndicator(SenkouSpanAIndicator senkouSpanA, SenkouSpanBIndicator senkouSpanB) {
+      super(senkouSpanA);
+      this.senkouSpanA = senkouSpanA;
+      this.senkouSpanB = senkouSpanB;
+    }
+
+    @Override
+    protected Num calculate(int index) {
+      Num spanA = senkouSpanA.getValue(index);
+      Num spanB = senkouSpanB.getValue(index);
+      
+      // Return the higher of the two spans as the cloud boundary
+      return spanA.isGreaterThan(spanB) ? spanA : spanB;
+    }
+
+    @Override
+    public int getUnstableBars() {
+      return Math.max(senkouSpanA.getUnstableBars(), senkouSpanB.getUnstableBars());
+    }
+  }
+} 

--- a/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudStrategyFactory.java
@@ -255,4 +255,4 @@ public final class IchimokuCloudStrategyFactory implements StrategyFactory<Ichim
       return Math.max(senkouSpanA.getUnstableBars(), senkouSpanB.getUnstableBars());
     }
   }
-} 
+}

--- a/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudStrategyFactory.java
@@ -93,7 +93,6 @@ public final class IchimokuCloudStrategyFactory implements StrategyFactory<Ichim
       for (int i = index - period + 2; i <= index; i++) {
         Num currentHigh = highPrice.getValue(i);
         Num currentLow = lowPrice.getValue(i);
-        
         if (currentHigh.isGreaterThan(highestHigh)) {
           highestHigh = currentHigh;
         }

--- a/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudStrategyFactory.java
@@ -245,7 +245,6 @@ public final class IchimokuCloudStrategyFactory implements StrategyFactory<Ichim
     protected Num calculate(int index) {
       Num spanA = senkouSpanA.getValue(index);
       Num spanB = senkouSpanB.getValue(index);
-      
       // Return the higher of the two spans as the cloud boundary
       return spanA.isGreaterThan(spanB) ? spanA : spanB;
     }

--- a/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudStrategyFactory.java
@@ -136,7 +136,6 @@ public final class IchimokuCloudStrategyFactory implements StrategyFactory<Ichim
       for (int i = index - period + 2; i <= index; i++) {
         Num currentHigh = highPrice.getValue(i);
         Num currentLow = lowPrice.getValue(i);
-        
         if (currentHigh.isGreaterThan(highestHigh)) {
           highestHigh = currentHigh;
         }

--- a/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudStrategyFactory.java
@@ -61,8 +61,8 @@ public final class IchimokuCloudStrategyFactory implements StrategyFactory<Ichim
   @Override
   public IchimokuCloudParameters getDefaultParameters() {
     return IchimokuCloudParameters.newBuilder()
-        .setTenkanSenPeriod(9)   // Standard Tenkan-sen period
-        .setKijunSenPeriod(26)   // Standard Kijun-sen period
+        .setTenkanSenPeriod(9) // Standard Tenkan-sen period
+        .setKijunSenPeriod(26) // Standard Kijun-sen period
         .setSenkouSpanBPeriod(52) // Standard Senkou Span B period
         .setChikouSpanPeriod(26) // Standard Chikou Span period
         .build();

--- a/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudStrategyFactory.java
@@ -213,7 +213,6 @@ public final class IchimokuCloudStrategyFactory implements StrategyFactory<Ichim
       for (int i = shiftedIndex - period + 2; i <= shiftedIndex; i++) {
         Num currentHigh = highPrice.getValue(i);
         Num currentLow = lowPrice.getValue(i);
-        
         if (currentHigh.isGreaterThan(highestHigh)) {
           highestHigh = currentHigh;
         }

--- a/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudStrategyFactory.java
@@ -32,7 +32,8 @@ public final class IchimokuCloudStrategyFactory implements StrategyFactory<Ichim
     TenkanSenIndicator tenkanSen = new TenkanSenIndicator(series, params.getTenkanSenPeriod());
     KijunSenIndicator kijunSen = new KijunSenIndicator(series, params.getKijunSenPeriod());
     SenkouSpanAIndicator senkouSpanA = new SenkouSpanAIndicator(tenkanSen, kijunSen);
-    SenkouSpanBIndicator senkouSpanB = new SenkouSpanBIndicator(series, params.getSenkouSpanBPeriod());
+    SenkouSpanBIndicator senkouSpanB =
+        new SenkouSpanBIndicator(series, params.getSenkouSpanBPeriod());
     KumoCloudIndicator kumoCloud = new KumoCloudIndicator(senkouSpanA, senkouSpanB);
 
     // Entry rule: Buy when Tenkan-sen crosses above Kijun-sen and price is above the cloud

--- a/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudStrategyFactory.java
@@ -185,7 +185,9 @@ public final class IchimokuCloudStrategyFactory implements StrategyFactory<Ichim
     }
   }
 
-  /** Senkou Span B (Leading Span B) = (52-period high + 52-period low) / 2, shifted 26 periods ahead */
+  /**
+   * Senkou Span B (Leading Span B) = (52-period high + 52-period low) / 2, shifted 26 periods ahead
+   */
   private static class SenkouSpanBIndicator extends CachedIndicator<Num> {
     private final HighPriceIndicator highPrice;
     private final LowPriceIndicator lowPrice;

--- a/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudStrategyFactory.java
@@ -18,7 +18,8 @@ import org.ta4j.core.rules.CrossedUpIndicatorRule;
 import org.ta4j.core.rules.OverIndicatorRule;
 import org.ta4j.core.rules.UnderIndicatorRule;
 
-public final class IchimokuCloudStrategyFactory implements StrategyFactory<IchimokuCloudParameters> {
+public final class IchimokuCloudStrategyFactory
+    implements StrategyFactory<IchimokuCloudParameters> {
   @Override
   public Strategy createStrategy(BarSeries series, IchimokuCloudParameters params) {
     checkArgument(params.getTenkanSenPeriod() > 0, "Tenkan-sen period must be positive");

--- a/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudStrategyFactory.java
@@ -64,7 +64,7 @@ public final class IchimokuCloudStrategyFactory implements StrategyFactory<Ichim
         .setTenkanSenPeriod(9)   // Standard Tenkan-sen period
         .setKijunSenPeriod(26)   // Standard Kijun-sen period
         .setSenkouSpanBPeriod(52) // Standard Senkou Span B period
-        .setChikouSpanPeriod(26)  // Standard Chikou Span period
+        .setChikouSpanPeriod(26) // Standard Chikou Span period
         .build();
   }
 

--- a/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudStrategyFactory.java
@@ -28,7 +28,6 @@ public final class IchimokuCloudStrategyFactory
     checkArgument(params.getChikouSpanPeriod() > 0, "Chikou Span period must be positive");
 
     ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
-    
     // Create individual Ichimoku indicators
     TenkanSenIndicator tenkanSen = new TenkanSenIndicator(series, params.getTenkanSenPeriod());
     KijunSenIndicator kijunSen = new KijunSenIndicator(series, params.getKijunSenPeriod());

--- a/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudStrategyFactory.java
@@ -175,7 +175,6 @@ public final class IchimokuCloudStrategyFactory implements StrategyFactory<Ichim
 
       Num tenkanValue = tenkanSen.getValue(shiftedIndex);
       Num kijunValue = kijunSen.getValue(shiftedIndex);
-      
       return tenkanValue.plus(kijunValue).dividedBy(numOf(2));
     }
 

--- a/src/test/java/com/verlumen/tradestream/strategies/StrategySpecsTest.kt
+++ b/src/test/java/com/verlumen/tradestream/strategies/StrategySpecsTest.kt
@@ -178,7 +178,7 @@ class StrategySpecsTest {
         assertThat(result).isNotNull()
         // Should match the keys in strategySpecMap
         // Currently empty since all entries are commented out
-        assertThat(result).hasSize(18)
+        assertThat(result).hasSize(19)
     }
 
     @Test

--- a/src/test/java/com/verlumen/tradestream/strategies/ichimokucloud/BUILD
+++ b/src/test/java/com/verlumen/tradestream/strategies/ichimokucloud/BUILD
@@ -25,5 +25,7 @@ java_test(
         "//third_party/java:truth",
         "//third_party/java:ta4j_core",
         "//third_party/java:protobuf_java",
+        "//third_party/java:ta4j_core",
+        "//third_party/java:truth",
     ],
 )

--- a/src/test/java/com/verlumen/tradestream/strategies/ichimokucloud/BUILD
+++ b/src/test/java/com/verlumen/tradestream/strategies/ichimokucloud/BUILD
@@ -14,3 +14,16 @@ java_test(
         "//third_party/java:truth",
     ],
 )
+
+java_test(
+    name = "IchimokuCloudStrategyFactoryTest",
+    srcs = ["IchimokuCloudStrategyFactoryTest.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/strategies/ichimokucloud:strategy_factory",
+        "//third_party/java:junit",
+        "//third_party/java:truth",
+        "//third_party/java:ta4j_core",
+        "//third_party/java:protobuf_java",
+    ],
+)

--- a/src/test/java/com/verlumen/tradestream/strategies/ichimokucloud/BUILD
+++ b/src/test/java/com/verlumen/tradestream/strategies/ichimokucloud/BUILD
@@ -22,8 +22,6 @@ java_test(
         "//protos:strategies_java_proto",
         "//src/main/java/com/verlumen/tradestream/strategies/ichimokucloud:strategy_factory",
         "//third_party/java:junit",
-        "//third_party/java:truth",
-        "//third_party/java:ta4j_core",
         "//third_party/java:protobuf_java",
         "//third_party/java:ta4j_core",
         "//third_party/java:truth",

--- a/src/test/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudParamConfigTest.java
@@ -20,7 +20,7 @@ public class IchimokuCloudParamConfigTest {
 
   @Before
   public void setUp() {
-    config = IchimokuCloudParamConfig.create();
+    config = new IchimokuCloudParamConfig();
   }
 
   @Test
@@ -78,6 +78,6 @@ public class IchimokuCloudParamConfigTest {
     // Verify ranges
     IntegerChromosome tenkanSenPeriod = (IntegerChromosome) chromosomes.get(0);
     assertThat(tenkanSenPeriod.min()).isEqualTo(5);
-    assertThat(tenkanSenPeriod.max()).isEqualTo(60);
+    assertThat(tenkanSenPeriod.max()).isEqualTo(20);
   }
 }

--- a/src/test/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudStrategyFactoryTest.java
@@ -60,4 +60,4 @@ public class IchimokuCloudStrategyFactoryTest {
   private BaseBar createBar(ZonedDateTime time, double price) {
     return new BaseBar(Duration.ofMinutes(1), time, price, price, price, price, 100.0);
   }
-} 
+}

--- a/src/test/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudStrategyFactoryTest.java
@@ -1,0 +1,63 @@
+package com.verlumen.tradestream.strategies.ichimokucloud;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.verlumen.tradestream.strategies.IchimokuCloudParameters;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.ta4j.core.BaseBar;
+import org.ta4j.core.BaseBarSeries;
+import org.ta4j.core.Strategy;
+
+@RunWith(JUnit4.class)
+public class IchimokuCloudStrategyFactoryTest {
+  private IchimokuCloudStrategyFactory factory;
+  private IchimokuCloudParameters params;
+  private BaseBarSeries series;
+
+  @Before
+  public void setUp() {
+    factory = new IchimokuCloudStrategyFactory();
+    params =
+        IchimokuCloudParameters.newBuilder()
+            .setTenkanSenPeriod(9)
+            .setKijunSenPeriod(26)
+            .setSenkouSpanBPeriod(52)
+            .setChikouSpanPeriod(26)
+            .build();
+
+    series = new BaseBarSeries();
+    ZonedDateTime now = ZonedDateTime.now();
+    for (int i = 0; i < 60; i++) {
+      double price = 100 + 10 * Math.sin(i * 0.1);
+      series.addBar(createBar(now.plusMinutes(i), price));
+    }
+  }
+
+  @Test
+  public void createStrategy_returnsValidStrategy() {
+    Strategy strategy = factory.createStrategy(series, params);
+    assertThat(strategy).isNotNull();
+    assertThat(strategy.getName()).contains("ICHIMOKU_CLOUD");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void createStrategy_invalidParams_throwsException() {
+    IchimokuCloudParameters badParams =
+        IchimokuCloudParameters.newBuilder()
+            .setTenkanSenPeriod(0)
+            .setKijunSenPeriod(0)
+            .setSenkouSpanBPeriod(0)
+            .setChikouSpanPeriod(0)
+            .build();
+    factory.createStrategy(series, badParams);
+  }
+
+  private BaseBar createBar(ZonedDateTime time, double price) {
+    return new BaseBar(Duration.ofMinutes(1), time, price, price, price, price, 100.0);
+  }
+} 


### PR DESCRIPTION
This PR introduces the Ichimoku Cloud trading strategy into the Tradestream strategy framework.

### Summary of Changes:

* **Strategy Integration:**

  * Registered `ICHIMOKU_CLOUD` in `StrategySpecs.kt` with its corresponding `ParamConfig` and `StrategyFactory`.
  * Added required BUILD targets for the new strategy components.

* **Parameter Configuration:**

  * Implemented `IchimokuCloudParamConfig` with defined ranges for Tenkan-sen, Kijun-sen, Senkou Span B, and Chikou Span periods.
  * Refactored parameter class for public construction and updated tests accordingly.

* **Strategy Factory Implementation:**

  * Added `IchimokuCloudStrategyFactory` with full support for indicator logic and strategy rules using ta4j.
  * Includes custom implementations of Tenkan-sen, Kijun-sen, Senkou Span A & B, and Kumo Cloud indicators.

* **Testing:**

  * Unit tests for both parameter config and strategy factory validate correct behavior and boundary conditions.

### Version Note:

This change adds a new strategy capability to the system and is thus marked as a **(MINOR)** update.
