### PR TITLE
Add DoubleTopBottom strategy with param config, factory, and test coverage (MINOR)

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -56,6 +56,8 @@ kt_jvm_library(
         "//src/main/java/com/verlumen/tradestream/strategies/donchianbreakout:strategy_factory",
         "//src/main/java/com/verlumen/tradestream/strategies/doubleemacrossover:param_config",
         "//src/main/java/com/verlumen/tradestream/strategies/doubleemacrossover:strategy_factory",
+        "//src/main/java/com/verlumen/tradestream/strategies/doubletopbottom:param_config",
+        "//src/main/java/com/verlumen/tradestream/strategies/doubletopbottom:strategy_factory",
         "//src/main/java/com/verlumen/tradestream/strategies/emamacd:param_config",
         "//src/main/java/com/verlumen/tradestream/strategies/emamacd:strategy_factory",
         "//src/main/java/com/verlumen/tradestream/strategies/elderrayma:param_config",

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategySpecs.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategySpecs.kt
@@ -28,6 +28,8 @@ import com.verlumen.tradestream.strategies.donchianbreakout.DonchianBreakoutPara
 import com.verlumen.tradestream.strategies.donchianbreakout.DonchianBreakoutStrategyFactory
 import com.verlumen.tradestream.strategies.doubleemacrossover.DoubleEmaCrossoverParamConfig
 import com.verlumen.tradestream.strategies.doubleemacrossover.DoubleEmaCrossoverStrategyFactory
+import com.verlumen.tradestream.strategies.doubletopbottom.DoubleTopBottomParamConfig
+import com.verlumen.tradestream.strategies.doubletopbottom.DoubleTopBottomStrategyFactory
 import com.verlumen.tradestream.strategies.elderrayma.ElderRayMAParamConfig
 import com.verlumen.tradestream.strategies.elderrayma.ElderRayMAStrategyFactory
 import com.verlumen.tradestream.strategies.emamacd.EmaMacdParamConfig
@@ -353,6 +355,11 @@ private val strategySpecMap: Map<StrategyType, StrategySpec> =
             StrategySpec(
                 paramConfig = PivotParamConfig(),
                 strategyFactory = PivotStrategyFactory(),
+            ),
+        StrategyType.DOUBLE_TOP_BOTTOM to
+            StrategySpec(
+                paramConfig = DoubleTopBottomParamConfig(),
+                strategyFactory = DoubleTopBottomStrategyFactory(),
             ),
         // To add a new strategy, just add a new entry here.
     )

--- a/src/main/java/com/verlumen/tradestream/strategies/doubletopbottom/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/doubletopbottom/BUILD
@@ -1,0 +1,27 @@
+java_library(
+    name = "param_config",
+    srcs = ["DoubleTopBottomParamConfig.java"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/discovery:param_config",
+        "//src/main/java/com/verlumen/tradestream/discovery:chromosome_spec",
+        "//third_party/java:guava",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:jenetics",
+    ],
+)
+
+java_library(
+    name = "strategy_factory",
+    srcs = ["DoubleTopBottomStrategyFactory.java"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":param_config",
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/strategies:strategy_factory",
+        "//third_party/java:ta4j_core",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:jenetics",
+    ],
+) 

--- a/src/main/java/com/verlumen/tradestream/strategies/doubletopbottom/DoubleTopBottomParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/doubletopbottom/DoubleTopBottomParamConfig.java
@@ -1,0 +1,39 @@
+package com.verlumen.tradestream.strategies.doubletopbottom;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.verlumen.tradestream.discovery.ChromosomeSpec;
+import com.verlumen.tradestream.discovery.ParamConfig;
+import com.verlumen.tradestream.strategies.DoubleTopBottomParameters;
+import io.jenetics.NumericChromosome;
+
+public final class DoubleTopBottomParamConfig implements ParamConfig {
+  private static final ImmutableList<ChromosomeSpec<?>> SPECS =
+      ImmutableList.of(ChromosomeSpec.ofInteger(10, 50));
+
+  @Override
+  public ImmutableList<ChromosomeSpec<?>> getChromosomeSpecs() {
+    return SPECS;
+  }
+
+  @Override
+  public Any createParameters(ImmutableList<? extends NumericChromosome<?, ?>> chromosomes) {
+    if (chromosomes.size() != 1) {
+      throw new IllegalArgumentException("Expected 1 chromosome, got " + chromosomes.size());
+    }
+
+    int period = ((NumericChromosome<Integer, ?>) chromosomes.get(0)).intValue();
+
+    DoubleTopBottomParameters parameters =
+        DoubleTopBottomParameters.newBuilder().setPeriod(period).build();
+
+    return Any.pack(parameters);
+  }
+
+  @Override
+  public ImmutableList<? extends NumericChromosome<?, ?>> initialChromosomes() {
+    return SPECS.stream()
+        .map(ChromosomeSpec::createChromosome)
+        .collect(ImmutableList.toImmutableList());
+  }
+}

