### PR TITLE
Add Rainbow Oscillator Strategy to StrategySpecs and StrategyFactory

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -120,5 +120,7 @@ kt_jvm_library(
         "//src/main/java/com/verlumen/tradestream/strategies/aroonmfi:strategy_factory",
         "//src/main/java/com/verlumen/tradestream/strategies/awesomeoscillator:param_config",
         "//src/main/java/com/verlumen/tradestream/strategies/awesomeoscillator:strategy_factory",
+        "//src/main/java/com/verlumen/tradestream/strategies/rainbowoscillator:param_config",
+        "//src/main/java/com/verlumen/tradestream/strategies/rainbowoscillator:strategy_factory",
     ],
 )

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategySpecs.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategySpecs.kt
@@ -54,6 +54,8 @@ import com.verlumen.tradestream.strategies.parabolicsarr.ParabolicSarParamConfig
 import com.verlumen.tradestream.strategies.parabolicsarr.ParabolicSarStrategyFactory
 import com.verlumen.tradestream.strategies.pvt.PvtParamConfig
 import com.verlumen.tradestream.strategies.pvt.PvtStrategyFactory
+import com.verlumen.tradestream.strategies.rainbowoscillator.RainbowOscillatorParamConfig
+import com.verlumen.tradestream.strategies.rainbowoscillator.RainbowOscillatorStrategyFactory
 import com.verlumen.tradestream.strategies.rsiemacrossover.RsiEmaCrossoverParamConfig
 import com.verlumen.tradestream.strategies.rsiemacrossover.RsiEmaCrossoverStrategyFactory
 import com.verlumen.tradestream.strategies.rvi.RviParamConfig
@@ -304,6 +306,11 @@ private val strategySpecMap: Map<StrategyType, StrategySpec> =
             StrategySpec(
                 paramConfig = DemaTemaCrossoverParamConfig(),
                 strategyFactory = DemaTemaCrossoverStrategyFactory(),
+            ),
+        StrategyType.RAINBOW_OSCILLATOR to
+            StrategySpec(
+                paramConfig = RainbowOscillatorParamConfig(),
+                strategyFactory = RainbowOscillatorStrategyFactory(),
             ),
         // To add a new strategy, just add a new entry here.
     )

--- a/src/main/java/com/verlumen/tradestream/strategies/rainbowoscillator/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/rainbowoscillator/BUILD
@@ -1,0 +1,27 @@
+java_library(
+    name = "param_config",
+    srcs = ["RainbowOscillatorParamConfig.java"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/discovery:chromosome_spec",
+        "//src/main/java/com/verlumen/tradestream/discovery:param_config",
+        "//third_party/java:guava",
+        "//third_party/java:jenetics",
+        "//third_party/java:protobuf_java",
+    ],
+)
+
+java_library(
+    name = "strategy_factory",
+    srcs = ["RainbowOscillatorStrategyFactory.java"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":param_config",
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/strategies:strategy_factory",
+        "//third_party/java:guava",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:ta4j_core",
+    ],
+)

--- a/src/main/java/com/verlumen/tradestream/strategies/rainbowoscillator/RainbowOscillatorParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/rainbowoscillator/RainbowOscillatorParamConfig.java
@@ -1,0 +1,65 @@
+package com.verlumen.tradestream.strategies.rainbowoscillator;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.verlumen.tradestream.discovery.ChromosomeSpec;
+import com.verlumen.tradestream.discovery.ParamConfig;
+import com.verlumen.tradestream.strategies.RainbowOscillatorParameters;
+import io.jenetics.IntegerChromosome;
+import io.jenetics.NumericChromosome;
+import java.util.logging.Logger;
+
+public final class RainbowOscillatorParamConfig implements ParamConfig {
+  private static final Logger logger =
+      Logger.getLogger(RainbowOscillatorParamConfig.class.getName());
+
+  // For simplicity, we'll use 3 periods: short, medium, long
+  private static final ImmutableList<ChromosomeSpec<?>> SPECS =
+      ImmutableList.of(
+          ChromosomeSpec.ofInteger(5, 20), // short period
+          ChromosomeSpec.ofInteger(10, 50), // medium period
+          ChromosomeSpec.ofInteger(20, 100) // long period
+          );
+
+  @Override
+  public ImmutableList<ChromosomeSpec<?>> getChromosomeSpecs() {
+    return SPECS;
+  }
+
+  @Override
+  public Any createParameters(ImmutableList<? extends NumericChromosome<?, ?>> chromosomes) {
+    if (chromosomes.size() != 3) {
+      logger.warning("Expected 3 chromosomes but got " + chromosomes.size());
+      return Any.pack(getDefaultParameters());
+    }
+
+    try {
+      RainbowOscillatorParameters parameters =
+          RainbowOscillatorParameters.newBuilder()
+              .addPeriods(((IntegerChromosome) chromosomes.get(0)).intValue())
+              .addPeriods(((IntegerChromosome) chromosomes.get(1)).intValue())
+              .addPeriods(((IntegerChromosome) chromosomes.get(2)).intValue())
+              .build();
+
+      return Any.pack(parameters);
+    } catch (Exception e) {
+      logger.warning("Error creating parameters: " + e.getMessage());
+      return Any.pack(getDefaultParameters());
+    }
+  }
+
+  @Override
+  public ImmutableList<? extends NumericChromosome<?, ?>> initialChromosomes() {
+    return SPECS.stream()
+        .map(ChromosomeSpec::createChromosome)
+        .collect(ImmutableList.toImmutableList());
+  }
+
+  private RainbowOscillatorParameters getDefaultParameters() {
+    return RainbowOscillatorParameters.newBuilder()
+        .addPeriods(10)
+        .addPeriods(20)
+        .addPeriods(50)
+        .build();
+  }
+}

