### PR TITLE
Add Elder Ray MA Strategy Implementation and Integration

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -116,6 +116,8 @@ kt_jvm_library(
         "//src/main/java/com/verlumen/tradestream/strategies/trixsignalline:strategy_factory",
         "//src/main/java/com/verlumen/tradestream/strategies/dematemacrossover:param_config",
         "//src/main/java/com/verlumen/tradestream/strategies/dematemacrossover:strategy_factory",
+        "//src/main/java/com/verlumen/tradestream/strategies/elderrayma:param_config",
+        "//src/main/java/com/verlumen/tradestream/strategies/elderrayma:strategy_factory",
         "//src/main/java/com/verlumen/tradestream/strategies/aroonmfi:param_config",
         "//src/main/java/com/verlumen/tradestream/strategies/aroonmfi:strategy_factory",
         "//src/main/java/com/verlumen/tradestream/strategies/awesomeoscillator:param_config",

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategySpecs.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategySpecs.kt
@@ -28,6 +28,8 @@ import com.verlumen.tradestream.strategies.donchianbreakout.DonchianBreakoutPara
 import com.verlumen.tradestream.strategies.donchianbreakout.DonchianBreakoutStrategyFactory
 import com.verlumen.tradestream.strategies.doubleemacrossover.DoubleEmaCrossoverParamConfig
 import com.verlumen.tradestream.strategies.doubleemacrossover.DoubleEmaCrossoverStrategyFactory
+import com.verlumen.tradestream.strategies.elderrayma.ElderRayMAParamConfig
+import com.verlumen.tradestream.strategies.elderrayma.ElderRayMAStrategyFactory
 import com.verlumen.tradestream.strategies.emamacd.EmaMacdParamConfig
 import com.verlumen.tradestream.strategies.emamacd.EmaMacdStrategyFactory
 import com.verlumen.tradestream.strategies.heikenashi.HeikenAshiParamConfig
@@ -308,6 +310,11 @@ private val strategySpecMap: Map<StrategyType, StrategySpec> =
             StrategySpec(
                 paramConfig = DemaTemaCrossoverParamConfig(),
                 strategyFactory = DemaTemaCrossoverStrategyFactory(),
+            ),
+        StrategyType.ELDER_RAY_MA to
+            StrategySpec(
+                paramConfig = ElderRayMAParamConfig(),
+                strategyFactory = ElderRayMAStrategyFactory(),
             ),
         StrategyType.RAINBOW_OSCILLATOR to
             StrategySpec(

--- a/src/main/java/com/verlumen/tradestream/strategies/elderrayma/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/elderrayma/BUILD
@@ -1,0 +1,28 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
+java_library(
+    name = "param_config",
+    srcs = ["ElderRayMAParamConfig.java"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/discovery:chromosome_spec",
+        "//src/main/java/com/verlumen/tradestream/discovery:param_config",
+        "//third_party/java:guava",
+        "//third_party/java:jenetics",
+        "//third_party/java:protobuf_java",
+    ],
+)
+
+java_library(
+    name = "strategy_factory",
+    srcs = ["ElderRayMAStrategyFactory.java"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":param_config",
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/strategies:strategy_factory",
+        "//third_party/java:guava",
+        "//third_party/java:ta4j_core",
+    ],
+)

--- a/src/main/java/com/verlumen/tradestream/strategies/elderrayma/ElderRayMAParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/elderrayma/ElderRayMAParamConfig.java
@@ -1,0 +1,53 @@
+package com.verlumen.tradestream.strategies.elderrayma;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.verlumen.tradestream.discovery.ChromosomeSpec;
+import com.verlumen.tradestream.discovery.ParamConfig;
+import com.verlumen.tradestream.strategies.ElderRayMAParameters;
+import io.jenetics.IntegerChromosome;
+import io.jenetics.NumericChromosome;
+import java.util.logging.Logger;
+
+public final class ElderRayMAParamConfig implements ParamConfig {
+  private static final Logger logger = Logger.getLogger(ElderRayMAParamConfig.class.getName());
+
+  private static final ImmutableList<ChromosomeSpec<?>> SPECS =
+      ImmutableList.of(ChromosomeSpec.ofInteger(5, 50));
+
+  @Override
+  public ImmutableList<ChromosomeSpec<?>> getChromosomeSpecs() {
+    return SPECS;
+  }
+
+  @Override
+  public Any createParameters(ImmutableList<? extends NumericChromosome<?, ?>> chromosomes) {
+    if (chromosomes.size() != 1) {
+      logger.warning("Expected 1 chromosome but got " + chromosomes.size());
+      return Any.pack(getDefaultParameters());
+    }
+
+    try {
+      int emaPeriod = ((IntegerChromosome) chromosomes.get(0)).intValue();
+
+      ElderRayMAParameters parameters =
+          ElderRayMAParameters.newBuilder().setEmaPeriod(emaPeriod).build();
+
+      return Any.pack(parameters);
+    } catch (Exception e) {
+      logger.warning("Error creating parameters: " + e.getMessage());
+      return Any.pack(getDefaultParameters());
+    }
+  }
+
+  @Override
+  public ImmutableList<? extends NumericChromosome<?, ?>> initialChromosomes() {
+    return SPECS.stream()
+        .map(ChromosomeSpec::createChromosome)
+        .collect(ImmutableList.toImmutableList());
+  }
+
+  private ElderRayMAParameters getDefaultParameters() {
+    return ElderRayMAParameters.newBuilder().setEmaPeriod(20).build();
+  }
+}

--- a/src/main/java/com/verlumen/tradestream/strategies/elderrayma/ElderRayMAStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/elderrayma/ElderRayMAStrategyFactory.java
@@ -1,0 +1,70 @@
+package com.verlumen.tradestream.strategies.elderrayma;
+
+import com.verlumen.tradestream.strategies.ElderRayMAParameters;
+import com.verlumen.tradestream.strategies.StrategyFactory;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseStrategy;
+import org.ta4j.core.Indicator;
+import org.ta4j.core.Rule;
+import org.ta4j.core.Strategy;
+import org.ta4j.core.indicators.EMAIndicator;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.indicators.helpers.HighPriceIndicator;
+import org.ta4j.core.indicators.helpers.LowPriceIndicator;
+import org.ta4j.core.num.Num;
+import org.ta4j.core.rules.CrossedDownIndicatorRule;
+import org.ta4j.core.rules.CrossedUpIndicatorRule;
+
+public final class ElderRayMAStrategyFactory implements StrategyFactory<ElderRayMAParameters> {
+  @Override
+  public ElderRayMAParameters getDefaultParameters() {
+    return ElderRayMAParameters.newBuilder().setEmaPeriod(20).build();
+  }
+
+  @Override
+  public Strategy createStrategy(BarSeries series, ElderRayMAParameters parameters) {
+    int emaPeriod = parameters.getEmaPeriod();
+    ClosePriceIndicator close = new ClosePriceIndicator(series);
+    HighPriceIndicator high = new HighPriceIndicator(series);
+    LowPriceIndicator low = new LowPriceIndicator(series);
+    EMAIndicator ema = new EMAIndicator(close, emaPeriod);
+
+    // Bull Power = High - EMA
+    // Bear Power = Low - EMA
+    DifferenceIndicator bullPower = new DifferenceIndicator(high, ema);
+    DifferenceIndicator bearPower = new DifferenceIndicator(low, ema);
+
+    // Entry: Bull Power crosses up 0 (bullish)
+    Rule entryRule = new CrossedUpIndicatorRule(bullPower, series.numOf(0));
+    // Exit: Bear Power crosses down 0 (bearish)
+    Rule exitRule = new CrossedDownIndicatorRule(bearPower, series.numOf(0));
+
+    return new BaseStrategy("ElderRayMA", entryRule, exitRule);
+  }
+
+  // Custom indicator for difference between two indicators
+  private static class DifferenceIndicator implements Indicator<Num> {
+    private final Indicator<Num> a;
+    private final Indicator<Num> b;
+
+    public DifferenceIndicator(Indicator<Num> a, Indicator<Num> b) {
+      this.a = a;
+      this.b = b;
+    }
+
+    @Override
+    public Num getValue(int index) {
+      return a.getValue(index).minus(b.getValue(index));
+    }
+
+    @Override
+    public BarSeries getBarSeries() {
+      return a.getBarSeries();
+    }
+
+    @Override
+    public int getUnstableBars() {
+      return Math.max(a.getUnstableBars(), b.getUnstableBars());
+    }
+  }
+}

--- a/src/test/java/com/verlumen/tradestream/strategies/StrategySpecsTest.kt
+++ b/src/test/java/com/verlumen/tradestream/strategies/StrategySpecsTest.kt
@@ -176,7 +176,7 @@ class StrategySpecsTest {
 
         // Assert
         assertThat(result).isNotNull()
-        assertThat(result).hasSize(44)
+        assertThat(result).hasSize(45)
     }
 
     @Test

--- a/src/test/java/com/verlumen/tradestream/strategies/elderrayma/BUILD
+++ b/src/test/java/com/verlumen/tradestream/strategies/elderrayma/BUILD
@@ -1,0 +1,30 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
+java_test(
+    name = "param_config_test",
+    srcs = ["ElderRayMAParamConfigTest.java"],
+    test_class = "com.verlumen.tradestream.strategies.elderrayma.ElderRayMAParamConfigTest",
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/discovery:param_config",
+        "//src/main/java/com/verlumen/tradestream/strategies/elderrayma:param_config",
+        "//third_party/java:guava",
+        "//third_party/java:jenetics",
+        "//third_party/java:junit",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:truth",
+    ],
+)
+
+java_test(
+    name = "strategy_factory_test",
+    srcs = ["ElderRayMAStrategyFactoryTest.java"],
+    test_class = "com.verlumen.tradestream.strategies.elderrayma.ElderRayMAStrategyFactoryTest",
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/strategies/elderrayma:strategy_factory",
+        "//third_party/java:junit",
+        "//third_party/java:ta4j_core",
+        "//third_party/java:truth",
+    ],
+)

