### PR TITLE
Add Gann Swing strategy with configuration, factory, and tests (MINOR)

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -144,5 +144,7 @@ kt_jvm_library(
         "//src/main/java/com/verlumen/tradestream/strategies/renkochart:strategy_factory",
         "//src/main/java/com/verlumen/tradestream/strategies/rangebars:param_config",
         "//src/main/java/com/verlumen/tradestream/strategies/rangebars:strategy_factory",
+        "//src/main/java/com/verlumen/tradestream/strategies/gannswing:param_config",
+        "//src/main/java/com/verlumen/tradestream/strategies/gannswing:strategy_factory",
     ],
 )

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategySpecs.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategySpecs.kt
@@ -38,6 +38,8 @@ import com.verlumen.tradestream.strategies.fibonacciretracements.FibonacciRetrac
 import com.verlumen.tradestream.strategies.fibonacciretracements.FibonacciRetracementsStrategyFactory
 import com.verlumen.tradestream.strategies.frama.FramaParamConfig
 import com.verlumen.tradestream.strategies.frama.FramaStrategyFactory
+import com.verlumen.tradestream.strategies.gannswing.GannSwingParamConfig
+import com.verlumen.tradestream.strategies.gannswing.GannSwingStrategyFactory
 import com.verlumen.tradestream.strategies.heikenashi.HeikenAshiParamConfig
 import com.verlumen.tradestream.strategies.heikenashi.HeikenAshiStrategyFactory
 import com.verlumen.tradestream.strategies.ichimokucloud.IchimokuCloudParamConfig
@@ -70,6 +72,8 @@ import com.verlumen.tradestream.strategies.pvt.PvtParamConfig
 import com.verlumen.tradestream.strategies.pvt.PvtStrategyFactory
 import com.verlumen.tradestream.strategies.rainbowoscillator.RainbowOscillatorParamConfig
 import com.verlumen.tradestream.strategies.rainbowoscillator.RainbowOscillatorStrategyFactory
+import com.verlumen.tradestream.strategies.rangebars.RangeBarsParamConfig
+import com.verlumen.tradestream.strategies.rangebars.RangeBarsStrategyFactory
 import com.verlumen.tradestream.strategies.regressionchannel.RegressionChannelParamConfig
 import com.verlumen.tradestream.strategies.regressionchannel.RegressionChannelStrategyFactory
 import com.verlumen.tradestream.strategies.renkochart.RenkoChartParamConfig
@@ -108,8 +112,6 @@ import com.verlumen.tradestream.strategies.vwapcrossover.VwapCrossoverParamConfi
 import com.verlumen.tradestream.strategies.vwapcrossover.VwapCrossoverStrategyFactory
 import com.verlumen.tradestream.strategies.vwapmeanreversion.VwapMeanReversionParamConfig
 import com.verlumen.tradestream.strategies.vwapmeanreversion.VwapMeanReversionStrategyFactory
-import com.verlumen.tradestream.strategies.rangebars.RangeBarsParamConfig
-import com.verlumen.tradestream.strategies.rangebars.RangeBarsStrategyFactory
 import org.ta4j.core.BarSeries
 import org.ta4j.core.Strategy
 
@@ -388,6 +390,11 @@ private val strategySpecMap: Map<StrategyType, StrategySpec> =
             StrategySpec(
                 RangeBarsParamConfig(),
                 RangeBarsStrategyFactory(),
+            ),
+        StrategyType.GANN_SWING to
+            StrategySpec(
+                GannSwingParamConfig(),
+                GannSwingStrategyFactory(),
             ),
         // To add a new strategy, just add a new entry here.
     )

--- a/src/main/java/com/verlumen/tradestream/strategies/gannswing/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/gannswing/BUILD
@@ -1,0 +1,27 @@
+java_library(
+    name = "param_config",
+    srcs = ["GannSwingParamConfig.java"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/discovery:chromosome_spec",
+        "//src/main/java/com/verlumen/tradestream/discovery:param_config",
+        "//third_party/java:guava",
+        "//third_party/java:jenetics",
+        "//third_party/java:protobuf_java",
+    ],
+)
+
+java_library(
+    name = "strategy_factory",
+    srcs = ["GannSwingStrategyFactory.java"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":param_config",
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/strategies:strategy_factory",
+        "//third_party/java:guava",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:ta4j_core",
+    ],
+)

