### PR TITLE
Revert to commit 894c4917

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -247,19 +247,26 @@ jobs:
           ./bazel-bin/services/strategy_confidence_scorer/push_strategy_confidence_scorer_image --tag ${{ needs.build-images.outputs.version }}
 
   notify-deployment:
-    needs:
-      [
-        push-candle-ingestor,
-        push-top-crypto-updater,
-        push-strategy-discovery-request-factory,
-        push-strategy-discovery-pipeline,
-        push-strategy-consumer,
-        push-strategy-monitor-api,
-        push-strategy-monitor-ui,
-        push-strategy-confidence-scorer,
-      ]
+    needs: [build-images, push-candle-ingestor, push-top-crypto-updater, push-strategy-discovery-request-factory, push-strategy-discovery-pipeline, push-strategy-consumer, push-strategy-monitor-api, push-strategy-monitor-ui, push-strategy-confidence-scorer]
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Git
+        run: |
+          git config user.name "GitHub Action"
+          git config user.email "action@github.com"
+
+      - name: Push Tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+        run: |
+          git tag ${{ needs.build-images.outputs.version }}
+          git push https://$GITHUB_ACTOR:${{ secrets.ACTIONS_TOKEN }}@github.com/${{ github.repository }} --tags
+
       - name: Notify ArgoCD Deployment
         run: |
           echo "✅ All images pushed successfully!"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,12 +4,9 @@ on:
     branches:
       - main
       - develop
-
 jobs:
-  build-images:
+  release:
     runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.version.outputs.version_tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -30,6 +27,13 @@ jobs:
           git config user.name "GitHub Action"
           git config user.email "action@github.com"
 
+      - name: Push Tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+        run: |
+          git tag ${{ steps.version.outputs.version_tag }}
+          git push https://$GITHUB_ACTOR:${{ secrets.ACTIONS_TOKEN }}@github.com/${{ github.repository }} --tags
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -42,233 +46,46 @@ jobs:
           bazelrc: |
             build --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }}
 
-      # Build all images together
-      - name: Build All Images
+      # Build and push all images with the new tag
+      - name: Push the Candle Ingestor image
         run: |
-          bazel build \
-            //services/candle_ingestor:push_candle_ingestor_image \
-            //services/top_crypto_updater:push_top_crypto_updater_image \
-            //services/strategy_discovery_request_factory:push_strategy_discovery_request_factory_image \
-            //src/main/java/com/verlumen/tradestream/discovery:push_image \
-            //services/strategy_consumer:push_strategy_consumer_image \
-            //services/strategy_monitor_api:push_strategy_monitor_api_image \
-            //ui/strategy-monitor:push_strategy_monitor_ui_image \
-            //services/strategy_confidence_scorer:push_strategy_confidence_scorer_image
-
-      # Upload built images as artifacts for parallel jobs
-      - name: Upload Built Images
-        uses: actions/upload-artifact@v4
-        with:
-          name: built-images
-          path: |
-            bazel-bin/services/candle_ingestor/push_candle_ingestor_image
-            bazel-bin/services/top_crypto_updater/push_top_crypto_updater_image
-            bazel-bin/services/strategy_discovery_request_factory/push_strategy_discovery_request_factory_image
-            bazel-bin/src/main/java/com/verlumen/tradestream/discovery/push_image
-            bazel-bin/services/strategy_consumer/push_strategy_consumer_image
-            bazel-bin/services/strategy_monitor_api/push_strategy_monitor_api_image
-            bazel-bin/ui/strategy-monitor/push_strategy_monitor_ui_image
-            bazel-bin/services/strategy_confidence_scorer/push_strategy_confidence_scorer_image
-
-  push-candle-ingestor:
-    needs: build-images
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Download Built Images
-        uses: actions/download-artifact@v4
-        with:
-          name: built-images
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Push Candle Ingestor Image
+          bazel run //services/candle_ingestor:push_candle_ingestor_image \
+            -- \
+            --tag ${{ steps.version.outputs.version_tag }}
+      - name: Push the Top Crypto Updater image
         run: |
-          ./bazel-bin/services/candle_ingestor/push_candle_ingestor_image --tag ${{ needs.build-images.outputs.version }}
-
-  push-top-crypto-updater:
-    needs: build-images
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Download Built Images
-        uses: actions/download-artifact@v4
-        with:
-          name: built-images
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Push Top Crypto Updater Image
+          bazel run //services/top_crypto_updater:push_top_crypto_updater_image \
+            -- \
+            --tag ${{ steps.version.outputs.version_tag }}
+      - name: Push the Strategy Discovery Request Factory image
         run: |
