### PR TITLE
Remove deprecated `trade_checkpoint_mark` library target from marketdata BUILD file

### DIFF
--- a/src/main/java/com/verlumen/tradestream/marketdata/BUILD
+++ b/src/main/java/com/verlumen/tradestream/marketdata/BUILD
@@ -94,13 +94,3 @@ kt_jvm_library(
         "//third_party/java:protobuf_java_util",
     ],
 )
-
-# Checkpoint mark for the unbounded source
-kt_jvm_library(
-    name = "trade_checkpoint_mark",
-    srcs = ["TradeCheckpointMark.kt"],
-    deps = [
-        "//third_party/java:beam_sdks_java_core",
-        "//third_party/java:joda_time",
-    ],
-)


### PR DESCRIPTION
This change removes the `kt_jvm_library` target named `trade_checkpoint_mark` from the `BUILD` file in the `marketdata` module. The deleted target included the `TradeCheckpointMark.kt` source file and dependencies on Beam SDK and Joda-Time. This cleanup eliminates unused or obsolete build configurations, improving maintainability of the build definition.

No functional code changes are included in this patch.