### PR TITLE
fix: Update strategy-monitor-ui nginx to listen on port 8080

### DIFF
--- a/ui/strategy-monitor/container-structure-test.yaml
+++ b/ui/strategy-monitor/container-structure-test.yaml
@@ -98,7 +98,7 @@ commandTests:
     args:
       [
         "-c", 
-        "nginx -g 'daemon off;' & sleep 3 && curl -f http://localhost:80/ >/dev/null 2>&1 && echo 'Web server is accessible' || echo 'Web server test failed'"
+        "nginx -g 'daemon off;' & sleep 3 && curl -f http://localhost:8080/ >/dev/null 2>&1 && echo 'Web server is accessible' || echo 'Web server test failed'"
       ]
     exitCode: 0
     expectedOutput:
@@ -109,7 +109,7 @@ commandTests:
     args:
       [
         "-c",
-        "cp /ui/strategy-monitor/nginx.conf /etc/nginx/nginx.conf && nginx -g 'daemon off;' & sleep 3 && curl -s http://localhost:80/ | grep -q '<html' && echo 'HTML content is valid' || echo 'HTML content validation failed'"
+        "cp /ui/strategy-monitor/nginx.conf /etc/nginx/nginx.conf && nginx -g 'daemon off;' & sleep 3 && curl -s http://localhost:8080/ | grep -q '<html' && echo 'HTML content is valid' || echo 'HTML content validation failed'"
       ]
     exitCode: 0
     expectedOutput:
@@ -120,7 +120,7 @@ commandTests:
     args:
       [
         "-c",
-        "cp /ui/strategy-monitor/nginx.conf /etc/nginx/nginx.conf && nginx -g 'daemon off;' & sleep 3 && curl -I http://localhost:80/ | grep -q 'HTTP/1.1 200' && echo 'HTTP response headers are correct' || echo 'HTTP response headers test failed'"
+        "cp /ui/strategy-monitor/nginx.conf /etc/nginx/nginx.conf && nginx -g 'daemon off;' & sleep 3 && curl -I http://localhost:8080/ | grep -q 'HTTP/1.1 200' && echo 'HTTP response headers are correct' || echo 'HTTP response headers test failed'"
       ]
     exitCode: 0
     expectedOutput:
@@ -131,7 +131,7 @@ commandTests:
     args:
       [
         "-c",
-        "cp /ui/strategy-monitor/nginx.conf /etc/nginx/nginx.conf && nginx -g 'daemon off;' & sleep 3 && curl -s http://localhost:80/index.html | grep -q '<html' && echo 'Static file serving works' || echo 'Static file serving test failed'"
+        "cp /ui/strategy-monitor/nginx.conf /etc/nginx/nginx.conf && nginx -g 'daemon off;' & sleep 3 && curl -s http://localhost:8080/index.html | grep -q '<html' && echo 'Static file serving works' || echo 'Static file serving test failed'"
       ]
     exitCode: 0
     expectedOutput:
@@ -142,7 +142,7 @@ commandTests:
     args:
       [
         "-c",
-        "cp /ui/strategy-monitor/nginx.conf /etc/nginx/nginx.conf && nginx -g 'daemon off;' & sleep 3 && curl -s -w '%{http_code}' http://localhost:80/nonexistent.html | grep -q '404' && echo '404 error handling works' || echo '404 error handling test failed'"
+        "cp /ui/strategy-monitor/nginx.conf /etc/nginx/nginx.conf && nginx -g 'daemon off;' & sleep 3 && curl -s -w '%{http_code}' http://localhost:8080/nonexistent.html | grep -q '404' && echo '404 error handling works' || echo '404 error handling test failed'"
       ]
     exitCode: 0
     expectedOutput:

--- a/ui/strategy-monitor/container-structure-test.yaml
+++ b/ui/strategy-monitor/container-structure-test.yaml
@@ -97,7 +97,7 @@ commandTests:
     args:
       [
         "-c",
-        "nginx -g 'daemon off;' & sleep 3 && curl -f http://localhost:8080/ >/dev/null 2>&1 && echo 'Web server is accessible' || echo 'Web server test failed'",
+        "cp /ui/strategy-monitor/nginx.conf /etc/nginx/nginx.conf && nginx -g 'daemon off;' & sleep 3 && curl -f http://localhost:8080/ >/dev/null 2>&1 && echo 'Web server is accessible' || echo 'Web server test failed'",
       ]
     exitCode: 0
     expectedOutput:

--- a/ui/strategy-monitor/container-structure-test.yaml
+++ b/ui/strategy-monitor/container-structure-test.yaml
@@ -30,7 +30,10 @@ commandTests:
   - name: "Nginx configuration test"
     command: "/bin/sh"
     args:
-      ["-c", "cp /ui/strategy-monitor/nginx.conf /etc/nginx/nginx.conf && nginx -t 2>&1"]
+      [
+        "-c",
+        "cp /ui/strategy-monitor/nginx.conf /etc/nginx/nginx.conf && nginx -t 2>&1",
+      ]
     exitCode: 0
     expectedOutput:
       - "nginx: configuration file /etc/nginx/nginx.conf test is successful"
@@ -72,11 +75,7 @@ commandTests:
 
   - name: "User permissions test"
     command: "/bin/sh"
-    args:
-      [
-        "-c",
-        "echo 'Running as user:' $(whoami); echo 'User ID:' $(id -u)",
-      ]
+    args: ["-c", "echo 'Running as user:' $(whoami); echo 'User ID:' $(id -u)"]
     exitCode: 0
     expectedOutput:
       - "Running as user:"
@@ -84,10 +83,10 @@ commandTests:
 
   - name: "Nginx process test"
     command: "/bin/sh"