--- a/src/main/java/com/verlumen/tradestream/strategies/doubletopbottom/DoubleTopBottomStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/doubletopbottom/DoubleTopBottomStrategyFactory.java
@@ -1,0 +1,40 @@
+package com.verlumen.tradestream.strategies.doubletopbottom;
+
+import com.google.protobuf.Any;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.verlumen.tradestream.strategies.DoubleTopBottomParameters;
+import com.verlumen.tradestream.strategies.StrategyFactory;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Strategy;
+import org.ta4j.core.indicators.EMAIndicator;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.rules.CrossedDownIndicatorRule;
+import org.ta4j.core.rules.CrossedUpIndicatorRule;
+
+public final class DoubleTopBottomStrategyFactory
+    implements StrategyFactory<DoubleTopBottomParameters> {
+
+  @Override
+  public DoubleTopBottomParameters getDefaultParameters() {
+    return DoubleTopBottomParameters.newBuilder().setPeriod(20).build();
+  }
+
+  @Override
+  public Strategy createStrategy(BarSeries series, DoubleTopBottomParameters parameters) {
+    ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
+    EMAIndicator ema = new EMAIndicator(closePrice, parameters.getPeriod());
+
+    // Entry: Buy when price crosses above EMA (potential double bottom)
+    // Exit: Sell when price crosses below EMA (potential double top)
+    return new org.ta4j.core.BaseStrategy(
+        new CrossedUpIndicatorRule(closePrice, ema), new CrossedDownIndicatorRule(closePrice, ema));
+  }
+
+  @Override
+  public Strategy createStrategy(BarSeries series, Any parameters)
+      throws InvalidProtocolBufferException {
+    DoubleTopBottomParameters unpackedParameters =
+        parameters.unpack(DoubleTopBottomParameters.class);
+    return createStrategy(series, unpackedParameters);
+  }
+}

--- a/src/test/java/com/verlumen/tradestream/strategies/StrategySpecsTest.kt
+++ b/src/test/java/com/verlumen/tradestream/strategies/StrategySpecsTest.kt
@@ -176,7 +176,7 @@ class StrategySpecsTest {
 
         // Assert
         assertThat(result).isNotNull()
-        assertThat(result).hasSize(49)
+        assertThat(result).hasSize(50)
     }
 
     @Test

--- a/src/test/java/com/verlumen/tradestream/strategies/doubletopbottom/BUILD
+++ b/src/test/java/com/verlumen/tradestream/strategies/doubletopbottom/BUILD
@@ -1,0 +1,32 @@
+java_test(
+    name = "param_config_test",
+    srcs = ["DoubleTopBottomParamConfigTest.java"],
+    test_class = "com.verlumen.tradestream.strategies.doubletopbottom.DoubleTopBottomParamConfigTest",
+    deps = [
+        "//src/main/java/com/verlumen/tradestream/strategies/doubletopbottom:param_config",
+        "//third_party/java:junit",
+        "//third_party/java:truth",
+        "//third_party/java:guava",
+        "//third_party/java:protobuf_java",
+        "//protos:strategies_java_proto",
+        "@com_google_protobuf//java/core",
+        "@tradestream_maven//:com_google_protobuf_protobuf_java",
+        "//third_party/java:jenetics",
+    ],
+)
+
+java_test(
+    name = "strategy_factory_test",
+    srcs = ["DoubleTopBottomStrategyFactoryTest.java"],
+    test_class = "com.verlumen.tradestream.strategies.doubletopbottom.DoubleTopBottomStrategyFactoryTest",
+    deps = [
+        "//src/main/java/com/verlumen/tradestream/strategies/doubletopbottom:strategy_factory",
+        "//third_party/java:junit",
+        "//third_party/java:truth",
+        "//third_party/java:ta4j_core",
+        "//third_party/java:protobuf_java",
+        "//protos:strategies_java_proto",
+        "@com_google_protobuf//java/core",
+        "@tradestream_maven//:com_google_protobuf_protobuf_java",
+    ],
+) 

