### PR TITLE
Remove branch suffix from version tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,6 @@ jobs:
         uses: paulhatch/semantic-version@v5.3.0
         with:
           tag_prefix: "v"
-          namespace: "${{ steps.extract_branch.outputs.branch }}"
           major_pattern: "(MAJOR)"
           minor_pattern: "(MINOR)"
           version_format: "${major}.${minor}.${patch}"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "tradestream",
-    version = "v1.0.4-main",
+    version = "v1.0.4",
     compatibility_level = 1,
 )
 

--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -1,6 +1,6 @@
 # Global configuration for all services
 global:
-  imageTag: "v2.45.97-develop" # Default tag, can be overridden by ArgoCD
+  imageTag: "v2.45.97" # Default tag, can be overridden by ArgoCD
 
 influxdb:
   enabled: true
@@ -128,7 +128,7 @@ strategyDiscoveryPipeline:
   enabled: true
   image:
     repository: tradestreamhq/strategy-discovery-pipeline
-    tag: v2.45.97-develop
+                tag: v2.45.97
     pullPolicy: IfNotPresent
   version: v1_18
   configuration:
@@ -176,7 +176,7 @@ candleIngestor:
   image:
     repository: "tradestreamhq/candle-ingestor"
     pullPolicy: IfNotPresent
-    tag: "v2.45.97-develop"
+    tag: "v2.45.97"
   config:
     # CCXT Exchange Configuration
     exchanges:
@@ -250,7 +250,7 @@ topCryptoUpdaterCronjob:
   image:
     repository: "tradestreamhq/top-crypto-updater"
     pullPolicy: IfNotPresent
-    tag: "v2.45.97-develop"
+    tag: "v2.45.97"
   concurrencyPolicy: "Forbid" # Prevents multiple jobs from running concurrently
   failedJobsHistoryLimit: 1
   successfulJobsHistoryLimit: 3
@@ -274,7 +274,7 @@ strategyDiscoveryRequestFactory:
   image:
     repository: "tradestreamhq/strategy-discovery-request-factory"
     pullPolicy: IfNotPresent
-    tag: "v2.45.97-develop"
+    tag: "v2.45.97"
   concurrencyPolicy: "Forbid" # Prevents multiple jobs from running concurrently
   failedJobsHistoryLimit: 1
   successfulJobsHistoryLimit: 3
@@ -318,7 +318,7 @@ strategyConsumer:
   image:
     repository: "tradestreamhq/strategy-consumer"
     pullPolicy: IfNotPresent
-    tag: "v2.45.97-develop"
+    tag: "v2.45.97"
   concurrencyPolicy: "Forbid" # Prevent multiple instances from running simultaneously
   failedJobsHistoryLimit: 2
   successfulJobsHistoryLimit: 3
@@ -365,7 +365,7 @@ strategyMonitorApi:
   image:
     repository: "tradestreamhq/strategy-monitor-api"
     pullPolicy: IfNotPresent
-    tag: "v2.45.97-develop"
+    tag: "v2.45.97"
   service:
     type: ClusterIP
     port: 8080
@@ -395,7 +395,7 @@ strategyMonitorUi:
   image:
     repository: "tradestreamhq/strategy-monitor-ui"
     pullPolicy: IfNotPresent
-    tag: "v2.45.97-develop"
+    tag: "v2.45.97"
   service:
     type: ClusterIP
     port: 8080


### PR DESCRIPTION
## Summary

This PR removes the branch suffix from version tags to clean up the versioning format.

## Changes Made

### Release Workflow (.github/workflows/release.yaml)
- **Removed**  parameter from the semantic version action
- This prevents the automatic addition of branch names as suffixes to version tags

### Module Version (MODULE.bazel)
- **Updated** version from  to 
- Removes the hardcoded branch suffix from the Bazel module version

### Helm Chart Values (charts/tradestream/values.yaml)
- **Updated** all image tags from  to 
- Affects all services: candle-ingestor, top-crypto-updater, strategy-discovery-request-factory, strategy-discovery-pipeline, strategy-consumer, strategy-monitor-api, strategy-monitor-ui

## Impact

- **Before**: Version tags included branch suffixes (e.g., , )
- **After**: Clean semantic versioning without branch suffixes (e.g., , )

## Benefits

1. **Cleaner Versioning**: Version tags are now purely semantic without branch context
2. **Simplified Tagging**: No more branch-specific version tags cluttering the repository
3. **Consistent Format**: All version references now use the same clean format
4. **Better CI/CD**: Release workflow will generate cleaner version tags

## Testing

- [x] Verified all references to old version format have been updated
- [x] Confirmed no remaining  or  suffixes in version strings
- [x] Release workflow will now generate clean version tags without branch suffixes