### PR TITLE
Add Variable Period EMA trading strategy implementation

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/BUILD
@@ -150,5 +150,7 @@ kt_jvm_library(
         "//src/main/java/com/verlumen/tradestream/strategies/sarmfi:strategy_factory",
         "//src/main/java/com/verlumen/tradestream/strategies/dpocrossover:param_config",
         "//src/main/java/com/verlumen/tradestream/strategies/dpocrossover:strategy_factory",
+        "//src/main/java/com/verlumen/tradestream/strategies/variableperiodema:param_config",
+        "//src/main/java/com/verlumen/tradestream/strategies/variableperiodema:strategy_factory",
     ],
 )

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategySpecs.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategySpecs.kt
@@ -102,6 +102,8 @@ import com.verlumen.tradestream.strategies.tripleemacrossover.TripleEmaCrossover
 import com.verlumen.tradestream.strategies.tripleemacrossover.TripleEmaCrossoverStrategyFactory
 import com.verlumen.tradestream.strategies.trixsignalline.TrixSignalLineParamConfig
 import com.verlumen.tradestream.strategies.trixsignalline.TrixSignalLineStrategyFactory
+import com.verlumen.tradestream.strategies.variableperiodema.VariablePeriodEmaParamConfig
+import com.verlumen.tradestream.strategies.variableperiodema.VariablePeriodEmaStrategyFactory
 import com.verlumen.tradestream.strategies.volatilitystop.VolatilityStopParamConfig
 import com.verlumen.tradestream.strategies.volatilitystop.VolatilityStopStrategyFactory
 import com.verlumen.tradestream.strategies.volumebreakout.VolumeBreakoutParamConfig
@@ -409,6 +411,11 @@ private val strategySpecMap: Map<StrategyType, StrategySpec> =
             StrategySpec(
                 paramConfig = DpoCrossoverParamConfig(),
                 strategyFactory = DpoCrossoverStrategyFactory(),
+            ),
+        StrategyType.VARIABLE_PERIOD_EMA to
+            StrategySpec(
+                paramConfig = VariablePeriodEmaParamConfig(),
+                strategyFactory = VariablePeriodEmaStrategyFactory(),
             ),
         // To add a new strategy, just add a new entry here.
     )

--- a/src/main/java/com/verlumen/tradestream/strategies/variableperiodema/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/variableperiodema/BUILD
@@ -1,0 +1,27 @@
+java_library(
+    name = "param_config",
+    srcs = ["VariablePeriodEmaParamConfig.java"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/discovery:chromosome_spec",
+        "//src/main/java/com/verlumen/tradestream/discovery:param_config",
+        "//third_party/java:guava",
+        "//third_party/java:jenetics",
+        "//third_party/java:protobuf_java",
+    ],
+)
+
+java_library(
+    name = "strategy_factory",
+    srcs = ["VariablePeriodEmaStrategyFactory.java"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":param_config",
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/strategies:strategy_factory",
+        "//third_party/java:guava",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:ta4j_core",
+    ],
+)

--- a/src/main/java/com/verlumen/tradestream/strategies/variableperiodema/VariablePeriodEmaParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/variableperiodema/VariablePeriodEmaParamConfig.java
@@ -1,0 +1,45 @@
+package com.verlumen.tradestream.strategies.variableperiodema;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.verlumen.tradestream.discovery.ChromosomeSpec;
+import com.verlumen.tradestream.discovery.ParamConfig;
+import com.verlumen.tradestream.strategies.VariablePeriodEmaParameters;
+import io.jenetics.IntegerChromosome;
+import io.jenetics.NumericChromosome;
+
+public final class VariablePeriodEmaParamConfig implements ParamConfig {
+  private static final ImmutableList<ChromosomeSpec<?>> SPECS =
+      ImmutableList.of(
+          ChromosomeSpec.ofInteger(5, 50), // minPeriod
+          ChromosomeSpec.ofInteger(10, 100) // maxPeriod
+          );
+
+  @Override
+  public ImmutableList<ChromosomeSpec<?>> getChromosomeSpecs() {
+    return SPECS;
+  }
+
+  @Override
+  public Any createParameters(ImmutableList<? extends NumericChromosome<?, ?>> chromosomes) {
+    if (chromosomes.size() != SPECS.size()) {
+      throw new IllegalArgumentException(
+          "Expected " + SPECS.size() + " chromosomes but got " + chromosomes.size());
+    }
+    IntegerChromosome minPeriodChrom = (IntegerChromosome) chromosomes.get(0);
+    IntegerChromosome maxPeriodChrom = (IntegerChromosome) chromosomes.get(1);
+    VariablePeriodEmaParameters parameters =
+        VariablePeriodEmaParameters.newBuilder()
+            .setMinPeriod(minPeriodChrom.gene().allele())
+            .setMaxPeriod(maxPeriodChrom.gene().allele())
+            .build();
+    return Any.pack(parameters);
+  }
+
+  @Override
+  public ImmutableList<? extends NumericChromosome<?, ?>> initialChromosomes() {
+    return SPECS.stream()
+        .map(ChromosomeSpec::createChromosome)
+        .collect(ImmutableList.toImmutableList());
+  }
+}