--- a/src/test/java/com/verlumen/tradestream/strategies/doubletopbottom/DoubleTopBottomParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/doubletopbottom/DoubleTopBottomParamConfigTest.java
@@ -1,0 +1,61 @@
+package com.verlumen.tradestream.strategies.doubletopbottom;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.verlumen.tradestream.strategies.DoubleTopBottomParameters;
+import io.jenetics.NumericChromosome;
+import org.junit.Test;
+
+public final class DoubleTopBottomParamConfigTest {
+
+  private final DoubleTopBottomParamConfig paramConfig = new DoubleTopBottomParamConfig();
+
+  @Test
+  public void getChromosomeSpecs_returnsCorrectSpecs() {
+    // Act
+    var specs = paramConfig.getChromosomeSpecs();
+
+    // Assert
+    assertThat(specs).hasSize(1);
+    assertThat(specs.get(0).getRange().lowerEndpoint()).isEqualTo(10);
+    assertThat(specs.get(0).getRange().upperEndpoint()).isEqualTo(50);
+  }
+
+  @Test
+  public void initialChromosomes_returnsCorrectChromosomes() {
+    // Act
+    var chromosomes = paramConfig.initialChromosomes();
+
+    // Assert
+    assertThat(chromosomes).hasSize(1);
+  }
+
+  @Test
+  public void createParameters_withValidChromosomes_returnsCorrectParameters()
+      throws InvalidProtocolBufferException {
+    // Arrange
+    var chromosome = paramConfig.getChromosomeSpecs().get(0).createChromosome();
+    var chromosomes = ImmutableList.of(chromosome);
+
+    // Act
+    Any result = paramConfig.createParameters(chromosomes);
+
+    // Assert
+    DoubleTopBottomParameters parameters = result.unpack(DoubleTopBottomParameters.class);
+    assertThat(parameters.getPeriod())
+        .isEqualTo(((NumericChromosome<Integer, ?>) chromosome).intValue());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void createParameters_withWrongNumberOfChromosomes_throwsException() {
+    // Arrange
+    var chromosome = paramConfig.getChromosomeSpecs().get(0).createChromosome();
+    var chromosomes = ImmutableList.of(chromosome, chromosome);
+
+    // Act
+    paramConfig.createParameters(chromosomes);
+  }
+}

--- a/src/test/java/com/verlumen/tradestream/strategies/doubletopbottom/DoubleTopBottomStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/doubletopbottom/DoubleTopBottomStrategyFactoryTest.java
@@ -1,0 +1,59 @@
+package com.verlumen.tradestream.strategies.doubletopbottom;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.protobuf.Any;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.verlumen.tradestream.strategies.DoubleTopBottomParameters;
+import org.junit.Test;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBarSeries;
+import org.ta4j.core.Strategy;
+
+public final class DoubleTopBottomStrategyFactoryTest {
+
+  private final DoubleTopBottomStrategyFactory factory = new DoubleTopBottomStrategyFactory();
+  private final BarSeries series = new BaseBarSeries();
+
+  @Test
+  public void getDefaultParameters_returnsCorrectParameters() {
+    // Act
+    DoubleTopBottomParameters result = factory.getDefaultParameters();
+
+    // Assert
+    assertThat(result.getPeriod()).isEqualTo(20);
+  }
+
+  @Test
+  public void createStrategy_withValidParameters_returnsStrategy()
+      throws InvalidProtocolBufferException {
+    // Arrange
+    DoubleTopBottomParameters parameters =
+        DoubleTopBottomParameters.newBuilder().setPeriod(15).build();
+
+    // Act
+    Strategy result = factory.createStrategy(series, parameters);
+
+    // Assert
+    assertThat(result).isNotNull();
+    assertThat(result.getEntryRule()).isNotNull();
+    assertThat(result.getExitRule()).isNotNull();
+  }
+
+  @Test
+  public void createStrategy_withAnyParameters_returnsStrategy()
+      throws InvalidProtocolBufferException {
+    // Arrange
+    DoubleTopBottomParameters parameters =
+        DoubleTopBottomParameters.newBuilder().setPeriod(25).build();
+    Any anyParameters = Any.pack(parameters);
+
+    // Act
+    Strategy result = factory.createStrategy(series, anyParameters);
+
+    // Assert
+    assertThat(result).isNotNull();
+    assertThat(result.getEntryRule()).isNotNull();
+    assertThat(result.getExitRule()).isNotNull();
+  }
+}


### PR DESCRIPTION
This PR introduces the new `DoubleTopBottom` trading strategy into the tradestream platform. The following components have been added:

* **Strategy integration**:

  * `DoubleTopBottomParamConfig`: Defines chromosome specifications and parameter generation.
  * `DoubleTopBottomStrategyFactory`: Implements logic to create strategy instances using TA4J EMA indicators.
* **Build configuration**:

  * Added necessary entries in the `BUILD` files to support the new strategy and its tests.
* **StrategySpecs.kt**:

  * Registered `DoubleTopBottom` in the global `strategySpecMap`.
* **Test coverage**:

  * Unit tests for both `DoubleTopBottomParamConfig` and `DoubleTopBottomStrategyFactory` ensure correctness and validation logic.

This change qualifies as a **(MINOR)** version update due to the addition of new, externally accessible functionality in the form of a strategy.