--- a/src/main/java/com/verlumen/tradestream/strategies/rainbowoscillator/RainbowOscillatorStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/rainbowoscillator/RainbowOscillatorStrategyFactory.java
@@ -1,0 +1,114 @@
+package com.verlumen.tradestream.strategies.rainbowoscillator;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.verlumen.tradestream.strategies.RainbowOscillatorParameters;
+import com.verlumen.tradestream.strategies.StrategyFactory;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseStrategy;
+import org.ta4j.core.Rule;
+import org.ta4j.core.Strategy;
+import org.ta4j.core.indicators.CachedIndicator;
+import org.ta4j.core.indicators.EMAIndicator;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.rules.CrossedDownIndicatorRule;
+import org.ta4j.core.rules.CrossedUpIndicatorRule;
+
+public final class RainbowOscillatorStrategyFactory
+    implements StrategyFactory<RainbowOscillatorParameters> {
+
+  @Override
+  public RainbowOscillatorParameters getDefaultParameters() {
+    return RainbowOscillatorParameters.newBuilder()
+        .addPeriods(10)
+        .addPeriods(20)
+        .addPeriods(50)
+        .build();
+  }
+
+  @Override
+  public Strategy createStrategy(BarSeries series, RainbowOscillatorParameters parameters) {
+    checkArgument(parameters.getPeriodsCount() >= 2, "At least 2 periods required");
+
+    ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
+
+    // Create multiple EMAs for the rainbow effect
+    EMAIndicator shortEma = new EMAIndicator(closePrice, parameters.getPeriods(0));
+    EMAIndicator longEma =
+        new EMAIndicator(closePrice, parameters.getPeriods(parameters.getPeriodsCount() - 1));
+
+    // Create a custom Rainbow Oscillator indicator
+    RainbowOscillatorIndicator rainbowOscillator =
+        new RainbowOscillatorIndicator(series, parameters);
+
+    // Entry rule: Buy when Rainbow Oscillator crosses above zero
+    Rule entryRule = new CrossedUpIndicatorRule(rainbowOscillator, new ZeroLineIndicator(series));
+
+    // Exit rule: Sell when Rainbow Oscillator crosses below zero
+    Rule exitRule = new CrossedDownIndicatorRule(rainbowOscillator, new ZeroLineIndicator(series));
+
+    return new BaseStrategy("Rainbow Oscillator", entryRule, exitRule);
+  }
+
+  /**
+   * Custom Rainbow Oscillator indicator that calculates the difference between the shortest and
+   * longest moving averages, normalized by the longest average.
+   */
+  private static class RainbowOscillatorIndicator extends CachedIndicator<org.ta4j.core.num.Num> {
+    private final RainbowOscillatorParameters parameters;
+    private final ClosePriceIndicator closePrice;
+
+    public RainbowOscillatorIndicator(BarSeries series, RainbowOscillatorParameters parameters) {
+      super(series);
+      this.parameters = parameters;
+      this.closePrice = new ClosePriceIndicator(series);
+    }
+
+    @Override
+    protected org.ta4j.core.num.Num calculate(int index) {
+      if (parameters.getPeriodsCount() < 2) {
+        return numOf(0);
+      }
+
+      // Get the shortest and longest periods
+      int shortPeriod = parameters.getPeriods(0);
+      int longPeriod = parameters.getPeriods(parameters.getPeriodsCount() - 1);
+
+      // Calculate EMAs
+      EMAIndicator shortEma = new EMAIndicator(closePrice, shortPeriod);
+      EMAIndicator longEma = new EMAIndicator(closePrice, longPeriod);
+
+      org.ta4j.core.num.Num shortEmaValue = shortEma.getValue(index);
+      org.ta4j.core.num.Num longEmaValue = longEma.getValue(index);
+
+      // Calculate oscillator: (short EMA - long EMA) / long EMA * 100
+      if (longEmaValue.isZero()) {
+        return numOf(0);
+      }
+
+      return shortEmaValue.minus(longEmaValue).dividedBy(longEmaValue).multipliedBy(numOf(100));
+    }
+
+    @Override
+    public int getUnstableBars() {
+      return 0;
+    }
+  }
+
+  /** Simple zero line indicator for crossover rules. */
+  private static class ZeroLineIndicator extends CachedIndicator<org.ta4j.core.num.Num> {
+    public ZeroLineIndicator(BarSeries series) {
+      super(series);
+    }
+
+    @Override
+    protected org.ta4j.core.num.Num calculate(int index) {
+      return numOf(0);
+    }
+
+    @Override
+    public int getUnstableBars() {
+      return 0;
+    }
+  }
+}

