### PR TITLE
feat: Add Flyway database migration infrastructure (#1486)

### DIFF
--- a/charts/tradestream/templates/database-migration-configmap.yaml
+++ b/charts/tradestream/templates/database-migration-configmap.yaml
@@ -1,0 +1,187 @@
+{{- if .Values.databaseMigration.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "tradestream.fullname" . }}-db-migrations
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "tradestream.name" . }}
+    component: database-migration
+    release: {{ .Release.Name }}
+data:
+  V1__baseline_strategies_table.sql: |
+    -- V1__baseline_strategies_table.sql
+    -- Baseline migration capturing existing Strategies table schema
+
+    CREATE TABLE IF NOT EXISTS Strategies (
+        strategy_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        symbol VARCHAR NOT NULL,
+        strategy_type VARCHAR NOT NULL,
+        parameters JSONB NOT NULL,
+        first_discovered_at TIMESTAMP NOT NULL DEFAULT NOW(),
+        last_evaluated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+        current_score DOUBLE PRECISION NOT NULL,
+        is_active BOOLEAN NOT NULL DEFAULT TRUE,
+        strategy_hash VARCHAR UNIQUE NOT NULL,
+        discovery_symbol VARCHAR,
+        discovery_start_time TIMESTAMP,
+        discovery_end_time TIMESTAMP,
+        created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+        updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_strategies_symbol ON Strategies(symbol);
+    CREATE INDEX IF NOT EXISTS idx_strategies_strategy_type ON Strategies(strategy_type);
+    CREATE INDEX IF NOT EXISTS idx_strategies_current_score ON Strategies(current_score);
+    CREATE INDEX IF NOT EXISTS idx_strategies_is_active ON Strategies(is_active);
+    CREATE INDEX IF NOT EXISTS idx_strategies_discovery_symbol ON Strategies(discovery_symbol);
+    CREATE INDEX IF NOT EXISTS idx_strategies_created_at ON Strategies(created_at);
+
+  V2__add_strategy_specs.sql: |
+    -- V2__add_strategy_specs.sql
+    -- Add strategy specification tables for config-based strategy definitions
+
+    CREATE TABLE IF NOT EXISTS strategy_specs (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        name VARCHAR(255) UNIQUE NOT NULL,
+        version INTEGER DEFAULT 1,
+        description TEXT,
+        complexity VARCHAR(50),
+        indicators JSONB NOT NULL,
+        entry_conditions JSONB NOT NULL,
+        exit_conditions JSONB NOT NULL,
+        parameters JSONB NOT NULL,
+        source VARCHAR(50) NOT NULL,
+        source_citation TEXT,
+        parent_spec_id UUID REFERENCES strategy_specs(id),
+        tags TEXT[],
+        is_active BOOLEAN NOT NULL DEFAULT TRUE,
+        created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+        updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_strategy_specs_name ON strategy_specs(name);
+    CREATE INDEX IF NOT EXISTS idx_strategy_specs_source ON strategy_specs(source);
+    CREATE INDEX IF NOT EXISTS idx_strategy_specs_is_active ON strategy_specs(is_active);
+    CREATE INDEX IF NOT EXISTS idx_strategy_specs_created_at ON strategy_specs(created_at);
+    CREATE INDEX IF NOT EXISTS idx_strategy_specs_tags ON strategy_specs USING GIN(tags);
+
+    CREATE TABLE IF NOT EXISTS strategy_implementations (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        spec_id UUID NOT NULL REFERENCES strategy_specs(id) ON DELETE CASCADE,
+        parameters JSONB NOT NULL,
+        discovered_by VARCHAR(50) NOT NULL,
+        generation INTEGER,
+        backtest_metrics JSONB,
+        paper_metrics JSONB,
+        live_metrics JSONB,
+        status VARCHAR(20) NOT NULL DEFAULT 'CANDIDATE',
+        deployed_at TIMESTAMP,
+        retired_at TIMESTAMP,
+        notes TEXT,
+        created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+        updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_strategy_impl_spec_id ON strategy_implementations(spec_id);
+    CREATE INDEX IF NOT EXISTS idx_strategy_impl_discovered_by ON strategy_implementations(discovered_by);
+    CREATE INDEX IF NOT EXISTS idx_strategy_impl_status ON strategy_implementations(status);
+    CREATE INDEX IF NOT EXISTS idx_strategy_impl_created_at ON strategy_implementations(created_at);
+
+    CREATE OR REPLACE FUNCTION update_updated_at_column()
+    RETURNS TRIGGER AS $$
+    BEGIN
+        NEW.updated_at = NOW();
+        RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+
+    DROP TRIGGER IF EXISTS update_strategy_specs_updated_at ON strategy_specs;
+    CREATE TRIGGER update_strategy_specs_updated_at
+        BEFORE UPDATE ON strategy_specs
+        FOR EACH ROW
+        EXECUTE FUNCTION update_updated_at_column();
+
+    DROP TRIGGER IF EXISTS update_strategy_implementations_updated_at ON strategy_implementations;
+    CREATE TRIGGER update_strategy_implementations_updated_at
+        BEFORE UPDATE ON strategy_implementations
+        FOR EACH ROW
+        EXECUTE FUNCTION update_updated_at_column();
+
+  V3__add_strategy_performance.sql: |
+    -- V3__add_strategy_performance.sql
+    -- Add strategy performance tracking tables
+
+    CREATE TABLE IF NOT EXISTS strategy_performance (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        implementation_id UUID NOT NULL REFERENCES strategy_implementations(id) ON DELETE CASCADE,
+        period_start TIMESTAMP NOT NULL,
+        period_end TIMESTAMP NOT NULL,
+        sharpe_ratio DECIMAL(10,4),
+        sortino_ratio DECIMAL(10,4),
+        calmar_ratio DECIMAL(10,4),
+        win_rate DECIMAL(5,4),
+        profit_factor DECIMAL(10,4),
+        max_drawdown DECIMAL(10,4),
+        avg_drawdown DECIMAL(10,4),
+        volatility DECIMAL(10,4),
+        var_95 DECIMAL(10,4),
+        total_trades INTEGER NOT NULL DEFAULT 0,
+        winning_trades INTEGER NOT NULL DEFAULT 0,
+        losing_trades INTEGER NOT NULL DEFAULT 0,
+        avg_trade_duration_seconds BIGINT,
+        avg_profit_per_trade DECIMAL(20,8),
+        total_return DECIMAL(10,4),
+        annualized_return DECIMAL(10,4),
+        environment VARCHAR(20) NOT NULL,
+        instrument VARCHAR(50) NOT NULL,
+        timeframe VARCHAR(20),
+        raw_metrics JSONB,
+        created_at TIMESTAMP NOT NULL DEFAULT NOW()
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_perf_impl_id ON strategy_performance(implementation_id);
+    CREATE INDEX IF NOT EXISTS idx_perf_impl_date ON strategy_performance(implementation_id, period_start);
+    CREATE INDEX IF NOT EXISTS idx_perf_environment ON strategy_performance(environment);
+    CREATE INDEX IF NOT EXISTS idx_perf_instrument ON strategy_performance(instrument);
+    CREATE INDEX IF NOT EXISTS idx_perf_created_at ON strategy_performance(created_at);
+
+  V4__add_signals.sql: |
+    -- V4__add_signals.sql
+    -- Add signals table for trading signal history
+
+    CREATE TABLE IF NOT EXISTS signals (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        spec_id UUID REFERENCES strategy_specs(id) ON DELETE SET NULL,
+        implementation_id UUID REFERENCES strategy_implementations(id) ON DELETE SET NULL,
+        instrument VARCHAR(50) NOT NULL,
+        signal_type VARCHAR(20) NOT NULL,
+        strength DECIMAL(5,4),
+        price DECIMAL(20,8) NOT NULL,
+        bid_price DECIMAL(20,8),
+        ask_price DECIMAL(20,8),
+        volume DECIMAL(20,8),
+        stop_loss DECIMAL(20,8),
+        take_profit DECIMAL(20,8),
+        position_size DECIMAL(10,4),
+        outcome VARCHAR(20),
+        exit_price DECIMAL(20,8),
+        exit_time TIMESTAMP,
+        pnl DECIMAL(20,8),
+        pnl_percent DECIMAL(10,4),
+        notified_at TIMESTAMP,
+        notification_channels TEXT[],
+        timeframe VARCHAR(20),
+        metadata JSONB,
+        created_at TIMESTAMP NOT NULL DEFAULT NOW()
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_signals_instrument ON signals(instrument);
+    CREATE INDEX IF NOT EXISTS idx_signals_instrument_time ON signals(instrument, created_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_signals_type ON signals(signal_type);
+    CREATE INDEX IF NOT EXISTS idx_signals_spec_id ON signals(spec_id);
+    CREATE INDEX IF NOT EXISTS idx_signals_impl_id ON signals(implementation_id);
+    CREATE INDEX IF NOT EXISTS idx_signals_outcome ON signals(outcome);
+    CREATE INDEX IF NOT EXISTS idx_signals_created_at ON signals(created_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_signals_instrument_type_time ON signals(instrument, signal_type, created_at DESC);
+{{- end }}

--- a/charts/tradestream/templates/database-migration.yaml
+++ b/charts/tradestream/templates/database-migration.yaml
@@ -1,0 +1,80 @@
+{{- if .Values.databaseMigration.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "tradestream.fullname" . }}-db-migration
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "tradestream.name" . }}
+    component: database-migration
+    release: {{ .Release.Name }}
+  annotations:
+    # Run before other workloads
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  ttlSecondsAfterFinished: {{ .Values.databaseMigration.ttlSecondsAfterFinished | default 300 }}
+  backoffLimit: {{ .Values.databaseMigration.backoffLimit | default 3 }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "tradestream.name" . }}
+        component: database-migration
+        release: {{ .Release.Name }}
+    spec:
+      restartPolicy: OnFailure
+      {{- if .Values.databaseMigration.initContainers }}
+      initContainers:
+        # Wait for PostgreSQL to be ready
+        - name: wait-for-postgres
+          image: busybox:1.36
+          command: ['sh', '-c']
+          args:
+            - |
+              echo "Waiting for PostgreSQL at {{ tpl .Values.databaseMigration.database.host . }}:{{ .Values.databaseMigration.database.port }}..."
+              until nc -z {{ tpl .Values.databaseMigration.database.host . }} {{ .Values.databaseMigration.database.port }}; do
+                echo "PostgreSQL is unavailable - sleeping"
+                sleep 2
+              done
+              echo "PostgreSQL is ready!"
+      {{- end }}
+      containers:
+        - name: flyway
+          image: "{{ .Values.databaseMigration.image.repository }}:{{ .Values.databaseMigration.image.tag }}"
+          imagePullPolicy: {{ .Values.databaseMigration.image.pullPolicy | default "IfNotPresent" }}
+          args:
+            - migrate
+          env:
+            - name: FLYWAY_URL
+              value: "jdbc:postgresql://{{ tpl .Values.databaseMigration.database.host . }}:{{ .Values.databaseMigration.database.port }}/{{ .Values.databaseMigration.database.database }}"
+            - name: FLYWAY_USER
+              value: "{{ .Values.databaseMigration.database.username }}"
+            - name: FLYWAY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ tpl .Values.databaseMigration.database.passwordSecret.name . }}
+                  key: {{ .Values.databaseMigration.database.passwordSecret.key }}
+            - name: FLYWAY_BASELINE_ON_MIGRATE
+              value: "{{ .Values.databaseMigration.baselineOnMigrate | default "true" }}"
+            - name: FLYWAY_BASELINE_VERSION
+              value: "{{ .Values.databaseMigration.baselineVersion | default "0" }}"
+            - name: FLYWAY_LOCATIONS
+              value: "filesystem:/flyway/sql"
+            - name: FLYWAY_CONNECT_RETRIES
+              value: "{{ .Values.databaseMigration.connectRetries | default 60 }}"
+            {{- if .Values.databaseMigration.outOfOrder }}
+            - name: FLYWAY_OUT_OF_ORDER
+              value: "true"
+            {{- end }}
+          volumeMounts:
+            - name: migrations
+              mountPath: /flyway/sql
+              readOnly: true
+          resources:
+            {{- toYaml .Values.databaseMigration.resources | nindent 12 }}
+      volumes:
+        - name: migrations
+          configMap:
+            name: {{ include "tradestream.fullname" . }}-db-migrations
+{{- end }}

--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -238,6 +238,42 @@ postgresql:
       limits:
         cpu: "1"
         memory: "2Gi"
+
+# Database Migration configuration (Flyway)
+databaseMigration:
+  enabled: true
+  image:
+    repository: "flyway/flyway"
+    tag: "10.22-alpine"
+    pullPolicy: IfNotPresent
+  # Wait for PostgreSQL before running migrations
+  initContainers: true
+  # Flyway configuration
+  baselineOnMigrate: "true"
+  baselineVersion: "0"
+  connectRetries: 60
+  outOfOrder: false
+  # Database connection (reuses PostgreSQL config)
+  database:
+    host: '{{ include "tradestream.fullname" . }}-postgresql'
+    port: 5432
+    database: "tradestream"
+    username: "postgres"
+    passwordSecret:
+      name: '{{ include "tradestream.fullname" . }}-postgresql'
+      key: "postgres-password"
+  # Resource limits
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "128Mi"
+    limits:
+      cpu: "200m"
+      memory: "256Mi"
+  # Job configuration
+  ttlSecondsAfterFinished: 300
+  backoffLimit: 3
+
 # Top Crypto Updater CronJob configuration
 topCryptoUpdaterCronjob:
   enabled: true

--- a/database/README.md
+++ b/database/README.md
@@ -1,0 +1,134 @@
+# Database Migrations
+
+This directory contains Flyway database migrations for TradeStream.
+
+## Migration Tool
+
+TradeStream uses [Flyway](https://flywaydb.org/) for database migrations. Migrations are executed automatically during Helm chart deployment via an init job.
+
+## Directory Structure
+
+```
+database/
+├── migrations/           # SQL migration files
+│   ├── V1__*.sql        # Baseline schema
+│   ├── V2__*.sql        # Strategy specs tables
+│   ├── V3__*.sql        # Performance tracking
+│   └── V4__*.sql        # Signal history
+└── README.md            # This file
+```
+
+## Naming Convention
+
+Migrations follow Flyway's versioned naming convention:
+```
+V{version}__{description}.sql
+```
+
+Examples:
+- `V1__baseline_strategies_table.sql`
+- `V2__add_strategy_specs.sql`
+- `V3__add_strategy_performance.sql`
+
+## Current Migrations
+
+| Version | Description | Tables Created |
+|---------|-------------|----------------|
+| V1 | Baseline | `Strategies` |
+| V2 | Strategy Specs | `strategy_specs`, `strategy_implementations` |
+| V3 | Performance | `strategy_performance` |
+| V4 | Signals | `signals` |
+
+## Running Migrations
+
+### In Kubernetes (Production)
+
+Migrations run automatically as a Helm hook during `helm install` or `helm upgrade`:
+
+```bash
+helm upgrade --install tradestream ./charts/tradestream
+```
+
+The migration job:
+1. Waits for PostgreSQL to be ready
+2. Runs Flyway with all pending migrations
+3. Deletes itself after successful completion
+
+### Locally (Development)
+
+```bash
+# Using Docker
+docker run --rm \
+  -v $(pwd)/database/migrations:/flyway/sql \
+  flyway/flyway:10.22-alpine \
+  -url=jdbc:postgresql://localhost:5432/tradestream \
+  -user=postgres \
+  -password=your_password \
+  migrate
+
+# Or using Flyway CLI
+flyway -url=jdbc:postgresql://localhost:5432/tradestream \
+       -user=postgres \
+       -password=your_password \
+       -locations=filesystem:./database/migrations \
+       migrate
+```
+
+## Adding New Migrations
+
+1. Create a new file in `database/migrations/`:
+   ```
+   V5__your_description.sql
+   ```
+
+2. Add the migration SQL to the Helm ConfigMap:
+   Edit `charts/tradestream/templates/database-migration-configmap.yaml`
+
+3. Test locally before deploying
+
+## Configuration
+
+Migration configuration is in `charts/tradestream/values.yaml`:
+
+```yaml
+databaseMigration:
+  enabled: true
+  baselineOnMigrate: "true"  # Creates baseline for existing databases
+  baselineVersion: "0"       # Version to use as baseline
+  connectRetries: 60         # Retries before failing
+```
+
+## Rollback
+
+Flyway Community Edition does not support automatic rollback. For production rollbacks:
+
+1. Create a new migration that reverses the changes
+2. Example: `V5__rollback_v4_signals.sql`
+
+## Troubleshooting
+
+### Migration job fails
+
+Check job logs:
+```bash
+kubectl logs job/tradestream-db-migration -n tradestream
+```
+
+### Database connection issues
+
+Verify PostgreSQL is running:
+```bash
+kubectl get pods -n tradestream | grep postgresql
+```
+
+Check connection details:
+```bash
+kubectl describe job/tradestream-db-migration -n tradestream
+```
+
+### Schema already exists
+
+If running on an existing database, Flyway's `baselineOnMigrate` setting will:
+1. Create the `flyway_schema_history` table
+2. Mark all existing migrations as applied
+3. Only run new migrations going forward

--- a/database/migrations/V1__baseline_strategies_table.sql
+++ b/database/migrations/V1__baseline_strategies_table.sql
@@ -1,0 +1,29 @@
+-- V1__baseline_strategies_table.sql
+-- Baseline migration capturing existing Strategies table schema
+-- This migration establishes the starting point for the migration framework
+
+-- Strategy discoveries table - stores GA-discovered trading strategies
+CREATE TABLE IF NOT EXISTS Strategies (
+    strategy_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    symbol VARCHAR NOT NULL,
+    strategy_type VARCHAR NOT NULL,
+    parameters JSONB NOT NULL,
+    first_discovered_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    last_evaluated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    current_score DOUBLE PRECISION NOT NULL,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    strategy_hash VARCHAR UNIQUE NOT NULL,
+    discovery_symbol VARCHAR,
+    discovery_start_time TIMESTAMP,
+    discovery_end_time TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- Indexes for query performance
+CREATE INDEX IF NOT EXISTS idx_strategies_symbol ON Strategies(symbol);
+CREATE INDEX IF NOT EXISTS idx_strategies_strategy_type ON Strategies(strategy_type);
+CREATE INDEX IF NOT EXISTS idx_strategies_current_score ON Strategies(current_score);
+CREATE INDEX IF NOT EXISTS idx_strategies_is_active ON Strategies(is_active);
+CREATE INDEX IF NOT EXISTS idx_strategies_discovery_symbol ON Strategies(discovery_symbol);
+CREATE INDEX IF NOT EXISTS idx_strategies_created_at ON Strategies(created_at);

--- a/database/migrations/V2__add_strategy_specs.sql
+++ b/database/migrations/V2__add_strategy_specs.sql
@@ -1,0 +1,87 @@
+-- V2__add_strategy_specs.sql
+-- Add strategy specification tables for config-based strategy definitions
+-- Supports #1462 (Config-Based Strategies) and #1488 (ConfigurableStrategyFactory)
+
+-- Strategy specifications - defines strategy structure (indicators, rules, parameters)
+CREATE TABLE IF NOT EXISTS strategy_specs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name VARCHAR(255) UNIQUE NOT NULL,
+    version INTEGER DEFAULT 1,
+    description TEXT,
+    complexity VARCHAR(50), -- 'simple', 'moderate', 'complex'
+
+    -- Strategy definition
+    indicators JSONB NOT NULL,        -- Indicator configurations
+    entry_conditions JSONB NOT NULL,  -- Entry rule definitions
+    exit_conditions JSONB NOT NULL,   -- Exit rule definitions
+    parameters JSONB NOT NULL,        -- Parameter definitions with ranges
+
+    -- Provenance tracking
+    source VARCHAR(50) NOT NULL,      -- 'MIGRATED', 'LLM_GENERATED', 'USER_CREATED'
+    source_citation TEXT,             -- Reference URL or book citation
+    parent_spec_id UUID REFERENCES strategy_specs(id), -- For derived specs
+
+    -- Metadata
+    tags TEXT[],
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- Indexes for strategy_specs
+CREATE INDEX IF NOT EXISTS idx_strategy_specs_name ON strategy_specs(name);
+CREATE INDEX IF NOT EXISTS idx_strategy_specs_source ON strategy_specs(source);
+CREATE INDEX IF NOT EXISTS idx_strategy_specs_is_active ON strategy_specs(is_active);
+CREATE INDEX IF NOT EXISTS idx_strategy_specs_created_at ON strategy_specs(created_at);
+CREATE INDEX IF NOT EXISTS idx_strategy_specs_tags ON strategy_specs USING GIN(tags);
+
+-- Strategy implementations - optimized parameter sets for a spec
+CREATE TABLE IF NOT EXISTS strategy_implementations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    spec_id UUID NOT NULL REFERENCES strategy_specs(id) ON DELETE CASCADE,
+
+    -- Implementation details
+    parameters JSONB NOT NULL,          -- Resolved parameter values
+    discovered_by VARCHAR(50) NOT NULL, -- 'GA', 'MANUAL', 'LLM', 'GRID_SEARCH'
+    generation INTEGER,                 -- GA generation number if applicable
+
+    -- Performance metrics (summary)
+    backtest_metrics JSONB,    -- Summary metrics from backtesting
+    paper_metrics JSONB,       -- Summary metrics from paper trading
+    live_metrics JSONB,        -- Summary metrics from live trading
+
+    -- Status and lifecycle
+    status VARCHAR(20) NOT NULL DEFAULT 'CANDIDATE',  -- 'CANDIDATE', 'VALIDATED', 'DEPLOYED', 'RETIRED'
+    deployed_at TIMESTAMP,
+    retired_at TIMESTAMP,
+
+    -- Metadata
+    notes TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- Indexes for strategy_implementations
+CREATE INDEX IF NOT EXISTS idx_strategy_impl_spec_id ON strategy_implementations(spec_id);
+CREATE INDEX IF NOT EXISTS idx_strategy_impl_discovered_by ON strategy_implementations(discovered_by);
+CREATE INDEX IF NOT EXISTS idx_strategy_impl_status ON strategy_implementations(status);
+CREATE INDEX IF NOT EXISTS idx_strategy_impl_created_at ON strategy_implementations(created_at);
+
+-- Trigger to update updated_at timestamps
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER update_strategy_specs_updated_at
+    BEFORE UPDATE ON strategy_specs
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER update_strategy_implementations_updated_at
+    BEFORE UPDATE ON strategy_implementations
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();

--- a/database/migrations/V3__add_strategy_performance.sql
+++ b/database/migrations/V3__add_strategy_performance.sql
@@ -1,0 +1,56 @@
+-- V3__add_strategy_performance.sql
+-- Add strategy performance tracking tables
+-- Enables historical performance analysis and learning
+
+-- Strategy performance history - detailed performance records
+CREATE TABLE IF NOT EXISTS strategy_performance (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    implementation_id UUID NOT NULL REFERENCES strategy_implementations(id) ON DELETE CASCADE,
+
+    -- Time period
+    period_start TIMESTAMP NOT NULL,
+    period_end TIMESTAMP NOT NULL,
+
+    -- Core metrics
+    sharpe_ratio DECIMAL(10,4),
+    sortino_ratio DECIMAL(10,4),
+    calmar_ratio DECIMAL(10,4),
+    win_rate DECIMAL(5,4),
+    profit_factor DECIMAL(10,4),
+
+    -- Risk metrics
+    max_drawdown DECIMAL(10,4),
+    avg_drawdown DECIMAL(10,4),
+    volatility DECIMAL(10,4),
+    var_95 DECIMAL(10,4),  -- Value at Risk 95%
+
+    -- Trade statistics
+    total_trades INTEGER NOT NULL DEFAULT 0,
+    winning_trades INTEGER NOT NULL DEFAULT 0,
+    losing_trades INTEGER NOT NULL DEFAULT 0,
+    avg_trade_duration_seconds BIGINT,
+    avg_profit_per_trade DECIMAL(20,8),
+
+    -- Returns
+    total_return DECIMAL(10,4),
+    annualized_return DECIMAL(10,4),
+
+    -- Environment
+    environment VARCHAR(20) NOT NULL, -- 'BACKTEST', 'PAPER', 'LIVE'
+    instrument VARCHAR(50) NOT NULL,
+    timeframe VARCHAR(20),            -- '1m', '5m', '1h', '1d', etc.
+
+    -- Metadata
+    raw_metrics JSONB,                -- Full metrics dump for analysis
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- Indexes for strategy_performance
+CREATE INDEX IF NOT EXISTS idx_perf_impl_id ON strategy_performance(implementation_id);
+CREATE INDEX IF NOT EXISTS idx_perf_impl_date ON strategy_performance(implementation_id, period_start);
+CREATE INDEX IF NOT EXISTS idx_perf_environment ON strategy_performance(environment);
+CREATE INDEX IF NOT EXISTS idx_perf_instrument ON strategy_performance(instrument);
+CREATE INDEX IF NOT EXISTS idx_perf_created_at ON strategy_performance(created_at);
+
+-- Partition hint for future: consider partitioning by period_start for large datasets
+COMMENT ON TABLE strategy_performance IS 'Historical performance records for strategy implementations. Consider partitioning by period_start for datasets > 10M rows.';

--- a/database/migrations/V4__add_signals.sql
+++ b/database/migrations/V4__add_signals.sql
@@ -1,0 +1,59 @@
+-- V4__add_signals.sql
+-- Add signals table for trading signal history
+-- Supports #1485 (Signal Notification Service)
+
+-- Trading signals - historical record of all generated signals
+CREATE TABLE IF NOT EXISTS signals (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- Strategy reference (optional - signals can exist without full strategy)
+    spec_id UUID REFERENCES strategy_specs(id) ON DELETE SET NULL,
+    implementation_id UUID REFERENCES strategy_implementations(id) ON DELETE SET NULL,
+
+    -- Signal details
+    instrument VARCHAR(50) NOT NULL,
+    signal_type VARCHAR(20) NOT NULL, -- 'BUY', 'SELL', 'HOLD', 'CLOSE_LONG', 'CLOSE_SHORT'
+    strength DECIMAL(5,4),            -- Signal confidence/strength 0.0-1.0
+
+    -- Price information at signal time
+    price DECIMAL(20,8) NOT NULL,
+    bid_price DECIMAL(20,8),
+    ask_price DECIMAL(20,8),
+    volume DECIMAL(20,8),
+
+    -- Risk parameters (if applicable)
+    stop_loss DECIMAL(20,8),
+    take_profit DECIMAL(20,8),
+    position_size DECIMAL(10,4),
+
+    -- Outcome tracking (filled in later)
+    outcome VARCHAR(20),              -- 'PROFIT', 'LOSS', 'BREAKEVEN', 'PENDING', 'CANCELLED'
+    exit_price DECIMAL(20,8),
+    exit_time TIMESTAMP,
+    pnl DECIMAL(20,8),
+    pnl_percent DECIMAL(10,4),
+
+    -- Notification tracking
+    notified_at TIMESTAMP,
+    notification_channels TEXT[],     -- ['telegram', 'email', 'webhook']
+
+    -- Metadata
+    timeframe VARCHAR(20),
+    metadata JSONB,                   -- Additional signal-specific data
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- Indexes for signals
+CREATE INDEX IF NOT EXISTS idx_signals_instrument ON signals(instrument);
+CREATE INDEX IF NOT EXISTS idx_signals_instrument_time ON signals(instrument, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_signals_type ON signals(signal_type);
+CREATE INDEX IF NOT EXISTS idx_signals_spec_id ON signals(spec_id);
+CREATE INDEX IF NOT EXISTS idx_signals_impl_id ON signals(implementation_id);
+CREATE INDEX IF NOT EXISTS idx_signals_outcome ON signals(outcome);
+CREATE INDEX IF NOT EXISTS idx_signals_created_at ON signals(created_at DESC);
+
+-- Composite index for signal queries
+CREATE INDEX IF NOT EXISTS idx_signals_instrument_type_time ON signals(instrument, signal_type, created_at DESC);
+
+-- Partition hint for future
+COMMENT ON TABLE signals IS 'Trading signal history. Consider partitioning by created_at for high-frequency signal generation.';


### PR DESCRIPTION
## Summary
- Add Flyway database migration framework for versioned schema management
- Create 4 initial migrations: baseline, strategy_specs, performance, signals
- Add Helm chart integration with migration Job template

## Changes

### New Migrations (`database/migrations/`)
| File | Description |
|------|-------------|
| `V1__baseline_strategies_table.sql` | Captures existing Strategies table schema |
| `V2__add_strategy_specs.sql` | Adds strategy_specs and strategy_implementations tables |
| `V3__add_strategy_performance.sql` | Adds performance tracking table |
| `V4__add_signals.sql` | Adds signals table for trading signal history |

### Helm Chart
- `database-migration.yaml` - Job template running Flyway as Helm hook
- `database-migration-configmap.yaml` - ConfigMap containing migration SQL
- `values.yaml` - Added databaseMigration configuration section

### Infrastructure
- Flyway 10.22-alpine image
- Runs as post-install/post-upgrade Helm hook
- Waits for PostgreSQL before running migrations
- Supports baseline migration for existing databases

## Test plan
- [ ] Helm lint passes
- [ ] CI builds pass
- [ ] values.yaml valid YAML
- [ ] Migration SQL syntax valid

## Related Issues
Closes #1486
Supports #1462 (Config-Based Strategies)
Enables #1485 (Signal Notification Service)

🤖 Generated with [Claude Code](https://claude.com/claude-code)