### PR TITLE
fix: Add Flink detached mode configuration to StrategyDiscoveryPipeli…

### DIFF
--- a/src/main/java/com/verlumen/tradestream/discovery/StrategyDiscoveryPipelineRunner.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/StrategyDiscoveryPipelineRunner.kt
@@ -112,8 +112,8 @@ class StrategyDiscoveryPipelineRunner {
 
             // Configure Flink-specific options for detached execution
             val flinkOptions = options.`as`(FlinkPipelineOptions::class.java)
-            flinkOptions.setAttachedMode(false)
-            flinkOptions.setStreaming(true)
+            flinkOptions.setAttachedMode(options.dryRun)
+            flinkOptions.setStreaming(options.isStreaming)
 
             // Override from environment variables if not set in args
             options.databaseUsername = getDatabaseUsername(options)


### PR DESCRIPTION
…neRunner

- Add FlinkPipelineOptions import and configuration
- Set attachedMode=false for detached execution
- Set streaming=true for Kafka consumption
- Fixes IllegalArgumentException when running on Flink in Kubernetes
- Follows same pattern as main pipeline App.java

This resolves the issue where the pipeline was trying to get execution results from a detached Flink job, which doesn't provide runtime results or accumulators.