### PR TITLE
Fix PostgreSQL JSON CSV escaping

### DIFF
--- a/src/main/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFn.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFn.kt
@@ -237,11 +237,19 @@ class WriteDiscoveredStrategiesToPostgresFn
                     .getInstance("SHA-256")
                     .digest(parametersJson.toByteArray())
                     .joinToString("") { "%02x".format(it) }
+            
+            // Replace only problematic characters that would break tab-delimited CSV
+            // Don't escape quotes or backslashes as that would make JSON invalid
+            val csvSafeJson = parametersJson
+                .replace("\t", " ")     // Replace tabs with spaces
+                .replace("\n", " ")     // Replace newlines with spaces  
+                .replace("\r", " ")     // Replace carriage returns with spaces
+            
             // Tab-separated values for PostgreSQL COPY
             return listOf(
                 element.symbol,
                 element.strategy.type.name,
-                parametersJson,
+                csvSafeJson,            // Use CSV-safe JSON
                 element.score.toString(),
                 hash,
                 element.symbol, // discovery_symbol

--- a/src/test/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFnTest.kt
+++ b/src/test/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFnTest.kt
@@ -366,11 +366,14 @@ class WriteDiscoveredStrategiesToPostgresFnTest {
     fun `test PostgreSQL COPY operation with valid JSON formats`() {
         // Create a strategy with valid parameters
         val validParameters =
-            Any
-                .newBuilder()
-                .setTypeUrl("type.googleapis.com/strategies.SmaRsiParameters")
-                .setValue(ByteString.copyFromUtf8("{\"shortPeriod\": 14, \"longPeriod\": 30}"))
-                .build()
+            Any.pack(
+                com.verlumen.tradestream.strategies.SmaRsiParameters.newBuilder()
+                    .setMovingAveragePeriod(14)
+                    .setRsiPeriod(14)
+                    .setOverboughtThreshold(70.0)
+                    .setOversoldThreshold(30.0)
+                    .build()
+            )
 
         val strategy =
             Strategy


### PR DESCRIPTION
Properly escape JSON for PostgreSQL COPY command CSV format. Replaces tabs/newlines in JSON, uses real protobuf in test. All tests green.