### PR TITLE
Robust parameter JSON serialization: always emit error marker for unknown/invalid types

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "tradestream",
-    version = "v2.45.41-develop",
+    version = "v2.45.42-develop",
     compatibility_level = 1,
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "tradestream",
-    version = "v1.0.1-main",
+    version = "v2.45.40-develop",
     compatibility_level = 1,
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "tradestream",
-    version = "v2.45.40-develop",
+    version = "v2.45.41-develop",
     compatibility_level = 1,
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -111,6 +111,7 @@ maven.install(
         "junit:junit:4.13.2",
         "org.mockito:mockito-core:5.17.0",
         "org.mockito.kotlin:mockito-kotlin:5.4.0",
+        "org.json:json:20240303",
     ],
     fetch_sources = True,
     repositories = [

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "tradestream",
-    version = "v2.45.39-develop",
+    version = "v1.0.1-main",
     compatibility_level = 1,
 )
 

--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -124,7 +124,7 @@ strategyDiscoveryPipeline:
   enabled: true
   image:
     repository: tradestreamhq/strategy-discovery-pipeline
-    tag: v2.45.39-develop
+    tag: v1.0.1-main
     pullPolicy: IfNotPresent
   version: v1_18
   configuration:
@@ -172,7 +172,7 @@ candleIngestor:
   image:
     repository: "tradestreamhq/candle-ingestor"
     pullPolicy: IfNotPresent
-    tag: "v2.45.39-develop"
+    tag: "v1.0.1-main"
   config:
     # CCXT Exchange Configuration
     exchanges:
@@ -246,7 +246,7 @@ topCryptoUpdaterCronjob:
   image:
     repository: "tradestreamhq/top-crypto-updater"
     pullPolicy: IfNotPresent
-    tag: "v2.45.39-develop"
+    tag: "v1.0.1-main"
   concurrencyPolicy: "Forbid" # Prevents multiple jobs from running concurrently
   failedJobsHistoryLimit: 1
   successfulJobsHistoryLimit: 3
@@ -270,7 +270,7 @@ strategyDiscoveryRequestFactory:
   image:
     repository: "tradestreamhq/strategy-discovery-request-factory"
     pullPolicy: IfNotPresent
-    tag: "v2.45.39-develop"
+    tag: "v1.0.1-main"
   concurrencyPolicy: "Forbid" # Prevents multiple jobs from running concurrently
   failedJobsHistoryLimit: 1
   successfulJobsHistoryLimit: 3

--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -124,7 +124,7 @@ strategyDiscoveryPipeline:
   enabled: true
   image:
     repository: tradestreamhq/strategy-discovery-pipeline
-    tag: v1.0.1-main
+    tag: v2.45.40-develop
     pullPolicy: IfNotPresent
   version: v1_18
   configuration:
@@ -172,7 +172,7 @@ candleIngestor:
   image:
     repository: "tradestreamhq/candle-ingestor"
     pullPolicy: IfNotPresent
-    tag: "v1.0.1-main"
+    tag: "v2.45.40-develop"
   config:
     # CCXT Exchange Configuration
     exchanges:
@@ -246,7 +246,7 @@ topCryptoUpdaterCronjob:
   image:
     repository: "tradestreamhq/top-crypto-updater"
     pullPolicy: IfNotPresent
-    tag: "v1.0.1-main"
+    tag: "v2.45.40-develop"
   concurrencyPolicy: "Forbid" # Prevents multiple jobs from running concurrently
   failedJobsHistoryLimit: 1
   successfulJobsHistoryLimit: 3
@@ -270,7 +270,7 @@ strategyDiscoveryRequestFactory:
   image:
     repository: "tradestreamhq/strategy-discovery-request-factory"
     pullPolicy: IfNotPresent
-    tag: "v1.0.1-main"
+    tag: "v2.45.40-develop"
   concurrencyPolicy: "Forbid" # Prevents multiple jobs from running concurrently
   failedJobsHistoryLimit: 1
   successfulJobsHistoryLimit: 3

--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -124,7 +124,7 @@ strategyDiscoveryPipeline:
   enabled: true
   image:
     repository: tradestreamhq/strategy-discovery-pipeline
-    tag: v2.45.40-develop
+    tag: v2.45.41-develop
     pullPolicy: IfNotPresent
   version: v1_18
   configuration:
@@ -172,7 +172,7 @@ candleIngestor:
   image:
     repository: "tradestreamhq/candle-ingestor"
     pullPolicy: IfNotPresent
-    tag: "v2.45.40-develop"
+    tag: "v2.45.41-develop"
   config:
     # CCXT Exchange Configuration
     exchanges:
@@ -246,7 +246,7 @@ topCryptoUpdaterCronjob:
   image:
     repository: "tradestreamhq/top-crypto-updater"
     pullPolicy: IfNotPresent
-    tag: "v2.45.40-develop"
+    tag: "v2.45.41-develop"
   concurrencyPolicy: "Forbid" # Prevents multiple jobs from running concurrently
   failedJobsHistoryLimit: 1
   successfulJobsHistoryLimit: 3
@@ -270,7 +270,7 @@ strategyDiscoveryRequestFactory:
   image:
     repository: "tradestreamhq/strategy-discovery-request-factory"
     pullPolicy: IfNotPresent
-    tag: "v2.45.40-develop"
+    tag: "v2.45.41-develop"
   concurrencyPolicy: "Forbid" # Prevents multiple jobs from running concurrently
   failedJobsHistoryLimit: 1
   successfulJobsHistoryLimit: 3

--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -124,7 +124,7 @@ strategyDiscoveryPipeline:
   enabled: true
   image:
     repository: tradestreamhq/strategy-discovery-pipeline
-    tag: v2.45.41-develop
+    tag: v2.45.42-develop
     pullPolicy: IfNotPresent
   version: v1_18
   configuration:
@@ -172,7 +172,7 @@ candleIngestor:
   image:
     repository: "tradestreamhq/candle-ingestor"
     pullPolicy: IfNotPresent
-    tag: "v2.45.41-develop"
+    tag: "v2.45.42-develop"
   config:
     # CCXT Exchange Configuration
     exchanges:
@@ -246,7 +246,7 @@ topCryptoUpdaterCronjob:
   image:
     repository: "tradestreamhq/top-crypto-updater"
     pullPolicy: IfNotPresent
-    tag: "v2.45.41-develop"
+    tag: "v2.45.42-develop"
   concurrencyPolicy: "Forbid" # Prevents multiple jobs from running concurrently
   failedJobsHistoryLimit: 1
   successfulJobsHistoryLimit: 3
@@ -270,7 +270,7 @@ strategyDiscoveryRequestFactory:
   image:
     repository: "tradestreamhq/strategy-discovery-request-factory"
     pullPolicy: IfNotPresent
-    tag: "v2.45.41-develop"
+    tag: "v2.45.42-develop"
   concurrencyPolicy: "Forbid" # Prevents multiple jobs from running concurrently
   failedJobsHistoryLimit: 1
   successfulJobsHistoryLimit: 3

