### PR TITLE
chore: reduce Bazel disk cache max age from 14d to 1d

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,7 +7,7 @@ build --tool_java_runtime_version=remotejdk_17
 build --tool_java_language_version=17
 
 build --experimental_disk_cache_gc_max_size=32G
-build --experimental_disk_cache_gc_max_age=14d
+build --experimental_disk_cache_gc_max_age=1d
 
 # Enable platform-based toolchain resolution
 build --incompatible_enable_cc_toolchain_resolution


### PR DESCRIPTION
## Summary
- Reduces `--experimental_disk_cache_gc_max_age` from `14d` to `1d` to more aggressively clean up stale cache entries
- Helps prevent excessive disk space usage on developer machines from repeated Bazel builds

## Technical Details
Bazel 7.4+ includes automatic garbage collection for the disk cache. By reducing the max age from 14 days to 1 day, cache entries that haven't been accessed for more than a day will be cleaned up during Bazel's idle period (default: 5 minutes after builds).

## Test plan
- [ ] CI passes with the new configuration
- [ ] Verify local builds work correctly with the new setting

Fixes #1495

🤖 Generated with [Claude Code](https://claude.com/claude-code)