-          ./bazel-bin/services/top_crypto_updater/push_top_crypto_updater_image --tag ${{ needs.build-images.outputs.version }}
-
-  push-strategy-discovery-request-factory:
-    needs: build-images
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Download Built Images
-        uses: actions/download-artifact@v4
-        with:
-          name: built-images
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Push Strategy Discovery Request Factory Image
+          bazel run //services/strategy_discovery_request_factory:push_strategy_discovery_request_factory_image \
+            -- \
+            --tag ${{ steps.version.outputs.version_tag }}
+      - name: Push the Strategy Discovery Pipeline image
         run: |
-          ./bazel-bin/services/strategy_discovery_request_factory/push_strategy_discovery_request_factory_image --tag ${{ needs.build-images.outputs.version }}
-
-  push-strategy-discovery-pipeline:
-    needs: build-images
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Download Built Images
-        uses: actions/download-artifact@v4
-        with:
-          name: built-images
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Push Strategy Discovery Pipeline Image
+          bazel run //src/main/java/com/verlumen/tradestream/discovery:push_image \
+            -- \
+            --tag ${{ steps.version.outputs.version_tag }}
+      - name: Push the Strategy Consumer image
         run: |
-          ./bazel-bin/src/main/java/com/verlumen/tradestream/discovery/push_image --tag ${{ needs.build-images.outputs.version }}
-
-  push-strategy-consumer:
-    needs: build-images
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Download Built Images
-        uses: actions/download-artifact@v4
-        with:
-          name: built-images
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Push Strategy Consumer Image
+          bazel run //services/strategy_consumer:push_strategy_consumer_image \
+            -- \
+            --tag ${{ steps.version.outputs.version_tag }}
+      - name: Push the Strategy Monitor API image
         run: |
-          ./bazel-bin/services/strategy_consumer/push_strategy_consumer_image --tag ${{ needs.build-images.outputs.version }}
-
-  push-strategy-monitor-api:
-    needs: build-images
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Download Built Images
-        uses: actions/download-artifact@v4
-        with:
-          name: built-images
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Push Strategy Monitor API Image
+          bazel run //services/strategy_monitor_api:push_strategy_monitor_api_image \
+            -- \
+            --tag ${{ steps.version.outputs.version_tag }}
+      - name: Push the Strategy Monitor UI image
         run: |
-          ./bazel-bin/services/strategy_monitor_api/push_strategy_monitor_api_image --tag ${{ needs.build-images.outputs.version }}
+          bazel run //ui/strategy-monitor:push_strategy_monitor_ui_image \
+            -- \
+            --tag ${{ steps.version.outputs.version_tag }}
 
-  push-strategy-monitor-ui:
-    needs: build-images
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Download Built Images
-        uses: actions/download-artifact@v4
-        with:
-          name: built-images
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Push Strategy Monitor UI Image
-        run: |
-          ./bazel-bin/ui/strategy-monitor/push_strategy_monitor_ui_image --tag ${{ needs.build-images.outputs.version }}
-
-  push-strategy-confidence-scorer:
-    needs: build-images
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Download Built Images
-        uses: actions/download-artifact@v4
-        with:
-          name: built-images
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Push Strategy Confidence Scorer Image
-        run: |
-          ./bazel-bin/services/strategy_confidence_scorer/push_strategy_confidence_scorer_image --tag ${{ needs.build-images.outputs.version }}
-
-  notify-deployment:
-    needs: [build-images, push-candle-ingestor, push-top-crypto-updater, push-strategy-discovery-request-factory, push-strategy-discovery-pipeline, push-strategy-consumer, push-strategy-monitor-api, push-strategy-monitor-ui, push-strategy-confidence-scorer]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set up Git
-        run: |
-          git config user.name "GitHub Action"
-          git config user.email "action@github.com"
-
-      - name: Push Tag
-        env:
-          GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
-        run: |
-          git tag ${{ needs.build-images.outputs.version }}
-          git push https://$GITHUB_ACTOR:${{ secrets.ACTIONS_TOKEN }}@github.com/${{ github.repository }} --tags
-
+      # Optional: Add a comment about ArgoCD handling the deployment
       - name: Notify ArgoCD Deployment
         run: |
-          echo "✅ All images pushed successfully!"
+          echo "✅ Images pushed with tag: ${{ steps.version.outputs.version_tag }}"
           echo "🔄 ArgoCD Image Updater will automatically detect and deploy the new images within 2-5 minutes"
           echo "📊 Monitor deployment: kubectl get application tradestream-dev -n argocd"


### PR DESCRIPTION
This PR reverts the codebase back to commit 894c49178c0511acb6ef622b0ce7f98ad932db31 by reverting the following commits:

- 0615b83d: Merge optimize-release-workflow-parallel-push into main
- 3d58d9e4: fix: move tag push to after all images are successfully pushed

This will restore the codebase to the state it was in before these changes were merged.