--- a/src/main/java/com/verlumen/tradestream/strategies/variableperiodema/VariablePeriodEmaStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/variableperiodema/VariablePeriodEmaStrategyFactory.java
@@ -1,0 +1,56 @@
+package com.verlumen.tradestream.strategies.variableperiodema;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.verlumen.tradestream.strategies.StrategyFactory;
+import com.verlumen.tradestream.strategies.StrategyType;
+import com.verlumen.tradestream.strategies.VariablePeriodEmaParameters;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseStrategy;
+import org.ta4j.core.Rule;
+import org.ta4j.core.Strategy;
+import org.ta4j.core.indicators.EMAIndicator;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.rules.CrossedDownIndicatorRule;
+import org.ta4j.core.rules.CrossedUpIndicatorRule;
+
+public final class VariablePeriodEmaStrategyFactory
+    implements StrategyFactory<VariablePeriodEmaParameters> {
+  @Override
+  public Strategy createStrategy(BarSeries series, VariablePeriodEmaParameters params)
+      throws InvalidProtocolBufferException {
+    checkArgument(params.getMinPeriod() > 0, "Min period must be positive");
+    checkArgument(params.getMaxPeriod() > 0, "Max period must be positive");
+    checkArgument(
+        params.getMaxPeriod() > params.getMinPeriod(),
+        "Max period must be greater than min period");
+
+    ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
+    // Use average of min and max periods for the EMA
+    int emaPeriod = (params.getMinPeriod() + params.getMaxPeriod()) / 2;
+    EMAIndicator ema = new EMAIndicator(closePrice, emaPeriod);
+
+    // Entry rule: Price crosses above EMA
+    Rule entryRule = new CrossedUpIndicatorRule(closePrice, ema);
+
+    // Exit rule: Price crosses below EMA
+    Rule exitRule = new CrossedDownIndicatorRule(closePrice, ema);
+
+    return new BaseStrategy(
+        String.format(
+            "%s (%d-%d, avg=%d)",
+            StrategyType.VARIABLE_PERIOD_EMA.name(),
+            params.getMinPeriod(),
+            params.getMaxPeriod(),
+            emaPeriod),
+        entryRule,
+        exitRule,
+        emaPeriod);
+  }
+
+  @Override
+  public VariablePeriodEmaParameters getDefaultParameters() {
+    return VariablePeriodEmaParameters.newBuilder().setMinPeriod(10).setMaxPeriod(30).build();
+  }
+}

--- a/src/test/java/com/verlumen/tradestream/strategies/StrategySpecsTest.kt
+++ b/src/test/java/com/verlumen/tradestream/strategies/StrategySpecsTest.kt
@@ -176,7 +176,7 @@ class StrategySpecsTest {
 
         // Assert
         assertThat(result).isNotNull()
-        assertThat(result).hasSize(57)
+        assertThat(result).hasSize(58)
     }
 
     @Test

--- a/src/test/java/com/verlumen/tradestream/strategies/variableperiodema/BUILD
+++ b/src/test/java/com/verlumen/tradestream/strategies/variableperiodema/BUILD
@@ -1,0 +1,32 @@
+java_test(
+    name = "param_config_test",
+    srcs = ["VariablePeriodEmaParamConfigTest.java"],
+    test_class = "com.verlumen.tradestream.strategies.variableperiodema.VariablePeriodEmaParamConfigTest",
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/discovery:param_config",
+        "//src/main/java/com/verlumen/tradestream/strategies/variableperiodema:param_config",
+        "//third_party/java:guava",
+        "//third_party/java:jenetics",
+        "//third_party/java:junit",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:truth",
+    ],
+)
+
+java_test(
+    name = "strategy_factory_test",
+    srcs = ["VariablePeriodEmaStrategyFactoryTest.java"],
+    test_class = "com.verlumen.tradestream.strategies.variableperiodema.VariablePeriodEmaStrategyFactoryTest",
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/strategies:strategy_factory",
+        "//src/main/java/com/verlumen/tradestream/strategies/variableperiodema:param_config",
+        "//src/main/java/com/verlumen/tradestream/strategies/variableperiodema:strategy_factory",
+        "//third_party/java:guava",
+        "//third_party/java:junit",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:ta4j_core",
+        "//third_party/java:truth",
+    ],
+)

