### PR TITLE
Simplify Helm templates to use only global.imageTag

### DIFF
--- a/charts/tradestream/templates/candle-ingestor.yaml
+++ b/charts/tradestream/templates/candle-ingestor.yaml
@@ -30,7 +30,7 @@ spec:
           restartPolicy: {{ .Values.candleIngestor.job.restartPolicy | default "OnFailure" }}
           containers:
             - name: candle-ingestor
-              image: "{{ .Values.candleIngestor.image.repository }}:{{ .Values.candleIngestor.image.tag | default .Values.global.imageTag | default .Chart.AppVersion }}"
+              image: "{{ .Values.candleIngestor.image.repository }}:{{ .Values.global.imageTag }}"
               imagePullPolicy: {{ .Values.candleIngestor.image.pullPolicy }}
               env:
                 - name: CANDLE_GRANULARITY_MINUTES

--- a/charts/tradestream/templates/strategy-consumer.yaml
+++ b/charts/tradestream/templates/strategy-consumer.yaml
@@ -30,7 +30,7 @@ spec:
           restartPolicy: {{ .Values.strategyConsumer.job.restartPolicy | default "OnFailure" }}
           containers:
             - name: strategy-consumer
-              image: "{{ .Values.strategyConsumer.image.repository }}:{{ .Values.strategyConsumer.image.tag | default .Values.global.imageTag | default .Chart.AppVersion }}"
+              image: "{{ .Values.strategyConsumer.image.repository }}:{{ .Values.global.imageTag }}"
               imagePullPolicy: {{ .Values.strategyConsumer.image.pullPolicy }}
               env:
                 # Kafka Configuration

--- a/charts/tradestream/templates/strategy-discovery-pipeline.yaml
+++ b/charts/tradestream/templates/strategy-discovery-pipeline.yaml
@@ -9,7 +9,7 @@ metadata:
     component: strategy-discovery-pipeline
     release: {{ .Release.Name }}
 spec:
-  image: {{ .Values.strategyDiscoveryPipeline.image.repository }}:{{ .Values.strategyDiscoveryPipeline.image.tag | default .Values.global.imageTag }}
+  image: {{ .Values.strategyDiscoveryPipeline.image.repository }}:{{ .Values.global.imageTag }}
   imagePullPolicy: {{ default "IfNotPresent" .Values.strategyDiscoveryPipeline.image.pullPolicy }}
   flinkVersion: {{ .Values.strategyDiscoveryPipeline.version }}
   flinkConfiguration:

--- a/charts/tradestream/templates/strategy-discovery-request-factory.yaml
+++ b/charts/tradestream/templates/strategy-discovery-request-factory.yaml
@@ -20,7 +20,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: strategy-discovery-request-factory
-              image: "{{ .Values.strategyDiscoveryRequestFactory.image.repository }}:{{ .Values.strategyDiscoveryRequestFactory.image.tag | default .Values.global.imageTag | default .Chart.AppVersion }}"
+              image: "{{ .Values.strategyDiscoveryRequestFactory.image.repository }}:{{ .Values.global.imageTag }}"
               imagePullPolicy: {{ .Values.strategyDiscoveryRequestFactory.image.pullPolicy }}
               env:
                 - name: INFLUXDB_URL

--- a/charts/tradestream/templates/top-crypto-updater-cronjob.yaml
+++ b/charts/tradestream/templates/top-crypto-updater-cronjob.yaml
@@ -20,7 +20,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: top-crypto-updater
-              image: "{{ .Values.topCryptoUpdaterCronjob.image.repository }}:{{ .Values.topCryptoUpdaterCronjob.image.tag | default .Values.global.imageTag }}"
+              image: "{{ .Values.topCryptoUpdaterCronjob.image.repository }}:{{ .Values.global.imageTag }}"
               imagePullPolicy: {{ .Values.topCryptoUpdaterCronjob.image.pullPolicy }}
               env:
                 - name: CMC_API_KEY


### PR DESCRIPTION
This PR simplifies the Helm templates to use only the global.imageTag parameter, removing conditional logic. Individual image tags are retained in values.yaml as defaults, but ArgoCD can override all image tags with a single global.imageTag parameter.