--- a/src/test/java/com/verlumen/tradestream/strategies/StrategySpecsTest.kt
+++ b/src/test/java/com/verlumen/tradestream/strategies/StrategySpecsTest.kt
@@ -176,7 +176,7 @@ class StrategySpecsTest {
 
         // Assert
         assertThat(result).isNotNull()
-        assertThat(result).hasSize(42)
+        assertThat(result).hasSize(43)
     }
 
     @Test

--- a/src/test/java/com/verlumen/tradestream/strategies/rainbowoscillator/BUILD
+++ b/src/test/java/com/verlumen/tradestream/strategies/rainbowoscillator/BUILD
@@ -1,0 +1,30 @@
+java_test(
+    name = "param_config_test",
+    srcs = ["RainbowOscillatorParamConfigTest.java"],
+    test_class = "com.verlumen.tradestream.strategies.rainbowoscillator.RainbowOscillatorParamConfigTest",
+    deps = [
+        "//protos:strategies_java_proto",
+        "//protos:strategies_proto",
+        "//src/main/java/com/verlumen/tradestream/strategies/rainbowoscillator:param_config",
+        "//third_party/java:guava",
+        "//third_party/java:jenetics",
+        "//third_party/java:junit",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:truth",
+    ],
+)
+
+java_test(
+    name = "strategy_factory_test",
+    srcs = ["RainbowOscillatorStrategyFactoryTest.java"],
+    test_class = "com.verlumen.tradestream.strategies.rainbowoscillator.RainbowOscillatorStrategyFactoryTest",
+    deps = [
+        "//protos:strategies_java_proto",
+        "//protos:strategies_proto",
+        "//src/main/java/com/verlumen/tradestream/strategies/rainbowoscillator:strategy_factory",
+        "//third_party/java:junit",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:ta4j_core",
+        "//third_party/java:truth",
+    ],
+)

--- a/src/test/java/com/verlumen/tradestream/strategies/rainbowoscillator/RainbowOscillatorParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/rainbowoscillator/RainbowOscillatorParamConfigTest.java
@@ -1,0 +1,76 @@
+package com.verlumen.tradestream.strategies.rainbowoscillator;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.verlumen.tradestream.strategies.RainbowOscillatorParameters;
+import io.jenetics.IntegerChromosome;
+import org.junit.Test;
+
+public final class RainbowOscillatorParamConfigTest {
+  private final RainbowOscillatorParamConfig paramConfig = new RainbowOscillatorParamConfig();
+
+  @Test
+  public void getChromosomeSpecs_returnsCorrectSpecs() {
+    // Act
+    var specs = paramConfig.getChromosomeSpecs();
+
+    // Assert
+    assertThat(specs).hasSize(3);
+  }
+
+  @Test
+  public void initialChromosomes_returnsCorrectNumberOfChromosomes() {
+    // Act
+    var chromosomes = paramConfig.initialChromosomes();
+
+    // Assert
+    assertThat(chromosomes).hasSize(3);
+  }
+
+  @Test
+  public void createParameters_withValidChromosomes_returnsValidParameters()
+      throws InvalidProtocolBufferException {
+    // Arrange
+    ImmutableList<IntegerChromosome> chromosomes =
+        ImmutableList.of(
+            IntegerChromosome.of(5, 20, 10), // min=5, max=20, value=10
+            IntegerChromosome.of(10, 50, 25), // min=10, max=50, value=25
+            IntegerChromosome.of(20, 100, 60) // min=20, max=100, value=60
+            );
+
+    // Act
+    Any result = paramConfig.createParameters(chromosomes);
+
+    // Assert
+    assertThat(result).isNotNull();
+    RainbowOscillatorParameters parameters = result.unpack(RainbowOscillatorParameters.class);
+    assertThat(parameters.getPeriodsCount()).isEqualTo(3);
+    assertThat(parameters.getPeriods(0)).isAtLeast(5);
+    assertThat(parameters.getPeriods(0)).isAtMost(20);
+    assertThat(parameters.getPeriods(1)).isAtLeast(10);
+    assertThat(parameters.getPeriods(1)).isAtMost(50);
+    assertThat(parameters.getPeriods(2)).isAtLeast(20);
+    assertThat(parameters.getPeriods(2)).isAtMost(100);
+  }
+
+  @Test
+  public void createParameters_withEmptyChromosomes_returnsDefaultParameters()
+      throws InvalidProtocolBufferException {
+    // Arrange
+    ImmutableList<IntegerChromosome> chromosomes = ImmutableList.of();
+
+    // Act
+    Any result = paramConfig.createParameters(chromosomes);
+
+    // Assert
+    assertThat(result).isNotNull();
+    RainbowOscillatorParameters parameters = result.unpack(RainbowOscillatorParameters.class);
+    assertThat(parameters.getPeriodsCount()).isEqualTo(3);
+    assertThat(parameters.getPeriods(0)).isEqualTo(10);
+    assertThat(parameters.getPeriods(1)).isEqualTo(20);
+    assertThat(parameters.getPeriods(2)).isEqualTo(50);
+  }
+}