--- a/src/main/java/com/verlumen/tradestream/strategies/gannswing/GannSwingParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/gannswing/GannSwingParamConfig.java
@@ -1,0 +1,37 @@
+package com.verlumen.tradestream.strategies.gannswing;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.verlumen.tradestream.discovery.ChromosomeSpec;
+import com.verlumen.tradestream.discovery.ParamConfig;
+import com.verlumen.tradestream.strategies.GannSwingParameters;
+import io.jenetics.IntegerChromosome;
+import io.jenetics.NumericChromosome;
+
+public final class GannSwingParamConfig implements ParamConfig {
+  private static final int MIN_GANN_PERIOD = 2;
+  private static final int MAX_GANN_PERIOD = 100;
+  private static final ImmutableList<ChromosomeSpec<?>> SPECS =
+      ImmutableList.of(ChromosomeSpec.ofInteger(MIN_GANN_PERIOD, MAX_GANN_PERIOD));
+
+  @Override
+  public ImmutableList<ChromosomeSpec<?>> getChromosomeSpecs() {
+    return SPECS;
+  }
+
+  @Override
+  public Any createParameters(ImmutableList<? extends NumericChromosome<?, ?>> chromosomes) {
+    int gannPeriod = MIN_GANN_PERIOD;
+    if (chromosomes != null && chromosomes.size() == 1) {
+      gannPeriod = ((IntegerChromosome) chromosomes.get(0)).intValue();
+    }
+    return Any.pack(GannSwingParameters.newBuilder().setGannPeriod(gannPeriod).build());
+  }
+
+  @Override
+  public ImmutableList<? extends NumericChromosome<?, ?>> initialChromosomes() {
+    return SPECS.stream()
+        .map(ChromosomeSpec::createChromosome)
+        .collect(ImmutableList.toImmutableList());
+  }
+}

--- a/src/main/java/com/verlumen/tradestream/strategies/gannswing/GannSwingStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/gannswing/GannSwingStrategyFactory.java
@@ -1,22 +1,21 @@
-package com.verlumen.tradestream.strategies.rangebars;
+package com.verlumen.tradestream.strategies.gannswing;
 
-import com.verlumen.tradestream.strategies.RangeBarsParameters;
+import com.verlumen.tradestream.strategies.GannSwingParameters;
 import com.verlumen.tradestream.strategies.StrategyFactory;
 import org.ta4j.core.BarSeries;
-import org.ta4j.core.Rule;
 import org.ta4j.core.Strategy;
 
