### PR TITLE
Add Stochastic EMA strategy support (MINOR)

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -89,6 +89,8 @@ kt_jvm_library(
         "//src/main/java/com/verlumen/tradestream/strategies/smarsi:strategy_factory",
         "//src/main/java/com/verlumen/tradestream/strategies/stochasticsrsi:param_config",
         "//src/main/java/com/verlumen/tradestream/strategies/stochasticsrsi:strategy_factory",
+        "//src/main/java/com/verlumen/tradestream/strategies/stochasticema:param_config",
+        "//src/main/java/com/verlumen/tradestream/strategies/stochasticema:strategy_factory",
         "//src/main/java/com/verlumen/tradestream/strategies/tripleemacrossover:param_config",
         "//src/main/java/com/verlumen/tradestream/strategies/tripleemacrossover:strategy_factory",
         "//src/main/java/com/verlumen/tradestream/strategies/volatilitystop:param_config",

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategySpecs.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategySpecs.kt
@@ -44,6 +44,8 @@ import com.verlumen.tradestream.strategies.smaemacrossover.SmaEmaCrossoverParamC
 import com.verlumen.tradestream.strategies.smaemacrossover.SmaEmaCrossoverStrategyFactory
 import com.verlumen.tradestream.strategies.smarsi.SmaRsiParamConfig
 import com.verlumen.tradestream.strategies.smarsi.SmaRsiStrategyFactory
+import com.verlumen.tradestream.strategies.stochasticema.StochasticEmaParamConfig
+import com.verlumen.tradestream.strategies.stochasticema.StochasticEmaStrategyFactory
 import com.verlumen.tradestream.strategies.stochasticsrsi.StochasticRsiParamConfig
 import com.verlumen.tradestream.strategies.stochasticsrsi.StochasticRsiStrategyFactory
 import com.verlumen.tradestream.strategies.tripleemacrossover.TripleEmaCrossoverParamConfig
@@ -192,6 +194,11 @@ private val strategySpecMap: Map<StrategyType, StrategySpec> =
             StrategySpec(
                 paramConfig = MassIndexParamConfig(),
                 strategyFactory = MassIndexStrategyFactory(),
+            ),
+        StrategyType.STOCHASTIC_EMA to
+            StrategySpec(
+                paramConfig = StochasticEmaParamConfig(),
+                strategyFactory = StochasticEmaStrategyFactory(),
             ),
         // To add a new strategy, just add a new entry here.
     )