--- a/src/test/java/com/verlumen/tradestream/strategies/rainbowoscillator/RainbowOscillatorStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/rainbowoscillator/RainbowOscillatorStrategyFactoryTest.java
@@ -1,0 +1,64 @@
+package com.verlumen.tradestream.strategies.rainbowoscillator;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.verlumen.tradestream.strategies.RainbowOscillatorParameters;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import org.junit.Test;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
+import org.ta4j.core.BaseBarSeries;
+import org.ta4j.core.Strategy;
+
+public final class RainbowOscillatorStrategyFactoryTest {
+  private final RainbowOscillatorStrategyFactory factory = new RainbowOscillatorStrategyFactory();
+
+  @Test
+  public void getDefaultParameters_returnsValidParameters() {
+    // Act
+    RainbowOscillatorParameters params = factory.getDefaultParameters();
+
+    // Assert
+    assertThat(params).isNotNull();
+    assertThat(params.getPeriodsCount()).isEqualTo(3);
+    assertThat(params.getPeriods(0)).isEqualTo(10);
+    assertThat(params.getPeriods(1)).isEqualTo(20);
+    assertThat(params.getPeriods(2)).isEqualTo(50);
+  }
+
+  @Test
+  public void createStrategy_returnsValidStrategy() {
+    // Arrange
+    BarSeries series = createTestBarSeries();
+    RainbowOscillatorParameters parameters = factory.getDefaultParameters();
+
+    // Act
+    Strategy strategy = factory.createStrategy(series, parameters);
+
+    // Assert
+    assertThat(strategy).isNotNull();
+    assertThat(strategy.getEntryRule()).isNotNull();
+    assertThat(strategy.getExitRule()).isNotNull();
+  }
+
+  private BarSeries createTestBarSeries() {
+    BaseBarSeries series = new BaseBarSeries();
+    ZonedDateTime now = ZonedDateTime.now();
+
+    for (int i = 0; i < 20; i++) {
+      series.addBar(
+          BaseBar.builder()
+              .endTime(now.plusMinutes(i))
+              .timePeriod(Duration.ofMinutes(1))
+              .openPrice(series.numOf(100.0 + i))
+              .highPrice(series.numOf(105.0 + i))
+              .lowPrice(series.numOf(95.0 + i))
+              .closePrice(series.numOf(102.0 + i))
+              .volume(series.numOf(1000.0))
+              .build());
+    }
+
+    return series;
+  }
+}


### PR DESCRIPTION
This pull request introduces the Rainbow Oscillator strategy into the trading system, including configuration, factory implementation, and test coverage.

### Summary of Changes:

* **Strategy Integration:**

  * Registered `RainbowOscillatorParamConfig` and `RainbowOscillatorStrategyFactory` in `StrategySpecs.kt`.
  * Added corresponding dependencies in the `BUILD` files.

* **New Strategy Implementation:**

  * Created `RainbowOscillatorParamConfig.java` defining parameter bounds and default chromosome settings.
  * Implemented `RainbowOscillatorStrategyFactory.java`, including:

    * A custom `RainbowOscillatorIndicator`.
    * Strategy entry/exit rules based on crossovers of the oscillator around a zero baseline.

* **Test Coverage:**

  * Added unit tests for both parameter config and strategy factory:

    * Verifies parameter construction and default fallbacks.
    * Asserts strategy rules and behavior with mock bar series data.

* **Build Configurations:**

  * Defined BUILD rules for new source and test files under `strategies/rainbowoscillator`.

(MINOR) This change introduces a new strategy module, constituting a backward-compatible enhancement.
