### PR TITLE
Fix: Add missing strategy monitor Helm templates

### DIFF
--- a/charts/tradestream/templates/strategy-monitor-api.yaml
+++ b/charts/tradestream/templates/strategy-monitor-api.yaml
@@ -1,0 +1,83 @@
+{{- if .Values.strategyMonitorApi.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "tradestream.fullname" . }}-strategy-monitor-api
+  labels:
+    {{- include "tradestream.labels" . | nindent 4 }}
+    app.kubernetes.io/component: strategy-monitor-api
+spec:
+  replicas: {{ .Values.strategyMonitorApi.replicaCount | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "tradestream.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: strategy-monitor-api
+  template:
+    metadata:
+      labels:
+        {{- include "tradestream.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: strategy-monitor-api
+    spec:
+      containers:
+        - name: strategy-monitor-api
+                        image: "{{ .Values.strategyMonitorApi.image.repository }}:{{ .Values.strategyMonitorApi.image.tag }}"
+          imagePullPolicy: {{ .Values.strategyMonitorApi.image.pullPolicy | default "IfNotPresent" }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.strategyMonitorApi.service.port | default 8080 }}
+              protocol: TCP
+          env:
+            - name: POSTGRES_HOST
+              value: {{ .Values.strategyMonitorApi.database.host | default (printf "%s-postgresql" (include "tradestream.fullname" .)) }}
+            - name: POSTGRES_PORT
+              value: {{ .Values.strategyMonitorApi.database.port | default "5432" | quote }}
+            - name: POSTGRES_DATABASE
+              value: {{ .Values.strategyMonitorApi.database.database | default "tradestream" }}
+            - name: POSTGRES_USERNAME
+              value: {{ .Values.strategyMonitorApi.database.username | default "postgres" }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.strategyMonitorApi.database.passwordSecret.name | default (printf "%s-postgresql" (include "tradestream.fullname" .)) }}
+                  key: {{ .Values.strategyMonitorApi.database.passwordSecret.key | default "postgres-password" }}
+            - name: API_PORT
+              value: {{ .Values.strategyMonitorApi.service.port | default 8080 | quote }}
+            - name: API_HOST
+              value: {{ .Values.strategyMonitorApi.service.host | default "0.0.0.0" }}
+          resources:
+            {{- toYaml .Values.strategyMonitorApi.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "tradestream.fullname" . }}-strategy-monitor-api
+  labels:
+    {{- include "tradestream.labels" . | nindent 4 }}
+    app.kubernetes.io/component: strategy-monitor-api
+spec:
+  type: {{ .Values.strategyMonitorApi.service.type | default "ClusterIP" }}
+  ports:
+    - port: {{ .Values.strategyMonitorApi.service.port | default 8080 }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "tradestream.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: strategy-monitor-api
+{{- end }} 

--- a/charts/tradestream/templates/strategy-monitor-ui.yaml
+++ b/charts/tradestream/templates/strategy-monitor-ui.yaml
@@ -1,0 +1,68 @@
+{{- if .Values.strategyMonitorUi.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "tradestream.fullname" . }}-strategy-monitor-ui
+  labels:
+    {{- include "tradestream.labels" . | nindent 4 }}
+    app.kubernetes.io/component: strategy-monitor-ui
+spec:
+  replicas: {{ .Values.strategyMonitorUi.replicaCount | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "tradestream.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: strategy-monitor-ui
+  template:
+    metadata:
+      labels:
+        {{- include "tradestream.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: strategy-monitor-ui
+    spec:
+      containers:
+        - name: strategy-monitor-ui
+                        image: "{{ .Values.strategyMonitorUi.image.repository }}:{{ .Values.strategyMonitorUi.image.tag }}"
+          imagePullPolicy: {{ .Values.strategyMonitorUi.image.pullPolicy | default "IfNotPresent" }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.strategyMonitorUi.service.port | default 8080 }}
+              protocol: TCP
+          env:
+            - name: API_BASE_URL
+              value: {{ .Values.strategyMonitorUi.apiBaseUrl | default (printf "http://%s-strategy-monitor-api:%d" (include "tradestream.fullname" .) (.Values.strategyMonitorApi.service.port | default 8080)) }}
+          resources:
+            {{- toYaml .Values.strategyMonitorUi.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "tradestream.fullname" . }}-strategy-monitor-ui
+  labels:
+    {{- include "tradestream.labels" . | nindent 4 }}
+    app.kubernetes.io/component: strategy-monitor-ui
+spec:
+  type: {{ .Values.strategyMonitorUi.service.type | default "ClusterIP" }}
+  ports:
+    - port: {{ .Values.strategyMonitorUi.service.port | default 8080 }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "tradestream.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: strategy-monitor-ui
+{{- end }} 


### PR DESCRIPTION
Adds missing strategy-monitor-api.yaml and strategy-monitor-ui.yaml templates to enable deployment via ArgoCD. These templates were missing causing strategy monitor services to not deploy despite being configured.