### PR TITLE
Add Linear Regression Channels Strategy Implementation and Integration

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -45,6 +45,8 @@ kt_jvm_library(
         "//third_party/java:ta4j_core",
 
         # Implementations for each strategy included in the map
+        "//src/main/java/com/verlumen/tradestream/strategies/adxdmi:param_config",
+        "//src/main/java/com/verlumen/tradestream/strategies/adxdmi:strategy_factory",
         "//src/main/java/com/verlumen/tradestream/strategies/adxstochastic:param_config",
         "//src/main/java/com/verlumen/tradestream/strategies/adxstochastic:strategy_factory",
         "//src/main/java/com/verlumen/tradestream/strategies/atrcci:param_config",
@@ -69,6 +71,8 @@ kt_jvm_library(
         "//src/main/java/com/verlumen/tradestream/strategies/ichimokucloud:strategy_factory",
         "//src/main/java/com/verlumen/tradestream/strategies/kstoscillator:param_config",
         "//src/main/java/com/verlumen/tradestream/strategies/kstoscillator:strategy_factory",
+        "//src/main/java/com/verlumen/tradestream/strategies/linearregressionchannels:param_config",
+        "//src/main/java/com/verlumen/tradestream/strategies/linearregressionchannels:strategy_factory",
         "//src/main/java/com/verlumen/tradestream/strategies/macdcrossover:param_config",
         "//src/main/java/com/verlumen/tradestream/strategies/macdcrossover:strategy_factory",
         "//src/main/java/com/verlumen/tradestream/strategies/massindex:param_config",

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategySpecs.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategySpecs.kt
@@ -208,6 +208,7 @@ private val strategySpecMap: Map<StrategyType, StrategySpec> =
             StrategySpec(
                 paramConfig = LinearRegressionChannelsParamConfig(),
                 strategyFactory = LinearRegressionChannelsStrategyFactory(),
+            ),
         StrategyType.STOCHASTIC_EMA to
             StrategySpec(
                 paramConfig = StochasticEmaParamConfig(),

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategySpecs.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategySpecs.kt
@@ -2,6 +2,8 @@ package com.verlumen.tradestream.strategies
 
 import com.google.protobuf.Any
 import com.google.protobuf.InvalidProtocolBufferException
+import com.verlumen.tradestream.strategies.adxdmi.AdxDmiParamConfig
+import com.verlumen.tradestream.strategies.adxdmi.AdxDmiStrategyFactory
 import com.verlumen.tradestream.strategies.adxstochastic.AdxStochasticParamConfig
 import com.verlumen.tradestream.strategies.adxstochastic.AdxStochasticStrategyFactory
 import com.verlumen.tradestream.strategies.atrcci.AtrCciParamConfig
@@ -26,6 +28,8 @@ import com.verlumen.tradestream.strategies.ichimokucloud.IchimokuCloudParamConfi
 import com.verlumen.tradestream.strategies.ichimokucloud.IchimokuCloudStrategyFactory
 import com.verlumen.tradestream.strategies.kstoscillator.KstOscillatorParamConfig
 import com.verlumen.tradestream.strategies.kstoscillator.KstOscillatorStrategyFactory
+import com.verlumen.tradestream.strategies.linearregressionchannels.LinearRegressionChannelsParamConfig
+import com.verlumen.tradestream.strategies.linearregressionchannels.LinearRegressionChannelsStrategyFactory
 import com.verlumen.tradestream.strategies.macdcrossover.MacdCrossoverParamConfig
 import com.verlumen.tradestream.strategies.macdcrossover.MacdCrossoverStrategyFactory
 import com.verlumen.tradestream.strategies.massindex.MassIndexParamConfig
@@ -192,6 +196,16 @@ private val strategySpecMap: Map<StrategyType, StrategySpec> =
             StrategySpec(
                 paramConfig = MassIndexParamConfig(),
                 strategyFactory = MassIndexStrategyFactory(),
+            ),
+        StrategyType.ADX_DMI to
+            StrategySpec(
+                paramConfig = AdxDmiParamConfig(),
+                strategyFactory = AdxDmiStrategyFactory(),
+            ),
+        StrategyType.LINEAR_REGRESSION_CHANNELS to
+            StrategySpec(
+                paramConfig = LinearRegressionChannelsParamConfig(),
+                strategyFactory = LinearRegressionChannelsStrategyFactory(),
             ),
         // To add a new strategy, just add a new entry here.
     )

--- a/src/main/java/com/verlumen/tradestream/strategies/linearregressionchannels/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/linearregressionchannels/BUILD
@@ -1,0 +1,29 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
+java_library(
+    name = "param_config",
+    srcs = ["LinearRegressionChannelsParamConfig.java"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/discovery:param_config",
+        "//src/main/java/com/verlumen/tradestream/discovery:chromosome_spec",
+        "//third_party/java:guava",
+        "//third_party/java:jenetics",
+        "//third_party/java:protobuf_java",
+    ],
+)
+
+java_library(
+    name = "strategy_factory",
+    srcs = ["LinearRegressionChannelsStrategyFactory.java"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":param_config",
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/strategies:strategy_factory",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:ta4j_core",
+        "//third_party/java:guava",
+    ],
+) 

--- a/src/main/java/com/verlumen/tradestream/strategies/linearregressionchannels/LinearRegressionChannelsParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/linearregressionchannels/LinearRegressionChannelsParamConfig.java
@@ -1,0 +1,93 @@
+package com.verlumen.tradestream.strategies.linearregressionchannels;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.verlumen.tradestream.discovery.ChromosomeSpec;
+import com.verlumen.tradestream.discovery.ParamConfig;
+import com.verlumen.tradestream.strategies.LinearRegressionChannelsParameters;
+import io.jenetics.DoubleChromosome;
+import io.jenetics.IntegerChromosome;
+import io.jenetics.NumericChromosome;
+import java.util.logging.Logger;
+
+public final class LinearRegressionChannelsParamConfig implements ParamConfig {
+  private static final Logger logger =
+      Logger.getLogger(LinearRegressionChannelsParamConfig.class.getName());
+
+  private static final ImmutableList<ChromosomeSpec<?>> SPECS =
+      ImmutableList.of(
+          ChromosomeSpec.ofInteger(10, 50), // period
+          ChromosomeSpec.ofDouble(1.0, 3.0) // multiplier
+          );
+
+  @Override
+  public ImmutableList<ChromosomeSpec<?>> getChromosomeSpecs() {
+    return SPECS;
+  }
+
+  @Override
+  public Any createParameters(ImmutableList<? extends NumericChromosome<?, ?>> chromosomes) {
+    try {
+      if (chromosomes.size() != SPECS.size()) {
+        logger.warning("Expected " + SPECS.size() + " chromosomes but got " + chromosomes.size());
+        return getDefaultParameters();
+      }
+
+      int period = getIntegerValue(chromosomes, 0, 20);
+      double multiplier = getDoubleValue(chromosomes, 1, 2.0);
+
+      return Any.pack(
+          LinearRegressionChannelsParameters.newBuilder()
+              .setPeriod(period)
+              .setMultiplier(multiplier)
+              .build());
+    } catch (Exception e) {
+      logger.warning("Error creating parameters: " + e.getMessage());
+      return getDefaultParameters();
+    }
+  }
+
+  private Any getDefaultParameters() {
+    return Any.pack(
+        LinearRegressionChannelsParameters.newBuilder().setPeriod(20).setMultiplier(2.0).build());
+  }
+
+  private int getIntegerValue(
+      ImmutableList<? extends NumericChromosome<?, ?>> chromosomes, int index, int defaultValue) {
+    try {
+      if (index >= chromosomes.size()) return defaultValue;
+      NumericChromosome<?, ?> chromosome = chromosomes.get(index);
+      if (chromosome instanceof IntegerChromosome) {
+        return ((IntegerChromosome) chromosome).gene().intValue();
+      } else {
+        return (int) chromosome.gene().doubleValue();
+      }
+    } catch (Exception e) {
+      return defaultValue;
+    }
+  }
+
+  private double getDoubleValue(
+      ImmutableList<? extends NumericChromosome<?, ?>> chromosomes,
+      int index,
+      double defaultValue) {
+    try {
+      if (index >= chromosomes.size()) return defaultValue;
+      NumericChromosome<?, ?> chromosome = chromosomes.get(index);
+      if (chromosome instanceof DoubleChromosome) {
+        return ((DoubleChromosome) chromosome).gene().doubleValue();
+      } else {
+        return chromosome.gene().doubleValue();
+      }
+    } catch (Exception e) {
+      return defaultValue;
+    }
+  }
+
+  @Override
+  public ImmutableList<? extends NumericChromosome<?, ?>> initialChromosomes() {
+    return SPECS.stream()
+        .map(ChromosomeSpec::createChromosome)
+        .collect(ImmutableList.toImmutableList());
+  }
+}

--- a/src/main/java/com/verlumen/tradestream/strategies/linearregressionchannels/LinearRegressionChannelsStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/linearregressionchannels/LinearRegressionChannelsStrategyFactory.java
@@ -1,0 +1,245 @@
+package com.verlumen.tradestream.strategies.linearregressionchannels;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.verlumen.tradestream.strategies.LinearRegressionChannelsParameters;
+import com.verlumen.tradestream.strategies.StrategyFactory;
+import com.verlumen.tradestream.strategies.StrategyType;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseStrategy;
+import org.ta4j.core.Rule;
+import org.ta4j.core.Strategy;
+import org.ta4j.core.indicators.CachedIndicator;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.num.Num;
+import org.ta4j.core.rules.CrossedDownIndicatorRule;
+import org.ta4j.core.rules.CrossedUpIndicatorRule;
+
+public final class LinearRegressionChannelsStrategyFactory
+    implements StrategyFactory<LinearRegressionChannelsParameters> {
+
+  @Override
+  public Strategy createStrategy(BarSeries series, LinearRegressionChannelsParameters params) {
+    checkArgument(params.getPeriod() > 0, "Period must be positive");
+    checkArgument(params.getMultiplier() > 0, "Multiplier must be positive");
+
+    ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
+    LinearRegressionChannelsIndicator lrcIndicator =
+        new LinearRegressionChannelsIndicator(series, params.getPeriod(), params.getMultiplier());
+
+    // Entry: Price crosses above upper channel (breakout)
+    Rule entryRule = new CrossedUpIndicatorRule(closePrice, lrcIndicator.getUpperChannel());
+
+    // Exit: Price crosses below lower channel (breakdown)
+    Rule exitRule = new CrossedDownIndicatorRule(closePrice, lrcIndicator.getLowerChannel());
+
+    return new BaseStrategy(
+        String.format(
+            "%s (Period: %d, Multiplier: %.2f)",
+            StrategyType.LINEAR_REGRESSION_CHANNELS.name(),
+            params.getPeriod(),
+            params.getMultiplier()),
+        entryRule,
+        exitRule,
+        params.getPeriod());
+  }
+
+  @Override
+  public LinearRegressionChannelsParameters getDefaultParameters() {
+    return LinearRegressionChannelsParameters.newBuilder().setPeriod(20).setMultiplier(2.0).build();
+  }
+
+  /**
+   * Custom indicator for Linear Regression Channels. Calculates upper and lower channels based on
+   * linear regression with standard deviation bands.
+   */
+  private static class LinearRegressionChannelsIndicator extends CachedIndicator<Num> {
+    private final int period;
+    private final double multiplier;
+    private final ClosePriceIndicator closePrice;
+    private final UpperChannelIndicator upperChannel;
+    private final LowerChannelIndicator lowerChannel;
+
+    public LinearRegressionChannelsIndicator(BarSeries series, int period, double multiplier) {
+      super(series);
+      this.period = period;
+      this.multiplier = multiplier;
+      this.closePrice = new ClosePriceIndicator(series);
+      this.upperChannel = new UpperChannelIndicator(series, period, multiplier);
+      this.lowerChannel = new LowerChannelIndicator(series, period, multiplier);
+    }
+
+    @Override
+    protected Num calculate(int index) {
+      // Return the middle line (linear regression)
+      return calculateLinearRegression(index);
+    }
+
+    @Override
+    public int getUnstableBars() {
+      return period;
+    }
+
+    public UpperChannelIndicator getUpperChannel() {
+      return upperChannel;
+    }
+
+    public LowerChannelIndicator getLowerChannel() {
+      return lowerChannel;
+    }
+
+    private Num calculateLinearRegression(int index) {
+      if (index < period - 1) {
+        return numOf(0);
+      }
+
+      // Calculate linear regression using least squares method
+      double sumX = 0, sumY = 0, sumXY = 0, sumX2 = 0;
+
+      for (int i = 0; i < period; i++) {
+        int barIndex = index - period + 1 + i;
+        double x = i;
+        double y = closePrice.getValue(barIndex).doubleValue();
+
+        sumX += x;
+        sumY += y;
+        sumXY += x * y;
+        sumX2 += x * x;
+      }
+
+      double n = period;
+      double slope = (n * sumXY - sumX * sumY) / (n * sumX2 - sumX * sumX);
+      double intercept = (sumY - slope * sumX) / n;
+
+      // Calculate the value at the current position
+      double x = period - 1;
+      return numOf(slope * x + intercept);
+    }
+  }
+
+  private static class UpperChannelIndicator extends CachedIndicator<Num> {
+    private final int period;
+    private final double multiplier;
+    private final ClosePriceIndicator closePrice;
+
+    public UpperChannelIndicator(BarSeries series, int period, double multiplier) {
+      super(series);
+      this.period = period;
+      this.multiplier = multiplier;
+      this.closePrice = new ClosePriceIndicator(series);
+    }
+
+    @Override
+    protected Num calculate(int index) {
+      if (index < period - 1) {
+        return numOf(0);
+      }
+
+      // Calculate standard deviation of residuals
+      double sumResiduals = 0, sumResidualsSquared = 0;
+      double sumX = 0, sumY = 0, sumXY = 0, sumX2 = 0;
+
+      for (int i = 0; i < period; i++) {
+        int barIndex = index - period + 1 + i;
+        double x = i;
+        double y = closePrice.getValue(barIndex).doubleValue();
+
+        sumX += x;
+        sumY += y;
+        sumXY += x * y;
+        sumX2 += x * x;
+      }
+
+      double n = period;
+      double slope = (n * sumXY - sumX * sumY) / (n * sumX2 - sumX * sumX);
+      double intercept = (sumY - slope * sumX) / n;
+
+      // Calculate residuals
+      for (int i = 0; i < period; i++) {
+        int barIndex = index - period + 1 + i;
+        double x = i;
+        double y = closePrice.getValue(barIndex).doubleValue();
+        double predicted = slope * x + intercept;
+        double residual = y - predicted;
+        sumResiduals += residual;
+        sumResidualsSquared += residual * residual;
+      }
+
+      double stdDev =
+          Math.sqrt((sumResidualsSquared - (sumResiduals * sumResiduals) / n) / (n - 1));
+
+      // Calculate upper channel
+      double x = period - 1;
+      double middleLine = slope * x + intercept;
+      return numOf(middleLine + multiplier * stdDev);
+    }
+
+    @Override
+    public int getUnstableBars() {
+      return period;
+    }
+  }
+
+  private static class LowerChannelIndicator extends CachedIndicator<Num> {
+    private final int period;
+    private final double multiplier;
+    private final ClosePriceIndicator closePrice;
+
+    public LowerChannelIndicator(BarSeries series, int period, double multiplier) {
+      super(series);
+      this.period = period;
+      this.multiplier = multiplier;
+      this.closePrice = new ClosePriceIndicator(series);
+    }
+
+    @Override
+    protected Num calculate(int index) {
+      if (index < period - 1) {
+        return numOf(0);
+      }
+
+      // Calculate standard deviation of residuals
+      double sumResiduals = 0, sumResidualsSquared = 0;
+      double sumX = 0, sumY = 0, sumXY = 0, sumX2 = 0;
+
+      for (int i = 0; i < period; i++) {
+        int barIndex = index - period + 1 + i;
+        double x = i;
+        double y = closePrice.getValue(barIndex).doubleValue();
+
+        sumX += x;
+        sumY += y;
+        sumXY += x * y;
+        sumX2 += x * x;
+      }
+
+      double n = period;
+      double slope = (n * sumXY - sumX * sumY) / (n * sumX2 - sumX * sumX);
+      double intercept = (sumY - slope * sumX) / n;
+
+      // Calculate residuals
+      for (int i = 0; i < period; i++) {
+        int barIndex = index - period + 1 + i;
+        double x = i;
+        double y = closePrice.getValue(barIndex).doubleValue();
+        double predicted = slope * x + intercept;
+        double residual = y - predicted;
+        sumResiduals += residual;
+        sumResidualsSquared += residual * residual;
+      }
+
+      double stdDev =
+          Math.sqrt((sumResidualsSquared - (sumResiduals * sumResiduals) / n) / (n - 1));
+
+      // Calculate lower channel
+      double x = period - 1;
+      double middleLine = slope * x + intercept;
+      return numOf(middleLine - multiplier * stdDev);
+    }
+
+    @Override
+    public int getUnstableBars() {
+      return period;
+    }
+  }
+}

--- a/src/test/java/com/verlumen/tradestream/strategies/StrategySpecsTest.kt
+++ b/src/test/java/com/verlumen/tradestream/strategies/StrategySpecsTest.kt
@@ -176,7 +176,7 @@ class StrategySpecsTest {
 
         // Assert
         assertThat(result).isNotNull()
-        assertThat(result).hasSize(28)
+        assertThat(result).hasSize(29)
     }
 
     @Test

--- a/src/test/java/com/verlumen/tradestream/strategies/StrategySpecsTest.kt
+++ b/src/test/java/com/verlumen/tradestream/strategies/StrategySpecsTest.kt
@@ -176,7 +176,7 @@ class StrategySpecsTest {
 
         // Assert
         assertThat(result).isNotNull()
-        assertThat(result).hasSize(26)
+        assertThat(result).hasSize(28)
     }
 
     @Test

--- a/src/test/java/com/verlumen/tradestream/strategies/linearregressionchannels/BUILD
+++ b/src/test/java/com/verlumen/tradestream/strategies/linearregressionchannels/BUILD
@@ -1,0 +1,30 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
+java_test(
+    name = "param_config_test",
+    srcs = ["LinearRegressionChannelsParamConfigTest.java"],
+    test_class = "com.verlumen.tradestream.strategies.linearregressionchannels.LinearRegressionChannelsParamConfigTest",
+    deps = [
+        "//src/main/java/com/verlumen/tradestream/strategies/linearregressionchannels:param_config",
+        "//third_party/java:junit",
+        "//third_party/java:truth",
+        "//third_party/java:guava",
+        "//third_party/java:jenetics",
+        "//protos:strategies_java_proto",
+        "//third_party/java:protobuf_java",
+    ],
+)
+
+java_test(
+    name = "strategy_factory_test",
+    srcs = ["LinearRegressionChannelsStrategyFactoryTest.java"],
+    test_class = "com.verlumen.tradestream.strategies.linearregressionchannels.LinearRegressionChannelsStrategyFactoryTest",
+    deps = [
+        "//src/main/java/com/verlumen/tradestream/strategies/linearregressionchannels:strategy_factory",
+        "//third_party/java:junit",
+        "//third_party/java:truth",
+        "//third_party/java:ta4j_core",
+        "//protos:strategies_java_proto",
+        "//third_party/java:protobuf_java",
+    ],
+) 

--- a/src/test/java/com/verlumen/tradestream/strategies/linearregressionchannels/LinearRegressionChannelsParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/linearregressionchannels/LinearRegressionChannelsParamConfigTest.java
@@ -1,0 +1,63 @@
+package com.verlumen.tradestream.strategies.linearregressionchannels;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.verlumen.tradestream.strategies.LinearRegressionChannelsParameters;
+import io.jenetics.DoubleChromosome;
+import io.jenetics.IntegerChromosome;
+import io.jenetics.NumericChromosome;
+import org.junit.Test;
+
+public final class LinearRegressionChannelsParamConfigTest {
+  private final LinearRegressionChannelsParamConfig config =
+      new LinearRegressionChannelsParamConfig();
+
+  @Test
+  public void getChromosomeSpecs_returnsExpectedSpecs() {
+    assertThat(config.getChromosomeSpecs()).hasSize(2);
+  }
+
+  @Test
+  public void initialChromosomes_matchesSpecsSize() {
+    assertThat(config.initialChromosomes()).hasSize(config.getChromosomeSpecs().size());
+  }
+
+  @Test
+  public void createParameters_withDefaultChromosomes_returnsValidAny() throws Exception {
+    ImmutableList<? extends NumericChromosome<?, ?>> chromosomes = config.initialChromosomes();
+    Any packed = config.createParameters(chromosomes);
+    assertThat(packed.is(LinearRegressionChannelsParameters.class)).isTrue();
+    LinearRegressionChannelsParameters params =
+        packed.unpack(LinearRegressionChannelsParameters.class);
+    assertThat(params.getPeriod()).isGreaterThan(0);
+    assertThat(params.getMultiplier()).isGreaterThan(0.0);
+  }
+
+  @Test
+  public void createParameters_withCustomValues_returnsCorrectParameters() throws Exception {
+    IntegerChromosome periodChrom = IntegerChromosome.of(10, 50);
+    DoubleChromosome multiplierChrom = DoubleChromosome.of(1.0, 3.0);
+
+    ImmutableList<NumericChromosome<?, ?>> chromosomes =
+        ImmutableList.of(periodChrom, multiplierChrom);
+    Any packed = config.createParameters(chromosomes);
+
+    LinearRegressionChannelsParameters params =
+        packed.unpack(LinearRegressionChannelsParameters.class);
+
+    // Extract the actual values from chromosomes
+    int expectedPeriod = periodChrom.gene().allele();
+    double expectedMultiplier = multiplierChrom.gene().allele();
+
+    assertThat(params.getPeriod()).isEqualTo(expectedPeriod);
+    assertThat(params.getMultiplier()).isEqualTo(expectedMultiplier);
+
+    // Also verify values are within expected ranges
+    assertThat(params.getPeriod()).isAtLeast(10);
+    assertThat(params.getPeriod()).isAtMost(50);
+    assertThat(params.getMultiplier()).isAtLeast(1.0);
+    assertThat(params.getMultiplier()).isAtMost(3.0);
+  }
+}

--- a/src/test/java/com/verlumen/tradestream/strategies/linearregressionchannels/LinearRegressionChannelsStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/linearregressionchannels/LinearRegressionChannelsStrategyFactoryTest.java
@@ -1,0 +1,68 @@
+package com.verlumen.tradestream.strategies.linearregressionchannels;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.verlumen.tradestream.strategies.LinearRegressionChannelsParameters;
+import java.time.Duration;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.ta4j.core.Bar;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
+import org.ta4j.core.BaseBarSeries;
+import org.ta4j.core.Strategy;
+
+public final class LinearRegressionChannelsStrategyFactoryTest {
+  private LinearRegressionChannelsStrategyFactory factory;
+  private BarSeries barSeries;
+
+  @Before
+  public void setUp() {
+    factory = new LinearRegressionChannelsStrategyFactory();
+
+    List<Bar> bars = new ArrayList<>();
+    ZonedDateTime now = ZonedDateTime.now(ZoneId.of("UTC"));
+    for (int i = 0; i < 100; i++) {
+      bars.add(
+          new BaseBar(
+              Duration.ofMinutes(1),
+              now.plusMinutes(i),
+              100.0 + i * 0.1,
+              100.5 + i * 0.1,
+              99.5 + i * 0.1,
+              100.2 + i * 0.1,
+              1000.0 + i * 10));
+    }
+    barSeries = new BaseBarSeries(bars);
+  }
+
+  @Test
+  public void createStrategy_withDefaultParameters_returnsStrategy() {
+    LinearRegressionChannelsParameters params = factory.getDefaultParameters();
+    Strategy strategy = factory.createStrategy(barSeries, params);
+    assertThat(strategy).isNotNull();
+    assertThat(strategy.getEntryRule()).isNotNull();
+    assertThat(strategy.getExitRule()).isNotNull();
+  }
+
+  @Test
+  public void createStrategy_withCustomParameters_returnsStrategy() {
+    LinearRegressionChannelsParameters params =
+        LinearRegressionChannelsParameters.newBuilder().setPeriod(15).setMultiplier(1.5).build();
+    Strategy strategy = factory.createStrategy(barSeries, params);
+    assertThat(strategy).isNotNull();
+    assertThat(strategy.getEntryRule()).isNotNull();
+    assertThat(strategy.getExitRule()).isNotNull();
+  }
+
+  @Test
+  public void getDefaultParameters_returnsValidParameters() {
+    LinearRegressionChannelsParameters params = factory.getDefaultParameters();
+    assertThat(params.getPeriod()).isEqualTo(20);
+    assertThat(params.getMultiplier()).isEqualTo(2.0);
+  }
+}


### PR DESCRIPTION
This pull request introduces support for the Linear Regression Channels strategy in the trading strategy framework. The following updates are included:

### Summary of Changes

* **New Strategy Added**: Implemented `LinearRegressionChannelsStrategyFactory` using a custom `LinearRegressionChannelsIndicator` with upper and lower channel logic based on linear regression and standard deviation.
* **Parameter Configuration**: Created `LinearRegressionChannelsParamConfig` with chromosome specs for `period` and `multiplier` parameters, integrated with the discovery module.
* **Integration**:

  * Registered the new strategy in `StrategySpecs.kt`.
  * Updated the BUILD files to include the new strategy and its components.
  * Incremented the strategy count in the corresponding test to reflect the two newly added entries.

### Testing

* Added unit tests for:

  * Parameter configuration creation and validation.
  * Strategy factory logic and behavior with both default and custom parameters.

(MINOR) – Introduces a new strategy without breaking existing functionality.