-public final class RangeBarsStrategyFactory implements StrategyFactory<RangeBarsParameters> {
+public final class GannSwingStrategyFactory implements StrategyFactory<GannSwingParameters> {
   @Override
-  public RangeBarsParameters getDefaultParameters() {
-    return RangeBarsParameters.newBuilder().setRangeSize(1.0).build();
+  public GannSwingParameters getDefaultParameters() {
+    return GannSwingParameters.newBuilder().setGannPeriod(14).build();
   }
 
   @Override
-  public Strategy createStrategy(BarSeries series, RangeBarsParameters parameters) {
-    // TODO: Implement the actual Range Bars strategy logic using TA4J or custom indicators.
-    // For now, return a dummy strategy to satisfy the interface.
-    return new org.ta4j.core.Strategy() {
+  public Strategy createStrategy(BarSeries series, GannSwingParameters parameters) {
+    // TODO: Implement the actual Gann Swing strategy logic using TA4J or custom indicators.
+    // For now, return a dummy Strategy implementation.
+    return new Strategy() {
       @Override
       public boolean shouldEnter(int index) {
         return false;
@@ -29,7 +28,7 @@ public final class RangeBarsStrategyFactory implements StrategyFactory<RangeBars
 
       @Override
       public String getName() {
-        return "RangeBarsDummy";
+        return "GannSwingDummy";
       }
 
       @Override
@@ -43,9 +42,7 @@ public final class RangeBarsStrategyFactory implements StrategyFactory<RangeBars
       }
 
       @Override
-      public void setUnstableBars(int unstableBars) {
-        /* no-op for dummy */
-      }
+      public void setUnstableBars(int unstableBars) {}
 
       @Override
       public Strategy opposite() {
@@ -53,12 +50,12 @@ public final class RangeBarsStrategyFactory implements StrategyFactory<RangeBars
       }
 
       @Override
-      public Strategy or(String name, Strategy other, int unstableBars) {
+      public Strategy or(String name, Strategy other, int unstablePeriod) {
         return this;
       }
 
       @Override
-      public Strategy and(String name, Strategy other, int unstableBars) {
+      public Strategy and(String name, Strategy other, int unstablePeriod) {
         return this;
       }
 
@@ -73,12 +70,12 @@ public final class RangeBarsStrategyFactory implements StrategyFactory<RangeBars
       }
 
       @Override
-      public Rule getEntryRule() {
+      public org.ta4j.core.Rule getEntryRule() {
         return null;
       }
 
       @Override
-      public Rule getExitRule() {
+      public org.ta4j.core.Rule getExitRule() {
         return null;
       }
     };

--- a/src/main/java/com/verlumen/tradestream/strategies/rangebars/RangeBarsParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/rangebars/RangeBarsParamConfig.java
@@ -4,8 +4,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;
 import com.verlumen.tradestream.discovery.ChromosomeSpec;
 import com.verlumen.tradestream.discovery.ParamConfig;
-import io.jenetics.NumericChromosome;
 import com.verlumen.tradestream.strategies.RangeBarsParameters;
+import io.jenetics.NumericChromosome;
 
 public final class RangeBarsParamConfig implements ParamConfig {
   private static final double MIN_RANGE_SIZE = 0.1;
@@ -36,4 +36,4 @@ public final class RangeBarsParamConfig implements ParamConfig {
     }
     return builder.build();
   }
-} 
+}

--- a/src/main/java/com/verlumen/tradestream/strategies/renkochart/RenkoChartParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/renkochart/RenkoChartParamConfig.java
@@ -4,8 +4,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;
 import com.verlumen.tradestream.discovery.ChromosomeSpec;
 import com.verlumen.tradestream.discovery.ParamConfig;
-import io.jenetics.NumericChromosome;
 import com.verlumen.tradestream.strategies.RenkoChartParameters;
+import io.jenetics.NumericChromosome;
 
 public final class RenkoChartParamConfig implements ParamConfig {
   private static final double MIN_BRICK_SIZE = 0.1;

--- a/src/main/java/com/verlumen/tradestream/strategies/renkochart/RenkoChartStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/renkochart/RenkoChartStrategyFactory.java
@@ -1,13 +1,13 @@
 package com.verlumen.tradestream.strategies.renkochart;
 
+import com.verlumen.tradestream.strategies.RenkoChartParameters;
 import com.verlumen.tradestream.strategies.StrategyFactory;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseStrategy;
+import org.ta4j.core.Rule;
 import org.ta4j.core.Strategy;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.rules.AbstractRule;
-import org.ta4j.core.Rule;
-import com.verlumen.tradestream.strategies.RenkoChartParameters;
 
 public final class RenkoChartStrategyFactory implements StrategyFactory<RenkoChartParameters> {
   @Override

--- a/src/test/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/test/java/com/verlumen/tradestream/strategies/BUILD
@@ -21,5 +21,9 @@ kt_jvm_test(
         # Renkochart tests
         "//src/test/java/com/verlumen/tradestream/strategies/renkochart:param_config_test",
         "//src/test/java/com/verlumen/tradestream/strategies/renkochart:strategy_factory_test",
+
+        # Gannswing tests
+        "//src/test/java/com/verlumen/tradestream/strategies/gannswing:param_config_test",
+        "//src/test/java/com/verlumen/tradestream/strategies/gannswing:strategy_factory_test",
     ],
 )

--- a/src/test/java/com/verlumen/tradestream/strategies/StrategySpecsTest.kt
+++ b/src/test/java/com/verlumen/tradestream/strategies/StrategySpecsTest.kt
@@ -176,7 +176,7 @@ class StrategySpecsTest {
 
         // Assert
         assertThat(result).isNotNull()
-        assertThat(result).hasSize(54)
+        assertThat(result).hasSize(55)
     }
 
     @Test

--- a/src/test/java/com/verlumen/tradestream/strategies/gannswing/BUILD
+++ b/src/test/java/com/verlumen/tradestream/strategies/gannswing/BUILD
@@ -1,0 +1,30 @@
+java_test(
+    name = "param_config_test",
+    srcs = ["GannSwingParamConfigTest.java"],
+    test_class = "com.verlumen.tradestream.strategies.gannswing.GannSwingParamConfigTest",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/discovery:param_config",
+        "//src/main/java/com/verlumen/tradestream/strategies/gannswing:param_config",
+        "//third_party/java:guava",
+        "//third_party/java:jenetics",
+        "//third_party/java:junit",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:truth",
+    ],
+)
+
+java_test(
+    name = "strategy_factory_test",
+    srcs = ["GannSwingStrategyFactoryTest.java"],
+    test_class = "com.verlumen.tradestream.strategies.gannswing.GannSwingStrategyFactoryTest",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/strategies/gannswing:strategy_factory",
+        "//third_party/java:junit",
+        "//third_party/java:ta4j_core",
+        "//third_party/java:truth",
+    ],
+)

--- a/src/test/java/com/verlumen/tradestream/strategies/gannswing/GannSwingParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/gannswing/GannSwingParamConfigTest.java
@@ -1,0 +1,41 @@
+package com.verlumen.tradestream.strategies.gannswing;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.protobuf.Any;
+import com.verlumen.tradestream.discovery.ParamConfig;
+import com.verlumen.tradestream.strategies.GannSwingParameters;
+import io.jenetics.NumericChromosome;
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+
+public final class GannSwingParamConfigTest {
+  private final ParamConfig config = new GannSwingParamConfig();
+
+  @Test
+  public void testGetChromosomeSpecs() {
+    assertThat(config.getChromosomeSpecs().size()).isEqualTo(1);
+  }
+
+  @Test
+  public void testInitialChromosomes() {
+    ImmutableList<? extends NumericChromosome<?, ?>> chromosomes = ImmutableList.copyOf(config.initialChromosomes());
+    assertThat(chromosomes).isNotNull();
+    assertThat(chromosomes.size()).isEqualTo(1);
+  }
+
+  @Test
+  public void testCreateParameters_valid() throws Exception {
+    ImmutableList<? extends NumericChromosome<?, ?>> chromosomes = ImmutableList.copyOf(config.initialChromosomes());
+    Any packed = config.createParameters(chromosomes);
+    GannSwingParameters params = packed.unpack(GannSwingParameters.class);
+    assertThat(params.hasGannPeriod()).isTrue();
+  }
+
+  @Test
+  public void testCreateParameters_empty() throws Exception {
+    Any packed = config.createParameters(ImmutableList.of());
+    GannSwingParameters params = packed.unpack(GannSwingParameters.class);
+    assertThat(params.hasGannPeriod()).isTrue();
+  }
+} 

--- a/src/test/java/com/verlumen/tradestream/strategies/gannswing/GannSwingStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/gannswing/GannSwingStrategyFactoryTest.java
@@ -1,0 +1,29 @@
+package com.verlumen.tradestream.strategies.gannswing;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.verlumen.tradestream.strategies.GannSwingParameters;
+import org.junit.Test;
+import org.ta4j.core.BaseBarSeries;
+import org.ta4j.core.Strategy;
+
+public final class GannSwingStrategyFactoryTest {
+  private final GannSwingStrategyFactory factory = new GannSwingStrategyFactory();
+
+  @Test
+  public void testGetDefaultParameters() {
+    GannSwingParameters params = factory.getDefaultParameters();
+    assertThat(params).isNotNull();
+    assertThat(params.hasGannPeriod()).isTrue();
+  }
+
+  @Test
+  public void testCreateStrategy() {
+    BaseBarSeries series = new BaseBarSeries();
+    GannSwingParameters params = factory.getDefaultParameters();
+    Strategy strategy = factory.createStrategy(series, params);
+    assertThat(strategy).isNotNull();
+    assertThat(strategy.shouldEnter(0)).isFalse();
+    assertThat(strategy.shouldExit(0)).isFalse();
+  }
+} 


### PR DESCRIPTION
This PR introduces the initial implementation of the Gann Swing strategy to the strategy framework. Key changes include:

Added GannSwingParamConfig for parameter configuration with Jenetics integration.

Implemented GannSwingStrategyFactory returning a stub strategy for now.

Registered the strategy in StrategySpecs.kt and updated associated build files.

Created corresponding unit tests for both ParamConfig and StrategyFactory.

Incremented the total strategy count in StrategySpecsTest.

The actual trading logic is yet to be implemented; the current strategy returns dummy results, laying the groundwork for future development.

Tag: (MINOR) – This adds new functionality by introducing a new strategy type.