--- a/src/main/java/com/verlumen/tradestream/strategies/stochasticema/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/stochasticema/BUILD
@@ -1,0 +1,28 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
+java_library(
+    name = "param_config",
+    srcs = ["StochasticEmaParamConfig.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/discovery:chromosome_spec",
+        "//src/main/java/com/verlumen/tradestream/discovery:param_config",
+        "//third_party/java:guava",
+        "//third_party/java:jenetics",
+        "//third_party/java:protobuf_java",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+java_library(
+    name = "strategy_factory",
+    srcs = ["StochasticEmaStrategyFactory.java"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/strategies:strategy_factory",
+        "//third_party/java:guava",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:ta4j_core",
+    ],
+    visibility = ["//visibility:public"],
+) 

--- a/src/main/java/com/verlumen/tradestream/strategies/stochasticema/StochasticEmaParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/stochasticema/StochasticEmaParamConfig.java
@@ -1,0 +1,114 @@
+package com.verlumen.tradestream.strategies.stochasticema;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.verlumen.tradestream.discovery.ChromosomeSpec;
+import com.verlumen.tradestream.discovery.ParamConfig;
+import com.verlumen.tradestream.strategies.StochasticEmaParameters;
+import io.jenetics.IntegerChromosome;
+import io.jenetics.NumericChromosome;
+import java.util.logging.Logger;
+
+/**
+ * Configuration for Stochastic EMA strategy parameters.
+ *
+ * <p>The Stochastic EMA combines the Stochastic Oscillator with an Exponential Moving Average to
+ * identify overbought/oversold conditions and trend direction.
+ */
+public final class StochasticEmaParamConfig implements ParamConfig {
+
+  private static final Logger logger = Logger.getLogger(StochasticEmaParamConfig.class.getName());
+
+  private static final ImmutableList<ChromosomeSpec<?>> SPECS =
+      ImmutableList.of(
+          ChromosomeSpec.ofInteger(5, 50), // EMA Period
+          ChromosomeSpec.ofInteger(5, 50), // Stochastic K Period
+          ChromosomeSpec.ofInteger(5, 50), // Stochastic D Period
+          ChromosomeSpec.ofInteger(70, 90), // Overbought Threshold
+          ChromosomeSpec.ofInteger(10, 30) // Oversold Threshold
+          );
+
+  @Override
+  public ImmutableList<ChromosomeSpec<?>> getChromosomeSpecs() {
+    return SPECS;
+  }
+
+  @Override
+  public Any createParameters(ImmutableList<? extends NumericChromosome<?, ?>> chromosomes) {
+    try {
+      if (chromosomes.size() != SPECS.size()) {
+        logger.warning(
+            "Expected "
+                + SPECS.size()
+                + " chromosomes but got "
+                + chromosomes.size()
+                + " - Using default values for Stochastic EMA parameters");
+
+        return Any.pack(
+            StochasticEmaParameters.newBuilder()
+                .setEmaPeriod(14)
+                .setStochasticKPeriod(14)
+                .setStochasticDPeriod(3)
+                .setOverboughtThreshold(80)
+                .setOversoldThreshold(20)
+                .build());
+      }
+
+      int emaPeriod = getIntegerValue(chromosomes, 0, 14);
+      int stochasticKPeriod = getIntegerValue(chromosomes, 1, 14);
+      int stochasticDPeriod = getIntegerValue(chromosomes, 2, 3);
+      int overboughtThreshold = getIntegerValue(chromosomes, 3, 80);
+      int oversoldThreshold = getIntegerValue(chromosomes, 4, 20);
+
+      StochasticEmaParameters parameters =
+          StochasticEmaParameters.newBuilder()
+              .setEmaPeriod(emaPeriod)
+              .setStochasticKPeriod(stochasticKPeriod)
+              .setStochasticDPeriod(stochasticDPeriod)
+              .setOverboughtThreshold(overboughtThreshold)
+              .setOversoldThreshold(oversoldThreshold)
+              .build();
+
+      return Any.pack(parameters);
+    } catch (Exception e) {
+      logger.warning(
+          "Error creating Stochastic EMA parameters: "
+              + e.getMessage()
+              + " - Using default values");
+
+      return Any.pack(
+          StochasticEmaParameters.newBuilder()
+              .setEmaPeriod(14)
+              .setStochasticKPeriod(14)
+              .setStochasticDPeriod(3)
+              .setOverboughtThreshold(80)
+              .setOversoldThreshold(20)
+              .build());
+    }
+  }
+
+  private int getIntegerValue(
+      ImmutableList<? extends NumericChromosome<?, ?>> chromosomes, int index, int defaultValue) {
+    try {
+      if (index >= chromosomes.size()) {
+        return defaultValue;
+      }
+
+      NumericChromosome<?, ?> chromosome = chromosomes.get(index);
+      if (chromosome instanceof IntegerChromosome) {
+        return ((IntegerChromosome) chromosome).gene().intValue();
+      } else {
+        return (int) chromosome.gene().doubleValue();
+      }
+    } catch (Exception e) {
+      return defaultValue;
+    }
+  }
+
+  @Override
+  public ImmutableList<? extends NumericChromosome<?, ?>> initialChromosomes() {
+    return SPECS.stream()
+        .map(ChromosomeSpec::createChromosome)
+        .collect(ImmutableList.toImmutableList());
+  }
+}

--- a/src/main/java/com/verlumen/tradestream/strategies/stochasticema/StochasticEmaStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/stochasticema/StochasticEmaStrategyFactory.java
@@ -1,0 +1,74 @@
+package com.verlumen.tradestream.strategies.stochasticema;
+
+import com.google.protobuf.Any;
+import com.verlumen.tradestream.strategies.StochasticEmaParameters;
+import com.verlumen.tradestream.strategies.StrategyFactory;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseStrategy;
+import org.ta4j.core.Rule;
+import org.ta4j.core.Strategy;
+import org.ta4j.core.indicators.EMAIndicator;
+import org.ta4j.core.indicators.StochasticOscillatorDIndicator;
+import org.ta4j.core.indicators.StochasticOscillatorKIndicator;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.rules.CrossedDownIndicatorRule;
+import org.ta4j.core.rules.CrossedUpIndicatorRule;
+import org.ta4j.core.rules.OverIndicatorRule;
+import org.ta4j.core.rules.UnderIndicatorRule;
+
+/**
+ * Factory for creating Stochastic EMA strategies.
+ *
+ * <p>This strategy combines the Stochastic Oscillator with an Exponential Moving Average to
+ * identify overbought/oversold conditions and trend direction.
+ */
+public class StochasticEmaStrategyFactory implements StrategyFactory<StochasticEmaParameters> {
+
+  @Override
+  public Strategy createStrategy(BarSeries barSeries, Any parameters) {
+    try {
+      StochasticEmaParameters params = parameters.unpack(StochasticEmaParameters.class);
+      return createStrategy(barSeries, params);
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Failed to unpack StochasticEmaParameters", e);
+    }
+  }
+
+  public Strategy createStrategy(BarSeries barSeries, StochasticEmaParameters parameters) {
+    // Create price indicator
+    ClosePriceIndicator closePrice = new ClosePriceIndicator(barSeries);
+
+    // Create Stochastic Oscillator K indicator
+    StochasticOscillatorKIndicator stochasticK =
+        new StochasticOscillatorKIndicator(barSeries, parameters.getStochasticKPeriod());
+
+    // Create Stochastic Oscillator D indicator (uses only the K indicator)
+    StochasticOscillatorDIndicator stochasticD = new StochasticOscillatorDIndicator(stochasticK);
+
+    // Create EMA of Stochastic K
+    EMAIndicator emaStochastic = new EMAIndicator(stochasticK, parameters.getEmaPeriod());
+
+    // Entry rule: Stochastic K crosses above its EMA AND Stochastic K is below oversold threshold
+    Rule entryRule =
+        new CrossedUpIndicatorRule(stochasticK, emaStochastic)
+            .and(new UnderIndicatorRule(stochasticK, parameters.getOversoldThreshold()));
+
+    // Exit rule: Stochastic K crosses below its EMA OR Stochastic K is above overbought threshold
+    Rule exitRule =
+        new CrossedDownIndicatorRule(stochasticK, emaStochastic)
+            .or(new OverIndicatorRule(stochasticK, parameters.getOverboughtThreshold()));
+
+    return new BaseStrategy("STOCHASTIC_EMA", entryRule, exitRule);
+  }
+
+  @Override
+  public StochasticEmaParameters getDefaultParameters() {
+    return StochasticEmaParameters.newBuilder()
+        .setEmaPeriod(14)
+        .setStochasticKPeriod(14)
+        .setStochasticDPeriod(3)
+        .setOverboughtThreshold(80)
+        .setOversoldThreshold(20)
+        .build();
+  }
+}

--- a/src/test/java/com/verlumen/tradestream/strategies/StrategySpecsTest.kt
+++ b/src/test/java/com/verlumen/tradestream/strategies/StrategySpecsTest.kt
@@ -176,7 +176,7 @@ class StrategySpecsTest {
 
         // Assert
         assertThat(result).isNotNull()
-        assertThat(result).hasSize(26)
+        assertThat(result).hasSize(27)
     }
 
     @Test

--- a/src/test/java/com/verlumen/tradestream/strategies/stochasticema/BUILD
+++ b/src/test/java/com/verlumen/tradestream/strategies/stochasticema/BUILD
@@ -1,0 +1,30 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
+java_test(
+    name = "param_config_test",
+    srcs = ["StochasticEmaParamConfigTest.java"],
+    test_class = "com.verlumen.tradestream.strategies.stochasticema.StochasticEmaParamConfigTest",
+    deps = [
+        "//src/main/java/com/verlumen/tradestream/strategies/stochasticema:param_config",
+        "//third_party/java:junit",
+        "//third_party/java:truth",
+        "//third_party/java:guava",
+        "//third_party/java:jenetics",
+        "//protos:strategies_java_proto",
+        "//third_party/java:protobuf_java",
+    ],
+)
+
+java_test(
+    name = "strategy_factory_test",
+    srcs = ["StochasticEmaStrategyFactoryTest.java"],
+    test_class = "com.verlumen.tradestream.strategies.stochasticema.StochasticEmaStrategyFactoryTest",
+    deps = [
+        "//src/main/java/com/verlumen/tradestream/strategies/stochasticema:strategy_factory",
+        "//third_party/java:junit",
+        "//third_party/java:ta4j_core",
+        "//third_party/java:truth",
+        "//protos:strategies_java_proto",
+        "//third_party/java:protobuf_java",
+    ],
+) 

--- a/src/test/java/com/verlumen/tradestream/strategies/stochasticema/StochasticEmaParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/stochasticema/StochasticEmaParamConfigTest.java
@@ -1,0 +1,36 @@
+package com.verlumen.tradestream.strategies.stochasticema;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.verlumen.tradestream.strategies.StochasticEmaParameters;
+import io.jenetics.NumericChromosome;
+import org.junit.Test;
+
+public final class StochasticEmaParamConfigTest {
+  private final StochasticEmaParamConfig config = new StochasticEmaParamConfig();
+
+  @Test
+  public void getChromosomeSpecs_returnsExpectedSpecs() {
+    assertThat(config.getChromosomeSpecs()).hasSize(5);
+  }
+
+  @Test
+  public void initialChromosomes_matchesSpecsSize() {
+    assertThat(config.initialChromosomes()).hasSize(config.getChromosomeSpecs().size());
+  }
+
+  @Test
+  public void createParameters_withDefaultChromosomes_returnsValidAny() throws Exception {
+    ImmutableList<? extends NumericChromosome<?, ?>> chromosomes = config.initialChromosomes();
+    Any packed = config.createParameters(chromosomes);
+    assertThat(packed.is(StochasticEmaParameters.class)).isTrue();
+    StochasticEmaParameters params = packed.unpack(StochasticEmaParameters.class);
+    assertThat(params.getEmaPeriod()).isGreaterThan(0);
+    assertThat(params.getStochasticKPeriod()).isGreaterThan(0);
+    assertThat(params.getStochasticDPeriod()).isGreaterThan(0);
+    assertThat(params.getOverboughtThreshold()).isGreaterThan(0);
+    assertThat(params.getOversoldThreshold()).isGreaterThan(0);
+  }
+}

--- a/src/test/java/com/verlumen/tradestream/strategies/stochasticema/StochasticEmaStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/stochasticema/StochasticEmaStrategyFactoryTest.java
@@ -1,0 +1,105 @@
+package com.verlumen.tradestream.strategies.stochasticema;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.protobuf.Any;
+import com.verlumen.tradestream.strategies.StochasticEmaParameters;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import org.junit.Test;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
+import org.ta4j.core.Strategy;
+
+public class StochasticEmaStrategyFactoryTest {
+
+  private final StochasticEmaStrategyFactory factory = new StochasticEmaStrategyFactory();
+
+  @Test
+  public void createStrategy_returnsValidStrategy() {
+    // Arrange
+    BarSeries barSeries = new org.ta4j.core.BaseBarSeries();
+    barSeries.addBar(
+        new BaseBar(Duration.ofDays(1), ZonedDateTime.now(), 100.0, 110.0, 90.0, 105.0, 1000.0));
+    barSeries.addBar(
+        new BaseBar(
+            Duration.ofDays(1),
+            ZonedDateTime.now().plusDays(1),
+            105.0,
+            115.0,
+            95.0,
+            110.0,
+            1100.0));
+    barSeries.addBar(
+        new BaseBar(
+            Duration.ofDays(1),
+            ZonedDateTime.now().plusDays(2),
+            110.0,
+            120.0,
+            100.0,
+            115.0,
+            1200.0));
+
+    StochasticEmaParameters params =
+        StochasticEmaParameters.newBuilder()
+            .setStochasticKPeriod(14)
+            .setStochasticDPeriod(3)
+            .setEmaPeriod(14)
+            .setOverboughtThreshold(80)
+            .setOversoldThreshold(20)
+            .build();
+
+    Any packedParams = Any.pack(params);
+
+    // Act
+    Strategy strategy = factory.createStrategy(barSeries, packedParams);
+
+    // Assert
+    assertThat(strategy).isNotNull();
+    assertThat(strategy.getEntryRule()).isNotNull();
+    assertThat(strategy.getExitRule()).isNotNull();
+  }
+
+  @Test
+  public void createStrategy_withDirectParameters_returnsValidStrategy() {
+    // Arrange
+    BarSeries barSeries = new org.ta4j.core.BaseBarSeries();
+    barSeries.addBar(
+        new BaseBar(Duration.ofDays(1), ZonedDateTime.now(), 100.0, 110.0, 90.0, 105.0, 1000.0));
+    barSeries.addBar(
+        new BaseBar(
+            Duration.ofDays(1),
+            ZonedDateTime.now().plusDays(1),
+            105.0,
+            115.0,
+            95.0,
+            110.0,
+            1100.0));
+    barSeries.addBar(
+        new BaseBar(
+            Duration.ofDays(1),
+            ZonedDateTime.now().plusDays(2),
+            110.0,
+            120.0,
+            100.0,
+            115.0,
+            1200.0));
+
+    StochasticEmaParameters params =
+        StochasticEmaParameters.newBuilder()
+            .setStochasticKPeriod(14)
+            .setStochasticDPeriod(3)
+            .setEmaPeriod(14)
+            .setOverboughtThreshold(80)
+            .setOversoldThreshold(20)
+            .build();
+
+    // Act
+    Strategy strategy = factory.createStrategy(barSeries, params);
+
+    // Assert
+    assertThat(strategy).isNotNull();
+    assertThat(strategy.getEntryRule()).isNotNull();
+    assertThat(strategy.getExitRule()).isNotNull();
+  }
+}


### PR DESCRIPTION
**Summary**
This PR introduces a new “Stochastic EMA” trading strategy, which combines the Stochastic Oscillator with an Exponential Moving Average to detect overbought/oversold conditions and trend direction. Key changes include:

* **BUILD rule updates**

  * Registered new targets `stochasticema:param_config` and `stochasticema:strategy_factory` in the main `strategies/BUILD`.
  * Added a dedicated `BUILD` file in `strategies/stochasticema/` defining both `java_library` and `java_test` targets for the new components.

* **StrategySpecs registration**

  * Imported and mapped `StochasticEmaParamConfig` and `StochasticEmaStrategyFactory` to `StrategyType.STOCHASTIC_EMA` in `StrategySpecs.kt`.

* **New Java implementations**

  * **`StochasticEmaParamConfig.java`**: Defines five chromosome specs and logic to convert chromosomes into a `StochasticEmaParameters` protobuf, with fallbacks.
  * **`StochasticEmaStrategyFactory.java`**: Builds a TA4J `Strategy` using Stochastic K, its EMA, and user-defined thresholds.

* **Tests**

  * Increased strategy count in `StrategySpecsTest` to 27.
  * Added `StochasticEmaParamConfigTest` and `StochasticEmaStrategyFactoryTest` to validate configuration, strategy creation, and rules.

**Context & Rationale**
This new strategy broadens the algorithmic options available in the system by offering a hybrid approach for identifying trading signals. The addition qualifies as a new feature, warranting a **minor** version bump.

**Breaking Changes**
None. Existing APIs and strategies are unaffected.

**Testing**
Run the following to verify correctness:

```sh
bazel test //src/test/...
```

**Versioning**
As this PR adds new functionality, it requires a **(MINOR)** version bump.