--- a/src/test/java/com/verlumen/tradestream/strategies/elderrayma/ElderRayMAParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/elderrayma/ElderRayMAParamConfigTest.java
@@ -1,0 +1,40 @@
+package com.verlumen.tradestream.strategies.elderrayma;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.verlumen.tradestream.strategies.ElderRayMAParameters;
+import io.jenetics.NumericChromosome;
+import org.junit.Test;
+
+public final class ElderRayMAParamConfigTest {
+  private final ElderRayMAParamConfig config = new ElderRayMAParamConfig();
+
+  @Test
+  public void testChromosomeSpecs() {
+    assertThat(config.getChromosomeSpecs()).hasSize(1);
+  }
+
+  @Test
+  public void testInitialChromosomes() {
+    assertThat(config.initialChromosomes()).hasSize(1);
+  }
+
+  @Test
+  public void testCreateParameters_valid() throws Exception {
+    NumericChromosome<?, ?> chromosome = config.getChromosomeSpecs().get(0).createChromosome();
+    Any packed = config.createParameters(ImmutableList.of(chromosome));
+    ElderRayMAParameters params = packed.unpack(ElderRayMAParameters.class);
+    assertThat(params.getEmaPeriod()).isAtLeast(5);
+    assertThat(params.getEmaPeriod()).isAtMost(50);
+  }
+
+  @Test
+  public void testCreateParameters_invalid() throws Exception {
+    // Should fallback to default if wrong chromosome count
+    Any packed = config.createParameters(ImmutableList.of());
+    ElderRayMAParameters params = packed.unpack(ElderRayMAParameters.class);
+    assertThat(params.getEmaPeriod()).isEqualTo(20);
+  }
+}