-    args: 
+    args:
       [
-        "-c", 
-        "cp /ui/strategy-monitor/nginx.conf /etc/nginx/nginx.conf && nginx -g 'daemon off;' & sleep 2 && if pgrep nginx >/dev/null; then echo 'Nginx process is running'; else echo 'Nginx process not found'; fi"
+        "-c",
+        "cp /ui/strategy-monitor/nginx.conf /etc/nginx/nginx.conf && nginx -g 'daemon off;' & sleep 2 && if pgrep nginx >/dev/null; then echo 'Nginx process is running'; else echo 'Nginx process not found'; fi",
       ]
     exitCode: 0
     expectedOutput:
@@ -97,8 +96,8 @@ commandTests:
     command: "/bin/sh"
     args:
       [
-        "-c", 
-        "nginx -g 'daemon off;' & sleep 3 && curl -f http://localhost:8080/ >/dev/null 2>&1 && echo 'Web server is accessible' || echo 'Web server test failed'"
+        "-c",
+        "nginx -g 'daemon off;' & sleep 3 && curl -f http://localhost:8080/ >/dev/null 2>&1 && echo 'Web server is accessible' || echo 'Web server test failed'",
       ]
     exitCode: 0
     expectedOutput:
@@ -109,7 +108,7 @@ commandTests:
     args:
       [
         "-c",
-        "cp /ui/strategy-monitor/nginx.conf /etc/nginx/nginx.conf && nginx -g 'daemon off;' & sleep 3 && curl -s http://localhost:8080/ | grep -q '<html' && echo 'HTML content is valid' || echo 'HTML content validation failed'"
+        "cp /ui/strategy-monitor/nginx.conf /etc/nginx/nginx.conf && nginx -g 'daemon off;' & sleep 3 && curl -s http://localhost:8080/ | grep -q '<html' && echo 'HTML content is valid' || echo 'HTML content validation failed'",
       ]
     exitCode: 0
     expectedOutput:
@@ -120,7 +119,7 @@ commandTests:
     args:
       [
         "-c",
-        "cp /ui/strategy-monitor/nginx.conf /etc/nginx/nginx.conf && nginx -g 'daemon off;' & sleep 3 && curl -I http://localhost:8080/ | grep -q 'HTTP/1.1 200' && echo 'HTTP response headers are correct' || echo 'HTTP response headers test failed'"
+        "cp /ui/strategy-monitor/nginx.conf /etc/nginx/nginx.conf && nginx -g 'daemon off;' & sleep 3 && curl -I http://localhost:8080/ | grep -q 'HTTP/1.1 200' && echo 'HTTP response headers are correct' || echo 'HTTP response headers test failed'",
       ]
     exitCode: 0
     expectedOutput:
@@ -131,7 +130,7 @@ commandTests:
     args:
       [
         "-c",
-        "cp /ui/strategy-monitor/nginx.conf /etc/nginx/nginx.conf && nginx -g 'daemon off;' & sleep 3 && curl -s http://localhost:8080/index.html | grep -q '<html' && echo 'Static file serving works' || echo 'Static file serving test failed'"
+        "cp /ui/strategy-monitor/nginx.conf /etc/nginx/nginx.conf && nginx -g 'daemon off;' & sleep 3 && curl -s http://localhost:8080/index.html | grep -q '<html' && echo 'Static file serving works' || echo 'Static file serving test failed'",
       ]
     exitCode: 0
     expectedOutput:
@@ -142,7 +141,7 @@ commandTests:
     args:
       [
         "-c",
-        "cp /ui/strategy-monitor/nginx.conf /etc/nginx/nginx.conf && nginx -g 'daemon off;' & sleep 3 && curl -s -w '%{http_code}' http://localhost:8080/nonexistent.html | grep -q '404' && echo '404 error handling works' || echo '404 error handling test failed'"
+        "cp /ui/strategy-monitor/nginx.conf /etc/nginx/nginx.conf && nginx -g 'daemon off;' & sleep 3 && curl -s -w '%{http_code}' http://localhost:8080/nonexistent.html | grep -q '404' && echo '404 error handling works' || echo '404 error handling test failed'",
       ]
     exitCode: 0
     expectedOutput:

--- a/ui/strategy-monitor/nginx.conf
+++ b/ui/strategy-monitor/nginx.conf
@@ -23,7 +23,7 @@ http {
     keepalive_timeout 65;
     
     server {
-        listen 80;
+        listen 8080;
         server_name localhost;
         
         root /usr/share/nginx/html;


### PR DESCRIPTION
## 🐛 Problem Fixed

The strategy-monitor-ui container was experiencing a CrashLoopBackOff due to a port mismatch:
- **nginx configuration**: Listening on port 80
- **Kubernetes deployment**: Expecting port 8080
- **Health checks**: Failing with connection refused on port 8080

This caused the container to start successfully but fail readiness probes, leading to continuous restarts.

## 🔧 Changes Made

1. **nginx.conf**: Changed `listen 80;` → `listen 8080;`
2. **container-structure-test.yaml**: Updated all test URLs from `:80` → `:8080`

## ✅ Testing

- [x] Container structure tests updated to match new port
- [x] Emergency patch confirmed the fix works in production
- [x] Service remains fully functional during transition

## 🚀 Impact

- **Immediate**: Fixes CrashLoopBackOff in strategy-monitor-ui pods
- **Long-term**: Ensures consistent port configuration between nginx and Kubernetes
- **CI/CD**: Resolves the same issue affecting GitHub Actions minikube tests

## 📋 Deployment Notes

After merge:
1. Build new image with this fix
2. Deploy updated image to tradestream-dev namespace
3. Verify pods achieve 1/1 Running status without restarts

Fixes the root cause identified in the CI.yaml troubleshooting investigation.