--- a/src/main/java/com/verlumen/tradestream/discovery/BUILD
+++ b/src/main/java/com/verlumen/tradestream/discovery/BUILD
@@ -435,6 +435,7 @@ kt_jvm_library(
     ],
     deps = [
         ":discovered_strategy_sink",
+        ":strategy_repository",
         "//protos:discovery_java_proto",
         "//protos:strategies_java_proto",
         "//src/main/java/com/verlumen/tradestream/marketdata:candle_fetcher",
@@ -446,6 +447,27 @@ kt_jvm_library(
         "//third_party/java:gson",
         "//third_party/java:guice",
         "//third_party/java:guice_assistedinject",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:protobuf_java_util",
+    ],
+)
+
+kt_jvm_library(
+    name = "strategy_repository",
+    srcs = [
+        "PostgresStrategyRepository.kt",
+        "StrategyCsvUtil.kt",
+        "StrategyRepository.kt",
+    ],
+    deps = [
+        "//protos:discovery_java_proto",
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/sql:bulk_copier_factory",
+        "//src/main/java/com/verlumen/tradestream/sql:data_source_factory",
+        "//src/main/java/com/verlumen/tradestream/strategies:strategy_parameter_type_registry",
+        "//third_party/java:flogger",
+        "//third_party/java:guice",
+        "//third_party/java:org_json",
         "//third_party/java:protobuf_java",
         "//third_party/java:protobuf_java_util",
     ],

--- a/src/main/java/com/verlumen/tradestream/discovery/BUILD
+++ b/src/main/java/com/verlumen/tradestream/discovery/BUILD
@@ -430,7 +430,9 @@ kt_jvm_library(
 
 kt_jvm_library(
     name = "write_discovered_strategies_to_postgres_fn",
-    srcs = ["WriteDiscoveredStrategiesToPostgresFn.kt"],
+    srcs = [
+        "WriteDiscoveredStrategiesToPostgresFn.kt",
+    ],
     deps = [
         ":discovered_strategy_sink",
         "//protos:discovery_java_proto",

--- a/src/main/java/com/verlumen/tradestream/discovery/DiscoveryModule.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/DiscoveryModule.kt
@@ -34,6 +34,7 @@ class DiscoveryModule : AbstractModule() {
                     WriteDiscoveredStrategiesToPostgresFn::class.java,
                 ).build(DiscoveredStrategySinkFactory::class.java),
         )
+        bind(StrategyRepository::class.java).to(PostgresStrategyRepository::class.java)
     }
 }
 

--- a/src/main/java/com/verlumen/tradestream/discovery/PostgresStrategyRepository.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/PostgresStrategyRepository.kt
@@ -1,0 +1,166 @@
+package com.verlumen.tradestream.discovery
+
+import com.google.common.flogger.FluentLogger
+import com.google.inject.Inject
+import com.google.protobuf.Any
+import com.google.protobuf.Timestamp
+import com.verlumen.tradestream.discovery.StrategyCsvUtil
+import com.verlumen.tradestream.sql.BulkCopierFactory
+import com.verlumen.tradestream.sql.DataSourceConfig
+import com.verlumen.tradestream.sql.DataSourceFactory
+import com.verlumen.tradestream.strategies.Strategy
+import org.json.JSONObject
+import java.io.StringReader
+import java.sql.ResultSet
+import javax.sql.DataSource
+
+class PostgresStrategyRepository
+    @Inject
+    constructor(
+        private val bulkCopierFactory: BulkCopierFactory,
+        private val dataSourceFactory: DataSourceFactory,
+        private val dataSourceConfig: DataSourceConfig,
+    ) : StrategyRepository {
+        companion object {
+            private val logger = FluentLogger.forEnclosingClass()
+        }
+
+        private val dataSource: DataSource by lazy { dataSourceFactory.create(dataSourceConfig) }
+
+        override fun save(strategy: DiscoveredStrategy) {
+            saveAll(listOf(strategy))
+        }
+
+        override fun saveAll(strategies: List<DiscoveredStrategy>) {
+            if (strategies.isEmpty()) return
+            dataSource.connection.use { conn ->
+                conn.autoCommit = false
+                val batchData = strategies.mapNotNull { StrategyCsvUtil.convertToCsvRow(it) }
+                if (batchData.isEmpty()) return
+                val createTempTableSql =
+                    """
+                    CREATE TEMP TABLE temp_strategies (
+                        symbol VARCHAR,
+                        strategy_type VARCHAR,
+                        parameters JSONB,
+                        current_score DOUBLE PRECISION,
+                        strategy_hash VARCHAR,
+                        discovery_symbol VARCHAR,
+                        discovery_start_time TIMESTAMP,
+                        discovery_end_time TIMESTAMP
+                    ) ON COMMIT DROP
+                    """.trimIndent()
+                conn.prepareStatement(createTempTableSql).use { it.execute() }
+                val copyManager = bulkCopierFactory.create(conn)
+                val csvData = batchData.joinToString("\n")
+                copyManager.copy("temp_strategies", StringReader(csvData))
+                val upsertSql =
+                    """
+                    INSERT INTO Strategies (
+                        strategy_id, symbol, strategy_type, parameters,
+                        first_discovered_at, last_evaluated_at, current_score,
+                        is_active, strategy_hash, discovery_symbol,
+                        discovery_start_time, discovery_end_time
+                    )
+                    SELECT
+                        gen_random_uuid(), symbol, strategy_type, parameters,
+                        NOW(), NOW(), current_score, TRUE, strategy_hash,
+                        discovery_symbol, discovery_start_time, discovery_end_time
+                    FROM temp_strategies
+                    ON CONFLICT (strategy_hash) DO UPDATE SET
+                        current_score = EXCLUDED.current_score,
+                        last_evaluated_at = NOW()
+                    """.trimIndent()
+                conn.prepareStatement(upsertSql).use { it.execute() }
+                conn.commit()
+            }
+        }
+
+        override fun findBySymbol(symbol: String): List<DiscoveredStrategy> {
+            val result = mutableListOf<DiscoveredStrategy>()
+            dataSource.connection.use { conn ->
+                val sql =
+                    """
+                    SELECT symbol, strategy_type, parameters, current_score, strategy_hash, 
+                           discovery_symbol, discovery_start_time, discovery_end_time 
+                    FROM Strategies WHERE symbol = ?
+                    """.trimIndent()
+                conn.prepareStatement(sql).use { stmt ->
+                    stmt.setString(1, symbol)
+                    val rs = stmt.executeQuery()
+                    while (rs.next()) {
+                        result.add(mapRowToDiscoveredStrategy(rs))
+                    }
+                }
+            }
+            return result
+        }
+
+        override fun findAll(): List<DiscoveredStrategy> {
+            val result = mutableListOf<DiscoveredStrategy>()
+            dataSource.connection.use { conn ->
+                val sql =
+                    """
+                    SELECT symbol, strategy_type, parameters, current_score, strategy_hash, 
+                           discovery_symbol, discovery_start_time, discovery_end_time 
+                    FROM Strategies
+                    """.trimIndent()
+                conn.prepareStatement(sql).use { stmt ->
+                    val rs = stmt.executeQuery()
+                    while (rs.next()) {
+                        result.add(mapRowToDiscoveredStrategy(rs))
+                    }
+                }
+            }
+            return result
+        }
+
+        private fun mapRowToDiscoveredStrategy(rs: ResultSet): DiscoveredStrategy {
+            val symbol = rs.getString("symbol")
+            val strategyType = rs.getString("strategy_type")
+            val parametersJson = rs.getString("parameters")
+            val score = rs.getDouble("current_score")
+            val startTime = rs.getTimestamp("discovery_start_time")
+            val endTime = rs.getTimestamp("discovery_end_time")
+
+            // Parse parameters JSON and decode base64
+            val jsonObj = JSONObject(parametersJson)
+            val base64 = jsonObj.getString("base64_data")
+            val bytes =
+                java.util.Base64
+                    .getDecoder()
+                    .decode(base64)
+            val parametersAny =
+                com.google.protobuf.Any
+                    .parseFrom(bytes)
+
+            // Build Strategy proto
+            val strategy =
+                com.verlumen.tradestream.strategies.Strategy
+                    .newBuilder()
+                    .setTypeValue(
+                        com.verlumen.tradestream.strategies.StrategyType
+                            .valueOf(strategyType)
+                            .number,
+                    ).setParameters(parametersAny)
+                    .build()
+
+            // Build DiscoveredStrategy proto
+            return DiscoveredStrategy
+                .newBuilder()
+                .setStrategy(strategy)
+                .setScore(score)
+                .setSymbol(symbol)
+                .setStartTime(
+                    com.google.protobuf.Timestamp
+                        .newBuilder()
+                        .setSeconds(startTime.time / 1000)
+                        .build(),
+                ).setEndTime(
+                    com.google.protobuf.Timestamp
+                        .newBuilder()
+                        .setSeconds(endTime.time / 1000)
+                        .build(),
+                ).build()
+        }
+    }

--- a/src/main/java/com/verlumen/tradestream/discovery/StrategyCsvUtil.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/StrategyCsvUtil.kt
@@ -1,5 +1,6 @@
 package com.verlumen.tradestream.discovery
 
+import com.verlumen.tradestream.strategies.StrategyParameterTypeRegistry
 import org.json.JSONException
 import org.json.JSONObject
 import java.util.Base64
@@ -7,11 +8,7 @@ import java.util.Base64
 object StrategyCsvUtil {
     fun convertToCsvRow(element: DiscoveredStrategy): String? {
         val parametersAny = element.strategy.parameters
-        if (parametersAny.value.isEmpty()) {
-            return ""
-        }
-        val base64 = Base64.getEncoder().encodeToString(parametersAny.toByteArray())
-        val json = "{" + "\"base64_data\": \"$base64\"}"
+        val json = StrategyParameterTypeRegistry.formatParametersToJson(parametersAny)
         val hash =
             java.security.MessageDigest
                 .getInstance(

--- a/src/main/java/com/verlumen/tradestream/discovery/StrategyCsvUtil.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/StrategyCsvUtil.kt
@@ -1,0 +1,47 @@
+package com.verlumen.tradestream.discovery
+
+import org.json.JSONException
+import org.json.JSONObject
+import java.util.Base64
+
+object StrategyCsvUtil {
+    fun convertToCsvRow(element: DiscoveredStrategy): String? {
+        val parametersAny = element.strategy.parameters
+        if (parametersAny.value.isEmpty()) {
+            return ""
+        }
+        val base64 = Base64.getEncoder().encodeToString(parametersAny.toByteArray())
+        val json = "{" + "\"base64_data\": \"$base64\"}"
+        val hash =
+            java.security.MessageDigest
+                .getInstance(
+                    "SHA-256",
+                ).digest(parametersAny.toByteArray())
+                .joinToString("") { "%02x".format(it) }
+        return listOf(
+            element.symbol,
+            element.strategy.type.name,
+            json,
+            element.score.toString(),
+            hash,
+            element.symbol,
+            element.startTime.seconds.toString(),
+            element.endTime.seconds.toString(),
+        ).joinToString("\t")
+    }
+
+    fun validateCsvRowJson(csvRow: String): Boolean {
+        val fields = csvRow.split("\t")
+        if (fields.size < 3) return false
+        val json = fields[2]
+        return validateJsonParameter(json)
+    }
+
+    fun validateJsonParameter(json: String): Boolean =
+        try {
+            JSONObject(json)
+            true
+        } catch (e: JSONException) {
+            false
+        }
+}

--- a/src/main/java/com/verlumen/tradestream/discovery/StrategyRepository.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/StrategyRepository.kt
@@ -1,0 +1,13 @@
+package com.verlumen.tradestream.discovery
+
+import com.verlumen.tradestream.discovery.DiscoveredStrategy
+
+interface StrategyRepository {
+    fun save(strategy: DiscoveredStrategy)
+
+    fun saveAll(strategies: List<DiscoveredStrategy>)
+
+    fun findBySymbol(symbol: String): List<DiscoveredStrategy>
+
+    fun findAll(): List<DiscoveredStrategy>
+}

--- a/src/main/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFn.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFn.kt
@@ -1,19 +1,10 @@
 package com.verlumen.tradestream.discovery
 
 import com.google.common.flogger.FluentLogger
-import com.google.gson.JsonParser
 import com.google.inject.Inject
-import com.google.inject.assistedinject.Assisted
-import com.verlumen.tradestream.sql.BulkCopierFactory
-import com.verlumen.tradestream.sql.DataSourceConfig
-import com.verlumen.tradestream.sql.DataSourceFactory
 import com.verlumen.tradestream.strategies.StrategyParameterTypeRegistry
-import java.io.StringReader
-import java.security.MessageDigest
-import java.sql.Connection
-import java.util.concurrent.ConcurrentLinkedQueue
-import javax.sql.DataSource
 import org.apache.commons.codec.digest.DigestUtils
+import java.util.concurrent.ConcurrentLinkedQueue
 
 /**
  * High-performance PostgreSQL writer using COPY command for bulk inserts.
@@ -30,58 +21,28 @@ import org.apache.commons.codec.digest.DigestUtils
 class WriteDiscoveredStrategiesToPostgresFn
     @Inject
     constructor(
-        private val bulkCopierFactory: BulkCopierFactory,
-        private val dataSourceFactory: DataSourceFactory,
-        @Assisted private val dataSourceConfig: DataSourceConfig,
+        // Remove strategyRepository: StrategyRepository
     ) : DiscoveredStrategySink() {
         companion object {
             private val logger = FluentLogger.forEnclosingClass()
             private const val BATCH_SIZE = 100
-            private const val MAX_RETRIES = 3
         }
 
-        @Transient
-        private var dataSource: DataSource? = null
-
-        @Transient
-        private var connection: Connection? = null
-
-        // Remove @Transient to prevent null after deserialization
-        private var batch: ConcurrentLinkedQueue<String>? = null
+        private var batch: ConcurrentLinkedQueue<DiscoveredStrategy>? = null
 
         @Setup
         fun setup() {
-            // Create DataSource using the factory
-            dataSource = dataSourceFactory.create(dataSourceConfig)
-            // Establish connection
-            connection =
-                dataSource!!.connection.apply {
-                    autoCommit = false
-                }
-
-            // Initialize batch queue
             batch = ConcurrentLinkedQueue()
-
-            logger.atInfo().log(
-                "PostgreSQL connection established for bulk writes to ${dataSourceConfig.databaseName}@${dataSourceConfig.serverName}",
-            )
+            logger.atInfo().log("Direct sink initialized (no repository abstraction)")
         }
 
         @ProcessElement
         fun processElement(
             @Element element: DiscoveredStrategy,
         ) {
-            val csvRow = convertToCsvRow(element)
-            if (csvRow != null) {
-                batch?.offer(csvRow)
-
-                if (batch?.size ?: 0 >= BATCH_SIZE) {
-                    flushBatch()
-                }
-            } else {
-                logger.atWarning().log(
-                    "Skipping strategy ${element.strategy.type.name} for ${element.symbol} due to invalid JSON parameters",
-                )
+            batch?.offer(element)
+            if (batch?.size ?: 0 >= BATCH_SIZE) {
+                flushBatch()
             }
         }
 
@@ -94,126 +55,18 @@ class WriteDiscoveredStrategiesToPostgresFn
 
         @Teardown
         fun teardown() {
-            connection?.close()
-            logger.atInfo().log("PostgreSQL connection closed")
+            // No-op
         }
 
         private fun flushBatch() {
-            val currentConnection = connection ?: return
             val currentBatch = batch ?: return
-            val batchData = mutableListOf<String>()
-
-            // Drain the queue
+            val batchData = mutableListOf<DiscoveredStrategy>()
             while (currentBatch.isNotEmpty()) {
                 currentBatch.poll()?.let { batchData.add(it) }
             }
-
             if (batchData.isEmpty()) return
-
-            // Validate all JSON parameters in the batch before database operations
-            val validatedBatchData =
-                batchData.filter { csvRow ->
-                    validateCsvRowTextProto(csvRow)
-                }
-
-            if (validatedBatchData.size != batchData.size) {
-                logger.atWarning().log(
-                    "Filtered out ${batchData.size - validatedBatchData.size} rows with invalid TextProto from batch of ${batchData.size}",
-                )
-            }
-
-            if (validatedBatchData.isEmpty()) {
-                logger.atWarning().log("No valid rows in batch, skipping database write")
-                return
-            }
-
-            var retryCount = 0
-            while (retryCount < MAX_RETRIES) {
-                try {
-                    executeBulkInsert(currentConnection, validatedBatchData)
-                    currentConnection.commit()
-                    logger.atInfo().log("Successfully wrote batch of ${validatedBatchData.size} strategies")
-                    break
-                } catch (e: Exception) {
-                    retryCount++
-                    logger
-                        .atWarning()
-                        .withCause(e)
-                        .log("Batch write failed (attempt $retryCount/$MAX_RETRIES)")
-
-                    if (retryCount >= MAX_RETRIES) {
-                        logger
-                            .atSevere()
-                            .withCause(e)
-                            .log("Failed to write batch after $MAX_RETRIES attempts")
-                        throw e
-                    }
-
-                    try {
-                        currentConnection.rollback()
-                        Thread.sleep(1000L * retryCount) // Exponential backoff
-                    } catch (rollbackEx: Exception) {
-                        logger
-                            .atWarning()
-                            .withCause(rollbackEx)
-                            .log("Failed to rollback transaction")
-                    }
-                }
-            }
-        }
-
-        private fun executeBulkInsert(
-            conn: Connection,
-            batchData: List<String>,
-        ) {
-            // Create temp table for upsert logic
-            val createTempTableSql =
-                """
-                CREATE TEMP TABLE temp_strategies (
-                    symbol VARCHAR,
-                    strategy_type VARCHAR,
-                    parameters JSONB,
-                    current_score DOUBLE PRECISION,
-                    strategy_hash VARCHAR,
-                    discovery_symbol VARCHAR,
-                    discovery_start_time TIMESTAMP,
-                    discovery_end_time TIMESTAMP
-                ) ON COMMIT DROP
-                """.trimIndent()
-            conn.prepareStatement(createTempTableSql).use { it.execute() }
-
-            // Bulk insert into temp table using COPY
-            val copyManager = bulkCopierFactory.create(conn)
-            val csvData = batchData.joinToString("\n")
-
-            // Log a sample of the CSV data for debugging (first 3 rows)
-            val sampleRows = batchData.take(3)
-            logger.atFine().log("Sample CSV rows for COPY operation: ${sampleRows.joinToString(" | ")}")
-
-            copyManager.copy(
-                "temp_strategies",
-                StringReader(csvData),
-            )
-
-            // Upsert from temp table to main table
-            val upsertSql =
-                """
-                INSERT INTO Strategies (
-                    strategy_id, symbol, strategy_type, parameters,
-                    first_discovered_at, last_evaluated_at, current_score,
-                    is_active, strategy_hash, discovery_symbol,
-                    discovery_start_time, discovery_end_time
-                )
-                SELECT
-                    gen_random_uuid(), symbol, strategy_type, parameters,
-                    NOW(), NOW(), current_score, TRUE, strategy_hash,
-                    discovery_symbol, discovery_start_time, discovery_end_time
-                FROM temp_strategies
-                ON CONFLICT (strategy_hash) DO UPDATE SET
-                    current_score = EXCLUDED.current_score,
-                    last_evaluated_at = NOW()
-                """.trimIndent()
-            conn.prepareStatement(upsertSql).use { it.execute() }
+            // TODO: Implement direct persistence logic here, or just log for now
+            logger.atInfo().log("Would persist ${batchData.size} strategies (repository abstraction removed)")
         }
 
         public fun convertToCsvRow(element: DiscoveredStrategy): String? {
@@ -237,16 +90,17 @@ class WriteDiscoveredStrategiesToPostgresFn
             val hash = DigestUtils.sha256Hex(parametersTextProto)
 
             // TextProto is much simpler than JSON - just replace tabs and newlines with spaces
-            val escapedTextProto = parametersTextProto
-                .replace("\t", " ")     // Replace tabs that would break CSV
-                .replace("\n", " ")     // Replace newlines that would break CSV  
-                .replace("\r", " ")     // Replace carriage returns
-                .trim()                 // Remove leading/trailing whitespace
+            val escapedTextProto =
+                parametersTextProto
+                    .replace("\t", " ") // Replace tabs that would break CSV
+                    .replace("\n", " ") // Replace newlines that would break CSV
+                    .replace("\r", " ") // Replace carriage returns
+                    .trim() // Remove leading/trailing whitespace
 
             return listOf(
                 element.symbol,
                 element.strategy.type.name,
-                escapedTextProto,        // Use escaped TextProto instead of raw TextProto
+                escapedTextProto, // Use escaped TextProto instead of raw TextProto
                 element.score.toString(),
                 hash,
                 element.symbol,
@@ -264,13 +118,14 @@ class WriteDiscoveredStrategiesToPostgresFn
                 }
 
                 val escapedParametersTextProto = fields[2] // parameters field is at index 2
-                
+
                 // Unescape the TextProto for validation
-                val parametersTextProto = escapedParametersTextProto
-                    .replace("\\t", "\t")     // Unescape tabs
-                    .replace("\\n", "\n")     // Unescape newlines
-                    .replace("\\r", "\r")     // Unescape carriage returns
-                
+                val parametersTextProto =
+                    escapedParametersTextProto
+                        .replace("\\t", "\t") // Unescape tabs
+                        .replace("\\n", "\n") // Unescape newlines
+                        .replace("\\r", "\r") // Unescape carriage returns
+
                 validateTextProtoParameter(parametersTextProto)
             } catch (e: Exception) {
                 logger.atWarning().withCause(e).log("Failed to validate CSV row TextProto: '$csvRow'")

--- a/src/main/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFn.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFn.kt
@@ -2,8 +2,7 @@ package com.verlumen.tradestream.discovery
 
 import com.google.common.flogger.FluentLogger
 import com.google.inject.Inject
-import com.verlumen.tradestream.strategies.StrategyParameterTypeRegistry
-import org.apache.commons.codec.digest.DigestUtils
+import com.google.inject.assistedinject.Assisted
 import java.util.concurrent.ConcurrentLinkedQueue
 
 /**
@@ -21,19 +20,21 @@ import java.util.concurrent.ConcurrentLinkedQueue
 class WriteDiscoveredStrategiesToPostgresFn
     @Inject
     constructor(
-        // Remove strategyRepository: StrategyRepository
+        private val strategyRepository: StrategyRepository,
+        @Assisted private val dataSourceConfig: com.verlumen.tradestream.sql.DataSourceConfig,
     ) : DiscoveredStrategySink() {
         companion object {
             private val logger = FluentLogger.forEnclosingClass()
             private const val BATCH_SIZE = 100
         }
 
+        // Remove @Transient to prevent null after deserialization
         private var batch: ConcurrentLinkedQueue<DiscoveredStrategy>? = null
 
         @Setup
         fun setup() {
+            // Initialize batch queue
             batch = ConcurrentLinkedQueue()
-            logger.atInfo().log("Direct sink initialized (no repository abstraction)")
         }
 
         @ProcessElement
@@ -65,94 +66,13 @@ class WriteDiscoveredStrategiesToPostgresFn
                 currentBatch.poll()?.let { batchData.add(it) }
             }
             if (batchData.isEmpty()) return
-            // TODO: Implement direct persistence logic here, or just log for now
-            logger.atInfo().log("Would persist ${batchData.size} strategies (repository abstraction removed)")
-        }
 
-        public fun convertToCsvRow(element: DiscoveredStrategy): String? {
-            val parametersTextProto = StrategyParameterTypeRegistry.formatParametersToTextProto(element.strategy.parameters)
-
-            // Treat error textproto as invalid
-            if (parametersTextProto.contains("error:")) {
-                logger.atWarning().log(
-                    "Error TextProto parameters for strategy ${element.strategy.type.name} on ${element.symbol}: '$parametersTextProto'",
-                )
-                return null
-            }
-            // Validate textproto before proceeding
-            if (!validateTextProtoParameter(parametersTextProto)) {
-                logger.atWarning().log(
-                    "Invalid TextProto parameters for strategy ${element.strategy.type.name} on ${element.symbol}: '$parametersTextProto'",
-                )
-                return null
-            }
-
-            val hash = DigestUtils.sha256Hex(parametersTextProto)
-
-            // TextProto is much simpler than JSON - just replace tabs and newlines with spaces
-            val escapedTextProto =
-                parametersTextProto
-                    .replace("\t", " ") // Replace tabs that would break CSV
-                    .replace("\n", " ") // Replace newlines that would break CSV
-                    .replace("\r", " ") // Replace carriage returns
-                    .trim() // Remove leading/trailing whitespace
-
-            return listOf(
-                element.symbol,
-                element.strategy.type.name,
-                escapedTextProto, // Use escaped TextProto instead of raw TextProto
-                element.score.toString(),
-                hash,
-                element.symbol,
-                element.startTime.seconds.toString(),
-                element.endTime.seconds.toString(),
-            ).joinToString("\t")
-        }
-
-        public fun validateCsvRowTextProto(csvRow: String): Boolean {
-            return try {
-                val fields = csvRow.split("\t")
-                if (fields.size < 3) {
-                    logger.atWarning().log("CSV row has insufficient fields: '$csvRow'")
-                    return false
-                }
-
-                val escapedParametersTextProto = fields[2] // parameters field is at index 2
-
-                // Unescape the TextProto for validation
-                val parametersTextProto =
-                    escapedParametersTextProto
-                        .replace("\\t", "\t") // Unescape tabs
-                        .replace("\\n", "\n") // Unescape newlines
-                        .replace("\\r", "\r") // Unescape carriage returns
-
-                validateTextProtoParameter(parametersTextProto)
+            try {
+                strategyRepository.saveAll(batchData)
+                logger.atInfo().log("Successfully persisted ${batchData.size} strategies")
             } catch (e: Exception) {
-                logger.atWarning().withCause(e).log("Failed to validate CSV row TextProto: '$csvRow'")
-                false
-            }
-        }
-
-        public fun validateTextProtoParameter(textProto: String): Boolean {
-            if (textProto.isNullOrBlank()) {
-                logger.atWarning().log("TextProto parameter is null or blank")
-                return false
-            }
-            val trimmed = textProto.trim()
-            return try {
-                // Accept any non-blank string with at least one colon and not containing 'error:'
-                if (trimmed.contains("error:")) {
-                    logger.atWarning().log("TextProto parameter contains error: '$trimmed'")
-                    false
-                } else if (trimmed.contains(":")) {
-                    true
-                } else {
-                    logger.atWarning().log("TextProto parameter has invalid format: '$trimmed'")
-                    false
-                }
-            } catch (e: Exception) {
-                logger.atWarning().withCause(e).log("Invalid TextProto detected: '$textProto'")
-                false
+                logger.atSevere().withCause(e).log("Failed to persist ${batchData.size} strategies")
+                throw e
             }
         }
     }

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyParameterTypeRegistry.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyParameterTypeRegistry.kt
@@ -4,7 +4,6 @@ import com.google.common.flogger.FluentLogger
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import com.google.protobuf.Any
-import com.google.protobuf.InvalidProtocolBufferException
 import com.google.protobuf.TextFormat
 import com.verlumen.tradestream.strategies.AdxDmiParameters
 import com.verlumen.tradestream.strategies.AdxStochasticParameters
@@ -71,10 +70,10 @@ object StrategyParameterTypeRegistry {
     // Trigger new build with JSON serialization fix
     private val logger = FluentLogger.forEnclosingClass()
 
-    fun formatParametersToTextProto(any: Any): String =
+    fun formatParametersToTextProto(any: Any): String {
         try {
             if (any.typeUrl.isNullOrBlank() || any.value == com.google.protobuf.ByteString.EMPTY) {
-                createErrorJson("empty parameters")
+                return "error: \"empty parameters\""
             } else {
                 val textProtoString =
                     when (any.typeUrl) {
@@ -82,7 +81,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(SmaRsiParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -90,7 +89,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(EmaMacdParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -98,7 +97,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(AdxStochasticParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -106,7 +105,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(AroonMfiParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -114,7 +113,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(IchimokuCloudParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -122,7 +121,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(ParabolicSarParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -130,7 +129,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(SmaEmaCrossoverParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -138,7 +137,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(DoubleEmaCrossoverParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -146,7 +145,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(TripleEmaCrossoverParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -154,7 +153,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(MacdCrossoverParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -162,7 +161,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(RsiEmaCrossoverParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -170,7 +169,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(StochasticEmaParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -178,7 +177,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(StochasticRsiParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -186,7 +185,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(VwapCrossoverParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -194,7 +193,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(VwapMeanReversionParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -202,7 +201,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(VolumeWeightedMacdParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -210,7 +209,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(ObvEmaParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -218,7 +217,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(PvtParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -226,7 +225,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(VptParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -234,7 +233,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(VolumeBreakoutParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -242,7 +241,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(VolumeSpreadAnalysisParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -250,7 +249,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(TrixSignalLineParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -258,7 +257,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(DemaTemaCrossoverParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -266,7 +265,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(AwesomeOscillatorParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -274,7 +273,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(RainbowOscillatorParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -282,7 +281,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(RegressionChannelParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -290,7 +289,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(PriceOscillatorSignalParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -298,7 +297,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(RenkoChartParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -306,7 +305,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(RangeBarsParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -314,7 +313,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(GannSwingParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -322,7 +321,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(SarMfiParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -330,7 +329,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(DpoCrossoverParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -338,7 +337,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(VariablePeriodEmaParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -346,7 +345,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(VolumeProfileParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -354,7 +353,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(VolumeProfileDeviationsParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -362,7 +361,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(AdxDmiParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -370,7 +369,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(AtrCciParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -378,7 +377,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(AtrTrailingStopParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -386,7 +385,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(BbandWRParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -394,7 +393,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(ChaikinOscillatorParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -402,7 +401,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(CmfZeroLineParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -410,7 +409,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(DonchianBreakoutParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -418,7 +417,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(DoubleTopBottomParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -426,7 +425,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(FibonacciRetracementsParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -434,7 +433,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(PriceGapParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -442,7 +441,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(ElderRayMAParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -450,7 +449,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(FramaParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -458,7 +457,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(HeikenAshiParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -466,7 +465,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(KstOscillatorParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -474,7 +473,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(LinearRegressionChannelsParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -482,7 +481,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(MassIndexParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -490,7 +489,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(MomentumPinballParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -498,7 +497,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(MomentumSmaCrossoverParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -506,7 +505,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(PivotParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -514,7 +513,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(RviParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -522,7 +521,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(KlingerVolumeParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -530,7 +529,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(VolatilityStopParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -538,7 +537,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(TickVolumeAnalysisParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -546,7 +545,7 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(CmoMfiParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
@@ -554,23 +553,21 @@ object StrategyParameterTypeRegistry {
                             val builder = StringBuilder()
                             TextFormat.printer().print(
                                 any.unpack(RocMaCrossoverParameters::class.java),
-                                builder
+                                builder,
                             )
                             builder.toString()
                         }
                         else -> {
-                            logger.atWarning().log("Unknown parameter type: ${any.typeUrl}")
-                            createErrorJson("unknown parameter type: ${any.typeUrl}")
+                            // Unknown type fallback
+                            return "error: \"unknown type: ${any.typeUrl}\""
                         }
                     }
-
-                // Replace newlines and tabs with spaces for CSV compatibility
-                textProtoString.replace("\n", " ").replace("\t", " ").trim()
+                return textProtoString
             }
         } catch (e: Exception) {
-            logger.atWarning().withCause(e).log("Error formatting parameters to textproto")
-            createErrorJson("formatting error: ${e.message}")
+            return "error: \"invalid proto: ${e.message}\""
         }
+    }
 
     private fun createFallbackJson(any: Any): String {
         val jsonObject = JsonObject()

--- a/src/main/java/com/verlumen/tradestream/strategies/StrategyParameterTypeRegistry.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/StrategyParameterTypeRegistry.kt
@@ -4,7 +4,7 @@ import com.google.common.flogger.FluentLogger
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import com.google.protobuf.Any
-import com.google.protobuf.TextFormat
+import com.google.protobuf.util.JsonFormat
 import com.verlumen.tradestream.strategies.AdxDmiParameters
 import com.verlumen.tradestream.strategies.AdxStochasticParameters
 import com.verlumen.tradestream.strategies.AroonMfiParameters
@@ -70,504 +70,261 @@ object StrategyParameterTypeRegistry {
     // Trigger new build with JSON serialization fix
     private val logger = FluentLogger.forEnclosingClass()
 
-    fun formatParametersToTextProto(any: Any): String {
+    fun formatParametersToJson(any: Any): String =
         try {
             if (any.typeUrl.isNullOrBlank() || any.value == com.google.protobuf.ByteString.EMPTY) {
-                return "error: \"empty parameters\""
+                "error: \"empty parameters\""
             } else {
-                val textProtoString =
+                val jsonString =
                     when (any.typeUrl) {
-                        "type.googleapis.com/strategies.SmaRsiParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.SmaRsiParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(SmaRsiParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.EmaMacdParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.EmaMacdParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(EmaMacdParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.AdxStochasticParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.AdxStochasticParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(AdxStochasticParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.AroonMfiParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.AroonMfiParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(AroonMfiParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.IchimokuCloudParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.IchimokuCloudParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(IchimokuCloudParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.ParabolicSarParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.ParabolicSarParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(ParabolicSarParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.SmaEmaCrossoverParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.SmaEmaCrossoverParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(SmaEmaCrossoverParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.DoubleEmaCrossoverParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.DoubleEmaCrossoverParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(DoubleEmaCrossoverParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.TripleEmaCrossoverParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.TripleEmaCrossoverParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(TripleEmaCrossoverParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.MacdCrossoverParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.MacdCrossoverParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(MacdCrossoverParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.RsiEmaCrossoverParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.RsiEmaCrossoverParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(RsiEmaCrossoverParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.StochasticEmaParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.StochasticEmaParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(StochasticEmaParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.StochasticRsiParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.StochasticRsiParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(StochasticRsiParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.VwapCrossoverParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.VwapCrossoverParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(VwapCrossoverParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.VwapMeanReversionParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.VwapMeanReversionParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(VwapMeanReversionParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.VolumeWeightedMacdParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.VolumeWeightedMacdParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(VolumeWeightedMacdParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.ObvEmaParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.ObvEmaParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(ObvEmaParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.PvtParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.PvtParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(PvtParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.VptParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.VptParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(VptParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.VolumeBreakoutParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.VolumeBreakoutParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(VolumeBreakoutParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.VolumeSpreadAnalysisParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.VolumeSpreadAnalysisParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(VolumeSpreadAnalysisParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.TrixSignalLineParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.TrixSignalLineParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(TrixSignalLineParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.DemaTemaCrossoverParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.DemaTemaCrossoverParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(DemaTemaCrossoverParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.AwesomeOscillatorParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.AwesomeOscillatorParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(AwesomeOscillatorParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.RainbowOscillatorParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.RainbowOscillatorParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(RainbowOscillatorParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.RegressionChannelParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.RegressionChannelParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(RegressionChannelParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.PriceOscillatorSignalParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.PriceOscillatorSignalParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(PriceOscillatorSignalParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.RenkoChartParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.RenkoChartParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(RenkoChartParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.RangeBarsParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.RangeBarsParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(RangeBarsParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.GannSwingParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.GannSwingParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(GannSwingParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.SarMfiParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.SarMfiParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(SarMfiParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.DpoCrossoverParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.DpoCrossoverParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(DpoCrossoverParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.VariablePeriodEmaParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.VariablePeriodEmaParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(VariablePeriodEmaParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.VolumeProfileParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.VolumeProfileParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(VolumeProfileParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.VolumeProfileDeviationsParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.VolumeProfileDeviationsParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(VolumeProfileDeviationsParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.AdxDmiParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.AdxDmiParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(AdxDmiParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.AtrCciParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.AtrCciParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(AtrCciParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.AtrTrailingStopParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.AtrTrailingStopParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(AtrTrailingStopParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.BbandWRParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.BbandWRParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(BbandWRParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.ChaikinOscillatorParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.ChaikinOscillatorParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(ChaikinOscillatorParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.CmfZeroLineParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.CmfZeroLineParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(CmfZeroLineParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.DonchianBreakoutParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.DonchianBreakoutParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(DonchianBreakoutParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.DoubleTopBottomParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.DoubleTopBottomParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(DoubleTopBottomParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.FibonacciRetracementsParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.FibonacciRetracementsParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(FibonacciRetracementsParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.PriceGapParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.PriceGapParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(PriceGapParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.ElderRayMAParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.ElderRayMAParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(ElderRayMAParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.FramaParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.FramaParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(FramaParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.HeikenAshiParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.HeikenAshiParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(HeikenAshiParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.KstOscillatorParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.KstOscillatorParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(KstOscillatorParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.LinearRegressionChannelsParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.LinearRegressionChannelsParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(LinearRegressionChannelsParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.MassIndexParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.MassIndexParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(MassIndexParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.MomentumPinballParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.MomentumPinballParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(MomentumPinballParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.MomentumSmaCrossoverParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.MomentumSmaCrossoverParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(MomentumSmaCrossoverParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.PivotParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.PivotParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(PivotParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.RviParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.RviParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(RviParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.KlingerVolumeParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.KlingerVolumeParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(KlingerVolumeParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.VolatilityStopParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.VolatilityStopParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(VolatilityStopParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.TickVolumeAnalysisParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.TickVolumeAnalysisParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(TickVolumeAnalysisParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.CmoMfiParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.CmoMfiParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(CmoMfiParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        "type.googleapis.com/strategies.RocMaCrossoverParameters" -> {
-                            val builder = StringBuilder()
-                            TextFormat.printer().print(
+                        "type.googleapis.com/strategies.RocMaCrossoverParameters" ->
+                            JsonFormat.printer().omittingInsignificantWhitespace().print(
                                 any.unpack(RocMaCrossoverParameters::class.java),
-                                builder,
                             )
-                            builder.toString()
-                        }
-                        else -> {
-                            // Unknown type fallback
-                            return "error: \"unknown type: ${any.typeUrl}\""
-                        }
+                        else ->
+                            createFallbackJson(any)
                     }
-                return textProtoString
+                jsonString
             }
         } catch (e: Exception) {
-            return "error: \"invalid proto: ${e.message}\""
+            "error: \"invalid proto: ${e.message}\""
         }
-    }
 
     private fun createFallbackJson(any: Any): String {
         val jsonObject = JsonObject()

--- a/src/test/java/com/verlumen/tradestream/discovery/BUILD
+++ b/src/test/java/com/verlumen/tradestream/discovery/BUILD
@@ -211,6 +211,7 @@ kt_jvm_test(
         "//src/main/java/com/verlumen/tradestream/sql:data_source_factory",
         "//third_party/java:beam_sdks_java_core",
         "//third_party/java:beam_sdks_java_test_utils",
+        "//third_party/java:commons_csv",
         "//third_party/java:guice",
         "//third_party/java:guice_testlib",
         "//third_party/java:jenetics",
@@ -221,7 +222,6 @@ kt_jvm_test(
         "//third_party/java:protobuf_java",
         "//third_party/java:protobuf_java_util",
         "//third_party/java:truth",
-        "//third_party/java:commons_csv",
     ],
 )
 
@@ -236,5 +236,21 @@ kt_jvm_test(
         "//third_party/java:beam_sdks_java_core",
         "//third_party/java:junit",
         "//third_party/java:truth",
+    ],
+)
+
+kt_jvm_test(
+    name = "PostgresStrategyRepositoryTest",
+    srcs = ["PostgresStrategyRepositoryTest.kt"],
+    deps = [
+        "//src/main/java/com/verlumen/tradestream/discovery:strategy_repository",
+        "//src/main/java/com/verlumen/tradestream/sql:data_source_factory",
+        "//src/main/java/com/verlumen/tradestream/strategies:strategy_factory",
+        "//third_party/java:flogger",
+        "//third_party/java:guice",
+        "//third_party/java:junit",
+        "//third_party/java:mockito_kotlin",
+        "//third_party/java:protobuf_java",
+        "//third_party/java:protobuf_java_util",
     ],
 )

--- a/src/test/java/com/verlumen/tradestream/discovery/PostgresStrategyRepositoryTest.kt
+++ b/src/test/java/com/verlumen/tradestream/discovery/PostgresStrategyRepositoryTest.kt
@@ -1,0 +1,84 @@
+package com.verlumen.tradestream.discovery
+
+import com.google.protobuf.Any
+import com.google.protobuf.Timestamp
+import com.verlumen.tradestream.sql.BulkCopier
+import com.verlumen.tradestream.sql.BulkCopierFactory
+import com.verlumen.tradestream.sql.DataSourceConfig
+import com.verlumen.tradestream.sql.DataSourceFactory
+import com.verlumen.tradestream.strategies.Strategy
+import com.verlumen.tradestream.strategies.StrategyType
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.io.Reader
+import java.sql.Connection
+import java.sql.PreparedStatement
+import javax.sql.DataSource
+
+class PostgresStrategyRepositoryTest {
+    private lateinit var repository: PostgresStrategyRepository
+    private lateinit var mockBulkCopierFactory: BulkCopierFactory
+    private lateinit var mockDataSourceFactory: DataSourceFactory
+    private lateinit var mockDataSource: DataSource
+    private lateinit var mockConnection: Connection
+    private lateinit var mockPreparedStatement: PreparedStatement
+    private lateinit var mockBulkCopier: BulkCopier
+    private val config =
+        DataSourceConfig(
+            serverName = "localhost",
+            databaseName = "test_db",
+            username = "user",
+            password = "pass",
+            portNumber = 5432,
+            applicationName = "test",
+            connectTimeout = 10,
+            socketTimeout = 10,
+            readOnly = false,
+        )
+
+    @Before
+    fun setUp() {
+        mockBulkCopierFactory = mock()
+        mockDataSourceFactory = mock()
+        mockDataSource = mock()
+        mockConnection = mock()
+        mockPreparedStatement = mock()
+        mockBulkCopier = mock()
+
+        whenever(mockDataSourceFactory.create(config)).thenReturn(mockDataSource)
+        whenever(mockDataSource.connection).thenReturn(mockConnection)
+        whenever(mockConnection.prepareStatement(org.mockito.kotlin.any())).thenReturn(mockPreparedStatement)
+        whenever(mockPreparedStatement.execute()).thenReturn(true)
+        whenever(mockBulkCopierFactory.create(mockConnection)).thenReturn(mockBulkCopier)
+        doNothing().whenever(mockBulkCopier).copy(org.mockito.kotlin.any(), org.mockito.kotlin.any<Reader>())
+
+        repository = PostgresStrategyRepository(mockBulkCopierFactory, mockDataSourceFactory, config)
+    }
+
+    @Test
+    fun testSaveAndFindAll_NoException() {
+        // This test just verifies that saveAll does not throw with valid input
+        val strategy =
+            Strategy
+                .newBuilder()
+                .setType(StrategyType.SMA_RSI)
+                .setParameters(Any.getDefaultInstance())
+                .build()
+        val discovered =
+            DiscoveredStrategy
+                .newBuilder()
+                .setStrategy(strategy)
+                .setScore(1.0)
+                .setSymbol("BTCUSDT")
+                .setStartTime(Timestamp.getDefaultInstance())
+                .setEndTime(Timestamp.getDefaultInstance())
+                .build()
+        repository.saveAll(listOf(discovered))
+        // No exception = pass
+    }
+
+    // Add more tests for findBySymbol and findAll with a real or in-memory DB if needed
+}

--- a/src/test/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFnTest.kt
+++ b/src/test/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFnTest.kt
@@ -1,48 +1,35 @@
 package com.verlumen.tradestream.discovery
 
 import com.google.common.flogger.FluentLogger
-import com.google.inject.Guice
+import com.google.common.truth.Truth.assertThat
 import com.google.inject.testing.fieldbinder.Bind
-import com.google.inject.testing.fieldbinder.BoundFieldModule
 import com.google.protobuf.Any
 import com.google.protobuf.Timestamp
 import com.verlumen.tradestream.sql.BulkCopier
 import com.verlumen.tradestream.sql.BulkCopierFactory
-import com.verlumen.tradestream.sql.DataSourceConfig
 import com.verlumen.tradestream.sql.DataSourceFactory
+import com.verlumen.tradestream.strategies.AdxStochasticParameters
+import com.verlumen.tradestream.strategies.AroonMfiParameters
+import com.verlumen.tradestream.strategies.EmaMacdParameters
+import com.verlumen.tradestream.strategies.IchimokuCloudParameters
+import com.verlumen.tradestream.strategies.ParabolicSarParameters
 import com.verlumen.tradestream.strategies.SmaRsiParameters
 import com.verlumen.tradestream.strategies.Strategy
 import com.verlumen.tradestream.strategies.StrategyType
 import org.apache.beam.sdk.testing.TestPipeline
-import org.apache.beam.sdk.transforms.Create
-import org.apache.beam.sdk.transforms.ParDo
-import org.apache.beam.sdk.values.PCollection
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.mockito.Mock
-import org.mockito.Mockito.anyString
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
-import org.mockito.MockitoAnnotations
-import org.mockito.kotlin.any
-import org.mockito.kotlin.whenever
 import java.sql.Connection
 import java.sql.PreparedStatement
-import java.time.Instant
 import javax.sql.DataSource
-import com.google.common.truth.Truth.assertThat
-import com.verlumen.tradestream.strategies.EmaMacdParameters
-import com.verlumen.tradestream.strategies.AdxStochasticParameters
-import com.verlumen.tradestream.strategies.AroonMfiParameters
-import com.verlumen.tradestream.strategies.IchimokuCloudParameters
-import com.verlumen.tradestream.strategies.ParabolicSarParameters
 
 /**
  * Unit tests for WriteDiscoveredStrategiesToPostgresFn using TextProto serialization.
- * 
+ *
  * These tests focus on the DoFn's data transformation logic using mocked dependencies.
  * Full integration tests with PostgreSQL would require a test database.
  */
@@ -92,40 +79,8 @@ class WriteDiscoveredStrategiesToPostgresFnTest {
     private val testReadOnly = false
 
     @Before
-    fun setUp() {
-        MockitoAnnotations.openMocks(this)
-
-        // Create Guice injector with BoundFieldModule to inject the test fixture
-        val injector = Guice.createInjector(BoundFieldModule.of(this))
-        injector.injectMembers(this)
-
-        // Setup mock behavior for DataSourceFactory
-        whenever(mockDataSourceFactory.create(any())).thenReturn(mockDataSource)
-        whenever(mockDataSource.connection).thenReturn(mockConnection)
-
-        // Create the function under test directly (simulating what the factory would do)
-        writeDiscoveredStrategiesToPostgresFn =
-            WriteDiscoveredStrategiesToPostgresFn(
-                bulkCopierFactory = mockBulkCopierFactory,
-                dataSourceFactory = mockDataSourceFactory,
-                dataSourceConfig =
-                    DataSourceConfig(
-                        serverName = testServerName,
-                        databaseName = testDatabaseName,
-                        username = testUsername,
-                        password = testPassword,
-                        portNumber = testPortNumber,
-                        applicationName = testApplicationName,
-                        connectTimeout = testConnectTimeout,
-                        socketTimeout = testSocketTimeout,
-                        readOnly = testReadOnly,
-                    ),
-            )
-
-        // Setup mocks
-        `when`(mockConnection.prepareStatement(anyString())).thenReturn(preparedStatement)
-        `when`(mockBulkCopierFactory.create(mockConnection)).thenReturn(bulkCopier)
-        `when`(preparedStatement.execute()).thenReturn(true)
+    fun setup() {
+        writeDiscoveredStrategiesToPostgresFn = WriteDiscoveredStrategiesToPostgresFn()
     }
 
     @Test
@@ -137,42 +92,48 @@ class WriteDiscoveredStrategiesToPostgresFnTest {
     @Test
     fun `test TextProto CSV format compatibility`() {
         // Create minimal test with known working proto
-        val validParameters = Any.pack(
-            SmaRsiParameters.newBuilder()
-                .setMovingAveragePeriod(14)
-                .setRsiPeriod(14)
-                .setOverboughtThreshold(70.0)
-                .setOversoldThreshold(30.0)
+        val validParameters =
+            Any.pack(
+                SmaRsiParameters
+                    .newBuilder()
+                    .setMovingAveragePeriod(14)
+                    .setRsiPeriod(14)
+                    .setOverboughtThreshold(70.0)
+                    .setOversoldThreshold(30.0)
+                    .build(),
+            )
+
+        val strategy =
+            Strategy
+                .newBuilder()
+                .setType(StrategyType.SMA_RSI)
+                .setParameters(validParameters)
                 .build()
-        )
 
-        val strategy = Strategy.newBuilder()
-            .setType(StrategyType.SMA_RSI)
-            .setParameters(validParameters)
-            .build()
-
-        val discoveredStrategy = DiscoveredStrategy.newBuilder()
-            .setSymbol("BTCUSDT")
-            .setStrategy(strategy)
-            .setScore(0.85)
-            .setStartTime(Timestamp.newBuilder().setSeconds(1640995200).build())
-            .setEndTime(Timestamp.newBuilder().setSeconds(1641081600).build())
-            .build()
+        val discoveredStrategy =
+            DiscoveredStrategy
+                .newBuilder()
+                .setSymbol("BTCUSDT")
+                .setStrategy(strategy)
+                .setScore(0.85)
+                .setStartTime(Timestamp.newBuilder().setSeconds(1640995200).build())
+                .setEndTime(Timestamp.newBuilder().setSeconds(1641081600).build())
+                .build()
 
         val csvRow = writeDiscoveredStrategiesToPostgresFn.convertToCsvRow(discoveredStrategy)
-        
+
         // Basic validation
         assertThat(csvRow).isNotNull()
-        
+
         val fields = csvRow!!.split("\t")
         assertThat(fields.size).isEqualTo(8)
-        
+
         // TextProto field should not contain problematic characters
         val textProtoField = fields[2]
         assertThat(textProtoField.contains("\n")).isFalse()
         assertThat(textProtoField.contains("\r")).isFalse()
         assertThat(textProtoField.contains("\t")).isFalse()
-        
+
         // Should contain expected field names (check actual proto definition)
         assertThat(textProtoField).isNotEmpty()
         assertThat(textProtoField).contains("movingAveragePeriod")
@@ -183,112 +144,128 @@ class WriteDiscoveredStrategiesToPostgresFnTest {
 
     @Test
     fun `test TextProto validation`() {
-        val discoveredStrategy = DiscoveredStrategy.newBuilder()
-            .setSymbol("BTCUSDT")
-            .setStrategy(
-                Strategy.newBuilder()
-                    .setType(StrategyType.SMA_RSI)
-                    .setParameters(createValidParametersForStrategy(StrategyType.SMA_RSI))
-                    .build()
-            )
-            .setScore(0.85)
-            .setStartTime(Timestamp.newBuilder().setSeconds(1640995200).build())
-            .setEndTime(Timestamp.newBuilder().setSeconds(1641081600).build())
-            .build()
-        
+        val discoveredStrategy =
+            DiscoveredStrategy
+                .newBuilder()
+                .setSymbol("BTCUSDT")
+                .setStrategy(
+                    Strategy
+                        .newBuilder()
+                        .setType(StrategyType.SMA_RSI)
+                        .setParameters(createValidParametersForStrategy(StrategyType.SMA_RSI))
+                        .build(),
+                ).setScore(0.85)
+                .setStartTime(Timestamp.newBuilder().setSeconds(1640995200).build())
+                .setEndTime(Timestamp.newBuilder().setSeconds(1641081600).build())
+                .build()
+
         val csvRow = writeDiscoveredStrategiesToPostgresFn.convertToCsvRow(discoveredStrategy)
         assertThat(csvRow).isNotNull()
         assertThat(writeDiscoveredStrategiesToPostgresFn.validateCsvRowTextProto(csvRow!!)).isTrue()
         assertThat(writeDiscoveredStrategiesToPostgresFn.validateCsvRowTextProto("invalid\tcsv")).isFalse()
-        
+
         val invalidCsvRow = "BTCUSDT\tSMA_RSI\tinvalid_textproto\t0.85\thash\tBTCUSDT\t1234567890\t1234567891"
         assertThat(writeDiscoveredStrategiesToPostgresFn.validateCsvRowTextProto(invalidCsvRow)).isFalse()
     }
 
     @Test
     fun `test TextProto validation for all strategy types`() {
-        val strategyTypes = listOf(
-            StrategyType.SMA_RSI,
-            StrategyType.EMA_MACD,
-            StrategyType.ADX_STOCHASTIC,
-            StrategyType.AROON_MFI,
-            StrategyType.ICHIMOKU_CLOUD,
-            StrategyType.PARABOLIC_SAR
-        )
-        
+        val strategyTypes =
+            listOf(
+                StrategyType.SMA_RSI,
+                StrategyType.EMA_MACD,
+                StrategyType.ADX_STOCHASTIC,
+                StrategyType.AROON_MFI,
+                StrategyType.ICHIMOKU_CLOUD,
+                StrategyType.PARABOLIC_SAR,
+            )
+
         for (strategyType in strategyTypes) {
-            val discoveredStrategy = DiscoveredStrategy.newBuilder()
-                .setSymbol("BTCUSDT")
-                .setStrategy(
-                    Strategy.newBuilder()
-                        .setType(strategyType)
-                        .setParameters(createValidParametersForStrategy(strategyType))
-                        .build()
-                )
-                .setScore(0.85)
-                .setStartTime(Timestamp.newBuilder().setSeconds(1234567890).build())
-                .setEndTime(Timestamp.newBuilder().setSeconds(1234567891).build())
-                .build()
-            
+            val discoveredStrategy =
+                DiscoveredStrategy
+                    .newBuilder()
+                    .setSymbol("BTCUSDT")
+                    .setStrategy(
+                        Strategy
+                            .newBuilder()
+                            .setType(strategyType)
+                            .setParameters(createValidParametersForStrategy(strategyType))
+                            .build(),
+                    ).setScore(0.85)
+                    .setStartTime(Timestamp.newBuilder().setSeconds(1234567890).build())
+                    .setEndTime(Timestamp.newBuilder().setSeconds(1234567891).build())
+                    .build()
+
             val csvRow = writeDiscoveredStrategiesToPostgresFn.convertToCsvRow(discoveredStrategy)
             assertThat(csvRow).isNotNull()
-            
+
             val fields = csvRow!!.split("\t")
             val textProtoString = fields[2]
             assertThat(textProtoString).matches("^\\s*\\w+\\s*:\\s*[^\\s]+.*$")
         }
     }
 
-    private fun createValidParametersForStrategy(strategyType: StrategyType): Any {
-        return when (strategyType) {
-            StrategyType.SMA_RSI -> Any.pack(
-                SmaRsiParameters.newBuilder()
-                    .setMovingAveragePeriod(14)
-                    .setRsiPeriod(14)
-                    .setOverboughtThreshold(70.0)
-                    .setOversoldThreshold(30.0)
-                    .build()
-            )
-            StrategyType.EMA_MACD -> Any.pack(
-                EmaMacdParameters.newBuilder()
-                    .setShortEmaPeriod(12)
-                    .setLongEmaPeriod(26)
-                    .setSignalPeriod(9)
-                    .build()
-            )
-            StrategyType.ADX_STOCHASTIC -> Any.pack(
-                AdxStochasticParameters.newBuilder()
-                    .setAdxPeriod(14)
-                    .setStochasticKPeriod(14)
-                    .setStochasticDPeriod(3)
-                    .setOverboughtThreshold(80)
-                    .setOversoldThreshold(20)
-                    .build()
-            )
-            StrategyType.AROON_MFI -> Any.pack(
-                AroonMfiParameters.newBuilder()
-                    .setAroonPeriod(14)
-                    .setMfiPeriod(14)
-                    .setOverboughtThreshold(80)
-                    .setOversoldThreshold(20)
-                    .build()
-            )
-            StrategyType.ICHIMOKU_CLOUD -> Any.pack(
-                IchimokuCloudParameters.newBuilder()
-                    .setTenkanSenPeriod(9)
-                    .setKijunSenPeriod(26)
-                    .setSenkouSpanBPeriod(52)
-                    .setChikouSpanPeriod(26)
-                    .build()
-            )
-            StrategyType.PARABOLIC_SAR -> Any.pack(
-                ParabolicSarParameters.newBuilder()
-                    .setAccelerationFactorStart(0.02)
-                    .setAccelerationFactorIncrement(0.02)
-                    .setAccelerationFactorMax(0.2)
-                    .build()
-            )
+    private fun createValidParametersForStrategy(strategyType: StrategyType): Any =
+        when (strategyType) {
+            StrategyType.SMA_RSI ->
+                Any.pack(
+                    SmaRsiParameters
+                        .newBuilder()
+                        .setMovingAveragePeriod(14)
+                        .setRsiPeriod(14)
+                        .setOverboughtThreshold(70.0)
+                        .setOversoldThreshold(30.0)
+                        .build(),
+                )
+            StrategyType.EMA_MACD ->
+                Any.pack(
+                    EmaMacdParameters
+                        .newBuilder()
+                        .setShortEmaPeriod(12)
+                        .setLongEmaPeriod(26)
+                        .setSignalPeriod(9)
+                        .build(),
+                )
+            StrategyType.ADX_STOCHASTIC ->
+                Any.pack(
+                    AdxStochasticParameters
+                        .newBuilder()
+                        .setAdxPeriod(14)
+                        .setStochasticKPeriod(14)
+                        .setStochasticDPeriod(3)
+                        .setOverboughtThreshold(80)
+                        .setOversoldThreshold(20)
+                        .build(),
+                )
+            StrategyType.AROON_MFI ->
+                Any.pack(
+                    AroonMfiParameters
+                        .newBuilder()
+                        .setAroonPeriod(14)
+                        .setMfiPeriod(14)
+                        .setOverboughtThreshold(80)
+                        .setOversoldThreshold(20)
+                        .build(),
+                )
+            StrategyType.ICHIMOKU_CLOUD ->
+                Any.pack(
+                    IchimokuCloudParameters
+                        .newBuilder()
+                        .setTenkanSenPeriod(9)
+                        .setKijunSenPeriod(26)
+                        .setSenkouSpanBPeriod(52)
+                        .setChikouSpanPeriod(26)
+                        .build(),
+                )
+            StrategyType.PARABOLIC_SAR ->
+                Any.pack(
+                    ParabolicSarParameters
+                        .newBuilder()
+                        .setAccelerationFactorStart(0.02)
+                        .setAccelerationFactorIncrement(0.02)
+                        .setAccelerationFactorMax(0.2)
+                        .build(),
+                )
             else -> throw IllegalArgumentException("Unsupported strategy type: $strategyType")
         }
-    }
 }

--- a/src/test/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFnTest.kt
+++ b/src/test/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToPostgresFnTest.kt
@@ -2,33 +2,32 @@ package com.verlumen.tradestream.discovery
 
 import com.google.common.flogger.FluentLogger
 import com.google.common.truth.Truth.assertThat
+import com.google.inject.Guice
 import com.google.inject.testing.fieldbinder.Bind
+import com.google.inject.testing.fieldbinder.BoundFieldModule
 import com.google.protobuf.Any
 import com.google.protobuf.Timestamp
-import com.verlumen.tradestream.sql.BulkCopier
-import com.verlumen.tradestream.sql.BulkCopierFactory
-import com.verlumen.tradestream.sql.DataSourceFactory
-import com.verlumen.tradestream.strategies.AdxStochasticParameters
-import com.verlumen.tradestream.strategies.AroonMfiParameters
+import com.verlumen.tradestream.discovery.StrategyCsvUtil
+import com.verlumen.tradestream.sql.DataSourceConfig
 import com.verlumen.tradestream.strategies.EmaMacdParameters
-import com.verlumen.tradestream.strategies.IchimokuCloudParameters
-import com.verlumen.tradestream.strategies.ParabolicSarParameters
 import com.verlumen.tradestream.strategies.SmaRsiParameters
 import com.verlumen.tradestream.strategies.Strategy
 import com.verlumen.tradestream.strategies.StrategyType
 import org.apache.beam.sdk.testing.TestPipeline
+import org.apache.commons.csv.CSVFormat
+import org.apache.commons.csv.CSVParser
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.mockito.Mock
-import java.sql.Connection
-import java.sql.PreparedStatement
-import javax.sql.DataSource
+import org.mockito.MockitoAnnotations
+import java.time.Instant
 
 /**
- * Unit tests for WriteDiscoveredStrategiesToPostgresFn using TextProto serialization.
+ * Unit tests for WriteDiscoveredStrategiesToPostgresFn using the new factory pattern
+ * with assisted injection.
  *
  * These tests focus on the DoFn's data transformation logic using mocked dependencies.
  * Full integration tests with PostgreSQL would require a test database.
@@ -47,22 +46,7 @@ class WriteDiscoveredStrategiesToPostgresFnTest {
 
     // Use BoundFieldModule to inject these mocks
     @Bind @Mock
-    lateinit var mockDataSourceFactory: DataSourceFactory
-
-    @Bind @Mock
-    lateinit var mockBulkCopierFactory: BulkCopierFactory
-
-    @Mock
-    lateinit var mockDataSource: DataSource
-
-    @Mock
-    lateinit var mockConnection: Connection
-
-    @Mock
-    private lateinit var preparedStatement: PreparedStatement
-
-    @Mock
-    private lateinit var bulkCopier: BulkCopier
+    lateinit var mockStrategyRepository: StrategyRepository
 
     // The class under test - will be created directly with mocked dependencies
     private lateinit var writeDiscoveredStrategiesToPostgresFn: WriteDiscoveredStrategiesToPostgresFn
@@ -79,36 +63,55 @@ class WriteDiscoveredStrategiesToPostgresFnTest {
     private val testReadOnly = false
 
     @Before
-    fun setup() {
-        writeDiscoveredStrategiesToPostgresFn = WriteDiscoveredStrategiesToPostgresFn()
-    }
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
 
-    @Test
-    fun `test instance created with correct parameters`() {
-        // Verify the instance is not null and was created successfully
-        assertThat(writeDiscoveredStrategiesToPostgresFn).isNotNull()
-    }
+        // Create Guice injector with BoundFieldModule to inject the test fixture
+        val injector = Guice.createInjector(BoundFieldModule.of(this))
+        injector.injectMembers(this)
 
-    @Test
-    fun `test TextProto CSV format compatibility`() {
-        // Create minimal test with known working proto
-        val validParameters =
-            Any.pack(
-                SmaRsiParameters
-                    .newBuilder()
-                    .setMovingAveragePeriod(14)
-                    .setRsiPeriod(14)
-                    .setOverboughtThreshold(70.0)
-                    .setOversoldThreshold(30.0)
-                    .build(),
+        // Create the function under test directly (simulating what the factory would do)
+        val dataSourceConfig =
+            DataSourceConfig(
+                serverName = testServerName,
+                databaseName = testDatabaseName,
+                username = testUsername,
+                password = testPassword,
+                portNumber = testPortNumber,
+                applicationName = testApplicationName,
+                connectTimeout = testConnectTimeout,
+                socketTimeout = testSocketTimeout,
+                readOnly = testReadOnly,
             )
+        writeDiscoveredStrategiesToPostgresFn = WriteDiscoveredStrategiesToPostgresFn(mockStrategyRepository, dataSourceConfig)
+    }
+
+    @Test
+    fun testInstanceCreatedWithCorrectParameters() {
+        // Verify the instance is not null and was created successfully
+        assert(writeDiscoveredStrategiesToPostgresFn != null) { "Instance should be created successfully" }
+    }
+
+    @Test
+    fun testCsvRowGeneration() {
+        val startTime = Instant.parse("2023-01-01T00:00:00Z")
+        val endTime = Instant.parse("2023-01-02T00:00:00Z")
 
         val strategy =
             Strategy
                 .newBuilder()
                 .setType(StrategyType.SMA_RSI)
-                .setParameters(validParameters)
-                .build()
+                .setParameters(
+                    Any.pack(
+                        SmaRsiParameters
+                            .newBuilder()
+                            .setMovingAveragePeriod(14)
+                            .setRsiPeriod(14)
+                            .setOverboughtThreshold(70.0)
+                            .setOversoldThreshold(30.0)
+                            .build(),
+                    ),
+                ).build()
 
         val discoveredStrategy =
             DiscoveredStrategy
@@ -116,156 +119,63 @@ class WriteDiscoveredStrategiesToPostgresFnTest {
                 .setSymbol("BTCUSDT")
                 .setStrategy(strategy)
                 .setScore(0.85)
-                .setStartTime(Timestamp.newBuilder().setSeconds(1640995200).build())
-                .setEndTime(Timestamp.newBuilder().setSeconds(1641081600).build())
+                .setStartTime(Timestamp.newBuilder().setSeconds(startTime.epochSecond).build())
+                .setEndTime(Timestamp.newBuilder().setSeconds(endTime.epochSecond).build())
                 .build()
 
-        val csvRow = writeDiscoveredStrategiesToPostgresFn.convertToCsvRow(discoveredStrategy)
-
-        // Basic validation
+        val csvRow = StrategyCsvUtil.convertToCsvRow(discoveredStrategy)
         assertThat(csvRow).isNotNull()
 
-        val fields = csvRow!!.split("\t")
-        assertThat(fields.size).isEqualTo(8)
+        // Parse CSV to verify structure
+        val csvParser = CSVParser.parse(csvRow, CSVFormat.TDF)
+        val records = csvParser.records
+        assertThat(records).hasSize(1)
 
-        // TextProto field should not contain problematic characters
-        val textProtoField = fields[2]
-        assertThat(textProtoField.contains("\n")).isFalse()
-        assertThat(textProtoField.contains("\r")).isFalse()
-        assertThat(textProtoField.contains("\t")).isFalse()
-
-        // Should contain expected field names (check actual proto definition)
-        assertThat(textProtoField).isNotEmpty()
-        assertThat(textProtoField).contains("movingAveragePeriod")
-        assertThat(textProtoField).contains("rsiPeriod")
-        assertThat(textProtoField).contains("overboughtThreshold")
-        assertThat(textProtoField).contains("oversoldThreshold")
+        val record = records[0]
+        assertThat(record.get(0)).isEqualTo("BTCUSDT") // symbol
+        assertThat(record.get(1)).isEqualTo("SMA_RSI") // strategy_type
+        assertThat(record.get(2)).isNotEmpty() // parameters (base64 JSON)
+        assertThat(record.get(3)).isEqualTo("0.85") // score
+        assertThat(record.get(4)).isNotEmpty() // hash
+        assertThat(record.get(5)).isEqualTo("BTCUSDT") // symbol (for ON CONFLICT)
+        assertThat(record.get(6)).isEqualTo(startTime.epochSecond.toString()) // start_time
+        assertThat(record.get(7)).isEqualTo(endTime.epochSecond.toString()) // end_time
     }
 
     @Test
-    fun `test TextProto validation`() {
+    fun `test PostgreSQL COPY compatibility`() {
+        val strategy =
+            Strategy
+                .newBuilder()
+                .setType(StrategyType.EMA_MACD)
+                .setParameters(
+                    Any.pack(
+                        EmaMacdParameters
+                            .newBuilder()
+                            .setShortEmaPeriod(12)
+                            .setLongEmaPeriod(26)
+                            .setSignalPeriod(9)
+                            .build(),
+                    ),
+                ).build()
+
         val discoveredStrategy =
             DiscoveredStrategy
                 .newBuilder()
-                .setSymbol("BTCUSDT")
-                .setStrategy(
-                    Strategy
-                        .newBuilder()
-                        .setType(StrategyType.SMA_RSI)
-                        .setParameters(createValidParametersForStrategy(StrategyType.SMA_RSI))
-                        .build(),
-                ).setScore(0.85)
+                .setSymbol("ETHUSDT")
+                .setStrategy(strategy)
+                .setScore(0.92)
                 .setStartTime(Timestamp.newBuilder().setSeconds(1640995200).build())
                 .setEndTime(Timestamp.newBuilder().setSeconds(1641081600).build())
                 .build()
 
-        val csvRow = writeDiscoveredStrategiesToPostgresFn.convertToCsvRow(discoveredStrategy)
+        val csvRow = StrategyCsvUtil.convertToCsvRow(discoveredStrategy)
         assertThat(csvRow).isNotNull()
-        assertThat(writeDiscoveredStrategiesToPostgresFn.validateCsvRowTextProto(csvRow!!)).isTrue()
-        assertThat(writeDiscoveredStrategiesToPostgresFn.validateCsvRowTextProto("invalid\tcsv")).isFalse()
 
-        val invalidCsvRow = "BTCUSDT\tSMA_RSI\tinvalid_textproto\t0.85\thash\tBTCUSDT\t1234567890\t1234567891"
-        assertThat(writeDiscoveredStrategiesToPostgresFn.validateCsvRowTextProto(invalidCsvRow)).isFalse()
+        // Verify no problematic characters for PostgreSQL COPY
+        assertThat(csvRow).doesNotContain("\n")
+        assertThat(csvRow).doesNotContain("\r")
+        // Tab is the delimiter, so it should be present
+        assertThat(csvRow).contains("\t")
     }
-
-    @Test
-    fun `test TextProto validation for all strategy types`() {
-        val strategyTypes =
-            listOf(
-                StrategyType.SMA_RSI,
-                StrategyType.EMA_MACD,
-                StrategyType.ADX_STOCHASTIC,
-                StrategyType.AROON_MFI,
-                StrategyType.ICHIMOKU_CLOUD,
-                StrategyType.PARABOLIC_SAR,
-            )
-
-        for (strategyType in strategyTypes) {
-            val discoveredStrategy =
-                DiscoveredStrategy
-                    .newBuilder()
-                    .setSymbol("BTCUSDT")
-                    .setStrategy(
-                        Strategy
-                            .newBuilder()
-                            .setType(strategyType)
-                            .setParameters(createValidParametersForStrategy(strategyType))
-                            .build(),
-                    ).setScore(0.85)
-                    .setStartTime(Timestamp.newBuilder().setSeconds(1234567890).build())
-                    .setEndTime(Timestamp.newBuilder().setSeconds(1234567891).build())
-                    .build()
-
-            val csvRow = writeDiscoveredStrategiesToPostgresFn.convertToCsvRow(discoveredStrategy)
-            assertThat(csvRow).isNotNull()
-
-            val fields = csvRow!!.split("\t")
-            val textProtoString = fields[2]
-            assertThat(textProtoString).matches("^\\s*\\w+\\s*:\\s*[^\\s]+.*$")
-        }
-    }
-
-    private fun createValidParametersForStrategy(strategyType: StrategyType): Any =
-        when (strategyType) {
-            StrategyType.SMA_RSI ->
-                Any.pack(
-                    SmaRsiParameters
-                        .newBuilder()
-                        .setMovingAveragePeriod(14)
-                        .setRsiPeriod(14)
-                        .setOverboughtThreshold(70.0)
-                        .setOversoldThreshold(30.0)
-                        .build(),
-                )
-            StrategyType.EMA_MACD ->
-                Any.pack(
-                    EmaMacdParameters
-                        .newBuilder()
-                        .setShortEmaPeriod(12)
-                        .setLongEmaPeriod(26)
-                        .setSignalPeriod(9)
-                        .build(),
-                )
-            StrategyType.ADX_STOCHASTIC ->
-                Any.pack(
-                    AdxStochasticParameters
-                        .newBuilder()
-                        .setAdxPeriod(14)
-                        .setStochasticKPeriod(14)
-                        .setStochasticDPeriod(3)
-                        .setOverboughtThreshold(80)
-                        .setOversoldThreshold(20)
-                        .build(),
-                )
-            StrategyType.AROON_MFI ->
-                Any.pack(
-                    AroonMfiParameters
-                        .newBuilder()
-                        .setAroonPeriod(14)
-                        .setMfiPeriod(14)
-                        .setOverboughtThreshold(80)
-                        .setOversoldThreshold(20)
-                        .build(),
-                )
-            StrategyType.ICHIMOKU_CLOUD ->
-                Any.pack(
-                    IchimokuCloudParameters
-                        .newBuilder()
-                        .setTenkanSenPeriod(9)
-                        .setKijunSenPeriod(26)
-                        .setSenkouSpanBPeriod(52)
-                        .setChikouSpanPeriod(26)
-                        .build(),
-                )
-            StrategyType.PARABOLIC_SAR ->
-                Any.pack(
-                    ParabolicSarParameters
-                        .newBuilder()
-                        .setAccelerationFactorStart(0.02)
-                        .setAccelerationFactorIncrement(0.02)
-                        .setAccelerationFactorMax(0.2)
-                        .build(),
-                )
-            else -> throw IllegalArgumentException("Unsupported strategy type: $strategyType")
-        }
 }

--- a/src/test/java/com/verlumen/tradestream/strategies/StrategyParameterTypeRegistryTest.kt
+++ b/src/test/java/com/verlumen/tradestream/strategies/StrategyParameterTypeRegistryTest.kt
@@ -101,9 +101,9 @@ class StrategyParameterTypeRegistryTest {
 
         val json = StrategyParameterTypeRegistry.formatParametersToJson(unknownAny)
 
-        // Verify the JSON is valid by checking its format
-        assert(json.contains("error:") || json.contains("base64_data")) {
-            "JSON should contain error or base64_data field"
+        // Verify the JSON contains an error message for unknown types
+        assert(json.contains("error:") && json.contains("unknown parameter type")) {
+            "JSON should contain error message for unknown parameter type"
         }
     }
 
@@ -119,9 +119,9 @@ class StrategyParameterTypeRegistryTest {
 
         val json = StrategyParameterTypeRegistry.formatParametersToJson(invalidAny)
 
-        // Verify the JSON is valid by checking its format
-        assert(json.contains("error:") || json.contains("base64_data")) {
-            "JSON should contain error or base64_data field"
+        // Verify the JSON contains an error message for invalid protobuf
+        assert(json.contains("error:")) {
+            "JSON should contain error message for invalid protobuf data"
         }
     }
 
@@ -137,8 +137,10 @@ class StrategyParameterTypeRegistryTest {
 
         val json = StrategyParameterTypeRegistry.formatParametersToJson(unknownAny)
 
-        // For unknown types, expect base64_data fallback
-        assert(json.contains("base64_data")) { "Fallback JSON should contain base64_data field" }
+        // For unknown types, expect error message
+        assert(json.contains("error:") && json.contains("unknown parameter type")) { 
+            "Error message should be complete for unknown parameter type" 
+        }
     }
 
     @Test
@@ -154,9 +156,9 @@ class StrategyParameterTypeRegistryTest {
 
         val json = StrategyParameterTypeRegistry.formatParametersToJson(unknownAny)
 
-        // Verify it's valid JSON by checking its format
-        assert(json.contains("base64_data")) {
-            "JSON should contain base64_data field"
+        // Verify it's a valid error message that doesn't contain problematic characters
+        assert(json.contains("error:") && !json.contains("\t") && !json.contains("\n") && !json.contains("\r")) {
+            "Error message should be safe for CSV format and not contain special characters"
         }
     }
 
@@ -174,9 +176,9 @@ class StrategyParameterTypeRegistryTest {
 
         val json = StrategyParameterTypeRegistry.formatParametersToJson(unknownAny)
 
-        // Verify it's valid JSON by checking its format
-        assert(json.contains("base64_data")) {
-            "JSON should contain base64_data field"
+        // Verify it's a valid error message that doesn't contain tabs
+        assert(json.contains("error:") && !json.contains("\t")) {
+            "Error message should not contain tabs for CSV compatibility"
         }
     }
 

--- a/third_party/java/BUILD
+++ b/third_party/java/BUILD
@@ -344,3 +344,11 @@ java_library(
         "@tradestream_maven//:org_apache_commons_commons_csv",
     ],
 )
+
+java_library(
+    name = "org_json",
+    visibility = ["//visibility:public"],
+    exports = [
+        "@tradestream_maven//:org_json_json",
+    ],
+)


### PR DESCRIPTION
This PR fixes the parameter serialization to be more robust and production-appropriate:

- Always emit error markers for unknown/invalid parameter types instead of fallback base64
- Update tests to expect the new behavior
- Ensure CSV compatibility for PostgreSQL COPY operations
- All tests now pass with the new serialization logic