--- a/src/test/java/com/verlumen/tradestream/strategies/elderrayma/ElderRayMAStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/elderrayma/ElderRayMAStrategyFactoryTest.java
@@ -1,0 +1,42 @@
+package com.verlumen.tradestream.strategies.elderrayma;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.verlumen.tradestream.strategies.ElderRayMAParameters;
+import org.junit.Test;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBarSeriesBuilder;
+import org.ta4j.core.Strategy;
+
+public final class ElderRayMAStrategyFactoryTest {
+  private final ElderRayMAStrategyFactory factory = new ElderRayMAStrategyFactory();
+
+  @Test
+  public void testGetDefaultParameters() {
+    ElderRayMAParameters params = factory.getDefaultParameters();
+    assertThat(params.getEmaPeriod()).isEqualTo(20);
+  }
+
+  @Test
+  public void testCreateStrategy() {
+    BarSeries series = new BaseBarSeriesBuilder().withName("test").build();
+    // Add some bars to the series for indicator calculation
+    for (int i = 0; i < 30; i++) {
+      series.addBar(
+          org.ta4j.core.BaseBar.builder()
+              .timePeriod(java.time.Duration.ofMinutes(1))
+              .endTime(java.time.ZonedDateTime.now().plusMinutes(i + 1))
+              .openPrice(org.ta4j.core.num.DecimalNum.valueOf(100 + i))
+              .highPrice(org.ta4j.core.num.DecimalNum.valueOf(105 + i))
+              .lowPrice(org.ta4j.core.num.DecimalNum.valueOf(95 + i))
+              .closePrice(org.ta4j.core.num.DecimalNum.valueOf(100 + i))
+              .volume(org.ta4j.core.num.DecimalNum.valueOf(1000))
+              .build());
+    }
+    ElderRayMAParameters params = ElderRayMAParameters.newBuilder().setEmaPeriod(10).build();
+    Strategy strategy = factory.createStrategy(series, params);
+    assertThat(strategy).isNotNull();
+    assertThat(strategy.getEntryRule()).isNotNull();
+    assertThat(strategy.getExitRule()).isNotNull();
+  }
+}


### PR DESCRIPTION
This PR introduces a new trading strategy based on the Elder Ray Moving Average (ElderRayMA). Key changes include:

* **New Strategy Implementation:**

  * Added `ElderRayMAParamConfig` for parameter configuration.
  * Added `ElderRayMAStrategyFactory` implementing the strategy using TA4J indicators.

* **Integration:**

  * Registered `ELDER_RAY_MA` in `StrategySpecs.kt` and included it in the strategy spec map.
  * Updated the `BUILD` files to include the new strategy's components.

* **Testing:**

  * Added unit tests for both `ElderRayMAParamConfig` and `ElderRayMAStrategyFactory`.
  * Verified strategy integration via `StrategySpecsTest`, increasing total strategy count from 44 to 45.

This change introduces a new feature to the platform.

**(MINOR)**
