### PR TITLE
Remove global.imageTag to enforce explicit individual image tags

### DIFF
--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -1,6 +1,3 @@
-# Global configuration for all services
-global: {}
-
 influxdb:
   enabled: true
   # Authentication configuration

--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -1,6 +1,5 @@
 # Global configuration for all services
-global:
-  imageTag: "v2.45.97-develop" # Default tag, can be overridden by ArgoCD
+global: {}
 
 influxdb:
   enabled: true


### PR DESCRIPTION
## Summary
Removes the global.imageTag configuration to enforce explicit individual image tags for better control and clarity.

## Changes
- Removed `global.imageTag` from `charts/tradestream/values.yaml`
- ArgoCD Image Updater now uses only explicit individual tags:
  - `candleIngestor.image.tag`
  - `topCryptoUpdaterCronjob.image.tag`
  - `strategyDiscoveryRequestFactory.image.tag`
  - `strategyDiscoveryPipeline.image.tag`
  - `strategyConsumer.image.tag`

## Benefits
- Enforces explicit configuration over global defaults
- Improves clarity and control over individual service image versions
- Aligns with best practices for Helm chart configuration