### PR TITLE
fix: push git tag only after successful image deployment

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,17 +24,7 @@ jobs:
           minor_pattern: "(MINOR)"
           version_format: "${major}.${minor}.${patch}"
 
-      - name: Set up Git
-        run: |
-          git config user.name "GitHub Action"
-          git config user.email "action@github.com"
 
-      - name: Push Tag
-        env:
-          GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
-        run: |
-          git tag ${{ steps.version.outputs.version_tag }}
-          git push https://$GITHUB_ACTOR:${{ secrets.ACTIONS_TOKEN }}@github.com/${{ github.repository }} --tags
 
   build-and-push:
     needs: prepare-release
@@ -84,8 +74,26 @@ jobs:
     needs: [prepare-release, build-and-push]
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Git
+        run: |
+          git config user.name "GitHub Action"
+          git config user.email "action@github.com"
+
+      - name: Push Tag After Successful Deployment
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+        run: |
+          git tag ${{ needs.prepare-release.outputs.version }}
+          git push https://$GITHUB_ACTOR:${{ secrets.ACTIONS_TOKEN }}@github.com/${{ github.repository }} --tags
+
       - name: Notify ArgoCD Deployment
         run: |
           echo "✅ All images pushed successfully with tag: ${{ needs.prepare-release.outputs.version }}"
+          echo "🏷️ Git tag ${{ needs.prepare-release.outputs.version }} created after successful deployment"
           echo "🔄 ArgoCD Image Updater will automatically detect and deploy the new images within 2-5 minutes"
           echo "📊 Monitor deployment: kubectl get application tradestream-dev -n argocd"


### PR DESCRIPTION
## Problem

The current parallel release workflow pushes the git tag **before** building and pushing images. This creates several issues:

- **Orphaned Tags**: If image builds/pushes fail, the tag exists but points to broken release
- **Rollback Confusion**: Failed releases still get tagged, making rollback scenarios unclear  
- **Release Integrity**: Tag creation should confirm successful deployment, not just intent

## Solution

Move tag creation from  job to  job:

### Before (❌ Current)
1. : Generate version + **Push tag immediately**
2. : Build/push 8 images in parallel  
3. : Notify completion

### After (✅ Fixed)  
1. : Generate version only
2. : Build/push 8 images in parallel
3. : **Push tag only after successful deployment** + Notify completion

## Benefits

- **🛡️ Release Integrity**: Tags only exist for successful deployments
- **🔄 Better Rollbacks**: Clean tag history showing only working releases
- **📈 Reliability**: Failed builds don't create confusing version artifacts
- **✅ Atomic Operations**: Tag creation confirms complete deployment success

## Implementation

- Removed tag pushing from  job
- Added tag pushing to  job (runs only after all matrix jobs succeed)
- Added checkout and git setup to  for tag creation
- Updated notification message to confirm tag creation

## Dependencies

The job dependency chain ensures proper execution:


This maintains all the performance benefits of parallel execution while ensuring release integrity.