### PR TITLE
fix: add missing Helm template functions

### DIFF
--- a/charts/tradestream/templates/_helpers.tpl
+++ b/charts/tradestream/templates/_helpers.tpl
@@ -11,3 +11,30 @@
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- $name -}}
 {{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "tradestream.labels" -}}
+helm.sh/chart: {{ include "tradestream.chart" . }}
+{{ include "tradestream.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "tradestream.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tradestream.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "tradestream.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}


### PR DESCRIPTION
## Problem
ArgoCD was failing to sync due to missing Helm template functions in the chart.

## Solution
- Add  template function
- Add  template function  
- Add  template function

## Fixes
- Resolves ArgoCD sync issue with strategy-monitor templates
- Template error: 

## Testing
- [x] Helm templates render correctly
- [x] ArgoCD can now sync successfully