--- a/src/test/java/com/verlumen/tradestream/strategies/variableperiodema/VariablePeriodEmaParamConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/variableperiodema/VariablePeriodEmaParamConfigTest.java
@@ -1,0 +1,49 @@
+package com.verlumen.tradestream.strategies.variableperiodema;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.verlumen.tradestream.discovery.ParamConfig;
+import com.verlumen.tradestream.strategies.VariablePeriodEmaParameters;
+import io.jenetics.IntegerChromosome;
+import io.jenetics.NumericChromosome;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class VariablePeriodEmaParamConfigTest {
+  private ParamConfig paramConfig;
+
+  @Before
+  public void setUp() {
+    paramConfig = new VariablePeriodEmaParamConfig();
+  }
+
+  @Test
+  public void getChromosomeSpecs_size() {
+    assertThat(paramConfig.getChromosomeSpecs().size()).isEqualTo(2);
+  }
+
+  @Test
+  public void initialChromosomes_size() {
+    assertThat(paramConfig.initialChromosomes().size()).isEqualTo(2);
+  }
+
+  @Test
+  public void createParameters_validInput() throws Exception {
+    ImmutableList<NumericChromosome<?, ?>> chromosomes =
+        ImmutableList.of(IntegerChromosome.of(5, 50, 15), IntegerChromosome.of(10, 100, 40));
+    Any packed = paramConfig.createParameters(chromosomes);
+    assertThat(packed.is(VariablePeriodEmaParameters.class)).isTrue();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void createParameters_invalidInput_throws() {
+    ImmutableList<NumericChromosome<?, ?>> chromosomes =
+        ImmutableList.of(IntegerChromosome.of(5, 50, 15));
+    paramConfig.createParameters(chromosomes);
+  }
+}

--- a/src/test/java/com/verlumen/tradestream/strategies/variableperiodema/VariablePeriodEmaStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/variableperiodema/VariablePeriodEmaStrategyFactoryTest.java
@@ -1,0 +1,55 @@
+package com.verlumen.tradestream.strategies.variableperiodema;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.verlumen.tradestream.strategies.VariablePeriodEmaParameters;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
+import org.ta4j.core.BaseBarSeries;
+import org.ta4j.core.Strategy;
+
+@RunWith(JUnit4.class)
+public final class VariablePeriodEmaStrategyFactoryTest {
+  private VariablePeriodEmaStrategyFactory factory;
+
+  @Before
+  public void setUp() {
+    factory = new VariablePeriodEmaStrategyFactory();
+  }
+
+  @Test
+  public void getDefaultParameters_returnsValid() {
+    VariablePeriodEmaParameters params = factory.getDefaultParameters();
+    assertThat(params.getMinPeriod()).isGreaterThan(0);
+    assertThat(params.getMaxPeriod()).isGreaterThan(0);
+    assertThat(params.getMaxPeriod()).isGreaterThan(params.getMinPeriod());
+  }
+
+  @Test
+  public void createStrategy_returnsNonNull() throws Exception {
+    BarSeries series = new BaseBarSeries();
+    for (int i = 0; i < 50; i++) {
+      series.addBar(
+          new BaseBar(
+              Duration.ofMinutes(1),
+              ZonedDateTime.now().plusMinutes(i),
+              1 + i,
+              2 + i,
+              0.5 + i,
+              1.5 + i,
+              100 + i));
+    }
+    VariablePeriodEmaParameters params =
+        VariablePeriodEmaParameters.newBuilder().setMinPeriod(10).setMaxPeriod(30).build();
+    Strategy strategy = factory.createStrategy(series, params);
+    assertThat(strategy).isNotNull();
+    assertThat(strategy.getEntryRule()).isNotNull();
+    assertThat(strategy.getExitRule()).isNotNull();
+  }
+}


### PR DESCRIPTION
- Implement VariablePeriodEmaParamConfig with chromosome specs for period parameters
- Implement VariablePeriodEmaStrategyFactory with ta4j-based EMA crossover logic
- Add strategy registration to StrategySpecs.kt
- Update StrategySpecsTest.kt expected count
- Include BUILD files for main and test targets