### PR TITLE
feat: add YAML loading support to StrategyConfigLoader (#1462)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -94,6 +94,7 @@ maven.install(
         "org.knowm.xchange:xchange-stream-coinbasepro:5.2.0",
         "org.postgresql:postgresql:42.7.6",
         "org.ta4j:ta4j-core:0.17",
+        "org.yaml:snakeyaml:2.2",
 
         # Test Dependencies
         "com.google.inject.extensions:guice-testlib:7.0.0",

--- a/src/main/java/com/verlumen/tradestream/strategies/configurable/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/configurable/BUILD
@@ -72,6 +72,7 @@ java_library(
     deps = [
         ":config_pojos",
         "//third_party/java:gson",
+        "//third_party/java:snakeyaml",
     ],
 )
 

--- a/src/main/java/com/verlumen/tradestream/strategies/smaemacrossover/BUILD
+++ b/src/main/java/com/verlumen/tradestream/strategies/smaemacrossover/BUILD
@@ -3,6 +3,7 @@ load("@rules_java//java:defs.bzl", "java_library")
 package(
     default_visibility = [
         "//src/main/java/com/verlumen/tradestream/strategies:__pkg__",
+        "//src/test/java/com/verlumen/tradestream/strategies/configurable:__pkg__",
         "//src/test/java/com/verlumen/tradestream/strategies/smaemacrossover:__pkg__",
     ],
 )

--- a/src/test/java/com/verlumen/tradestream/strategies/configurable/BUILD
+++ b/src/test/java/com/verlumen/tradestream/strategies/configurable/BUILD
@@ -43,11 +43,39 @@ java_test(
     ],
 )
 
+java_test(
+    name = "StrategyConfigLoaderTest",
+    srcs = ["StrategyConfigLoaderTest.java"],
+    test_class = "com.verlumen.tradestream.strategies.configurable.StrategyConfigLoaderTest",
+    deps = [
+        "//src/main/java/com/verlumen/tradestream/strategies/configurable:config_pojos",
+        "//src/main/java/com/verlumen/tradestream/strategies/configurable:strategy_config_loader",
+        "//third_party/java:junit",
+    ],
+)
+
+java_test(
+    name = "ConfigBasedVsHardcodedValidationTest",
+    srcs = ["ConfigBasedVsHardcodedValidationTest.java"],
+    test_class = "com.verlumen.tradestream.strategies.configurable.ConfigBasedVsHardcodedValidationTest",
+    deps = [
+        "//protos:strategies_java_proto",
+        "//src/main/java/com/verlumen/tradestream/strategies/configurable:config_pojos",
+        "//src/main/java/com/verlumen/tradestream/strategies/configurable:configurable_strategy_factory",
+        "//src/main/java/com/verlumen/tradestream/strategies/configurable:strategy_config_loader",
+        "//src/main/java/com/verlumen/tradestream/strategies/smaemacrossover:strategy_factory",
+        "//third_party/java:junit",
+        "//third_party/java:ta4j_core",
+    ],
+)
+
 test_suite(
     name = "all_tests",
     tests = [
+        ":ConfigBasedVsHardcodedValidationTest",
         ":ConfigurableParamConfigTest",
         ":ConfigurableStrategyFactoryTest",
         ":IndicatorRegistryTest",
+        ":StrategyConfigLoaderTest",
     ],
 )

--- a/src/test/java/com/verlumen/tradestream/strategies/configurable/ConfigBasedVsHardcodedValidationTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/configurable/ConfigBasedVsHardcodedValidationTest.java
@@ -1,0 +1,330 @@
+package com.verlumen.tradestream.strategies.configurable;
+
+import static org.junit.Assert.*;
+
+import com.verlumen.tradestream.strategies.ConfigurableStrategyParameters;
+import com.verlumen.tradestream.strategies.SmaEmaCrossoverParameters;
+import com.verlumen.tradestream.strategies.smaemacrossover.SmaEmaCrossoverStrategyFactory;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBarSeriesBuilder;
+import org.ta4j.core.Strategy;
+
+/**
+ * Validation tests to ensure config-based strategies produce the same signals as their hardcoded
+ * counterparts. This is critical for verifying the migration from Java classes to YAML configs.
+ */
+public class ConfigBasedVsHardcodedValidationTest {
+
+  private BarSeries testSeries;
+
+  @Before
+  public void setUp() {
+    // Create a test bar series with synthetic data that will generate entry/exit signals
+    testSeries = new BaseBarSeriesBuilder().withName("validation-test").build();
+
+    // Generate data with clear trends to trigger crossover signals
+    // Pattern: gradual increase, then gradual decrease, repeat
+    double basePrice = 100.0;
+    for (int i = 0; i < 200; i++) {
+      // Create oscillating price pattern
+      double cycle = Math.sin(i * 0.1) * 20 + Math.sin(i * 0.05) * 10;
+      double price = basePrice + cycle;
+      double high = price + 2;
+      double low = price - 2;
+      double open = price - 0.5;
+      double close = price;
+      long volume = 1000 + (long) (Math.random() * 500);
+
+      testSeries.addBar(
+          java.time.ZonedDateTime.now().plusMinutes(i), open, high, low, close, volume);
+    }
+  }
+
+  @Test
+  public void testSmaEmaCrossoverConfigMatchesHardcoded() throws Exception {
+    // Parameters to test with
+    int smaPeriod = 20;
+    int emaPeriod = 50;
+
+    // Create hardcoded strategy
+    SmaEmaCrossoverStrategyFactory hardcodedFactory = new SmaEmaCrossoverStrategyFactory();
+    SmaEmaCrossoverParameters hardcodedParams =
+        SmaEmaCrossoverParameters.newBuilder()
+            .setSmaPeriod(smaPeriod)
+            .setEmaPeriod(emaPeriod)
+            .build();
+    Strategy hardcodedStrategy = hardcodedFactory.createStrategy(testSeries, hardcodedParams);
+
+    // Create config-based strategy matching the hardcoded one
+    StrategyConfig config =
+        StrategyConfig.builder()
+            .name("SMA_EMA_CROSSOVER_CONFIG")
+            .description("Config-based SMA/EMA crossover for validation")
+            .complexity("SIMPLE")
+            .source("CONFIG")
+            .indicators(
+                List.of(
+                    IndicatorConfig.builder()
+                        .id("sma")
+                        .type("SMA")
+                        .input("close")
+                        .params(Map.of("period", "${smaPeriod}"))
+                        .build(),
+                    IndicatorConfig.builder()
+                        .id("ema")
+                        .type("EMA")
+                        .input("close")
+                        .params(Map.of("period", "${emaPeriod}"))
+                        .build()))
+            .entryConditions(
+                List.of(
+                    ConditionConfig.builder()
+                        .type("CROSSED_UP")
+                        .indicator("sma")
+                        .params(Map.of("crosses", "ema"))
+                        .build()))
+            .exitConditions(
+                List.of(
+                    ConditionConfig.builder()
+                        .type("CROSSED_DOWN")
+                        .indicator("sma")
+                        .params(Map.of("crosses", "ema"))
+                        .build()))
+            .parameters(
+                List.of(
+                    ParameterDefinition.builder()
+                        .name("smaPeriod")
+                        .type(ParameterType.INTEGER)
+                        .min(5)
+                        .max(100)
+                        .defaultValue(smaPeriod)
+                        .build(),
+                    ParameterDefinition.builder()
+                        .name("emaPeriod")
+                        .type(ParameterType.INTEGER)
+                        .min(5)
+                        .max(100)
+                        .defaultValue(emaPeriod)
+                        .build()))
+            .build();
+
+    ConfigurableStrategyFactory configFactory = new ConfigurableStrategyFactory(config);
+    ConfigurableStrategyParameters configParams =
+        ConfigurableStrategyParameters.newBuilder()
+            .putIntValues("smaPeriod", smaPeriod)
+            .putIntValues("emaPeriod", emaPeriod)
+            .build();
+    Strategy configStrategy = configFactory.createStrategy(testSeries, configParams);
+
+    // Compare signals for all bars after warmup period
+    int warmupPeriod = Math.max(smaPeriod, emaPeriod) + 10;
+    int mismatches = 0;
+    int totalChecks = 0;
+
+    for (int i = warmupPeriod; i < testSeries.getBarCount(); i++) {
+      boolean hardcodedEntry = hardcodedStrategy.shouldEnter(i);
+      boolean configEntry = configStrategy.shouldEnter(i);
+      boolean hardcodedExit = hardcodedStrategy.shouldExit(i);
+      boolean configExit = configStrategy.shouldExit(i);
+
+      totalChecks++;
+
+      if (hardcodedEntry != configEntry) {
+        mismatches++;
+        // Uncomment for debugging:
+        // System.err.printf("Entry mismatch at bar %d: hardcoded=%b, config=%b%n",
+        //     i, hardcodedEntry, configEntry);
+      }
+
+      if (hardcodedExit != configExit) {
+        mismatches++;
+        // Uncomment for debugging:
+        // System.err.printf("Exit mismatch at bar %d: hardcoded=%b, config=%b%n",
+        //     i, hardcodedExit, configExit);
+      }
+    }
+
+    // Assert no mismatches
+    assertEquals(
+        String.format(
+            "Config-based strategy should match hardcoded strategy. "
+                + "Found %d mismatches in %d checks",
+            mismatches, totalChecks * 2),
+        0,
+        mismatches);
+
+    // Ensure we actually tested something meaningful
+    assertTrue("Should have tested at least 50 bars", totalChecks >= 50);
+  }
+
+  @Test
+  public void testYamlLoadedConfigMatchesHardcoded() throws Exception {
+    // This test validates that YAML parsing produces identical results
+    String yamlContent =
+        "name: SMA_EMA_CROSSOVER\n"
+            + "description: SMA crosses EMA\n"
+            + "complexity: SIMPLE\n"
+            + "source: MIGRATED\n"
+            + "\n"
+            + "indicators:\n"
+            + "  - id: sma\n"
+            + "    type: SMA\n"
+            + "    input: close\n"
+            + "    params:\n"
+            + "      period: \"${smaPeriod}\"\n"
+            + "  - id: ema\n"
+            + "    type: EMA\n"
+            + "    input: close\n"
+            + "    params:\n"
+            + "      period: \"${emaPeriod}\"\n"
+            + "\n"
+            + "entryConditions:\n"
+            + "  - type: CROSSED_UP\n"
+            + "    indicator: sma\n"
+            + "    params:\n"
+            + "      crosses: ema\n"
+            + "\n"
+            + "exitConditions:\n"
+            + "  - type: CROSSED_DOWN\n"
+            + "    indicator: sma\n"
+            + "    params:\n"
+            + "      crosses: ema\n"
+            + "\n"
+            + "parameters:\n"
+            + "  - name: smaPeriod\n"
+            + "    type: INTEGER\n"
+            + "    min: 5\n"
+            + "    max: 50\n"
+            + "    defaultValue: 20\n"
+            + "  - name: emaPeriod\n"
+            + "    type: INTEGER\n"
+            + "    min: 5\n"
+            + "    max: 50\n"
+            + "    defaultValue: 50\n";
+
+    StrategyConfig config = StrategyConfigLoader.parseYaml(yamlContent);
+    assertNotNull("YAML config should parse successfully", config);
+
+    // Create both strategies with same parameters
+    int smaPeriod = 20;
+    int emaPeriod = 50;
+
+    SmaEmaCrossoverStrategyFactory hardcodedFactory = new SmaEmaCrossoverStrategyFactory();
+    SmaEmaCrossoverParameters hardcodedParams =
+        SmaEmaCrossoverParameters.newBuilder()
+            .setSmaPeriod(smaPeriod)
+            .setEmaPeriod(emaPeriod)
+            .build();
+    Strategy hardcodedStrategy = hardcodedFactory.createStrategy(testSeries, hardcodedParams);
+
+    ConfigurableStrategyFactory configFactory = new ConfigurableStrategyFactory(config);
+    ConfigurableStrategyParameters configParams =
+        ConfigurableStrategyParameters.newBuilder()
+            .putIntValues("smaPeriod", smaPeriod)
+            .putIntValues("emaPeriod", emaPeriod)
+            .build();
+    Strategy configStrategy = configFactory.createStrategy(testSeries, configParams);
+
+    // Verify signals match
+    int warmupPeriod = Math.max(smaPeriod, emaPeriod) + 10;
+    for (int i = warmupPeriod; i < testSeries.getBarCount(); i++) {
+      assertEquals(
+          String.format("Entry signal mismatch at bar %d", i),
+          hardcodedStrategy.shouldEnter(i),
+          configStrategy.shouldEnter(i));
+      assertEquals(
+          String.format("Exit signal mismatch at bar %d", i),
+          hardcodedStrategy.shouldExit(i),
+          configStrategy.shouldExit(i));
+    }
+  }
+
+  @Test
+  public void testConfigWithDifferentParametersProducesDifferentSignals() throws Exception {
+    // This test ensures our config system actually uses parameters correctly
+    StrategyConfig config =
+        StrategyConfig.builder()
+            .name("SMA_EMA_CONFIG")
+            .indicators(
+                List.of(
+                    IndicatorConfig.builder()
+                        .id("sma")
+                        .type("SMA")
+                        .input("close")
+                        .params(Map.of("period", "${smaPeriod}"))
+                        .build(),
+                    IndicatorConfig.builder()
+                        .id("ema")
+                        .type("EMA")
+                        .input("close")
+                        .params(Map.of("period", "${emaPeriod}"))
+                        .build()))
+            .entryConditions(
+                List.of(
+                    ConditionConfig.builder()
+                        .type("CROSSED_UP")
+                        .indicator("sma")
+                        .params(Map.of("crosses", "ema"))
+                        .build()))
+            .exitConditions(
+                List.of(
+                    ConditionConfig.builder()
+                        .type("CROSSED_DOWN")
+                        .indicator("sma")
+                        .params(Map.of("crosses", "ema"))
+                        .build()))
+            .parameters(
+                List.of(
+                    ParameterDefinition.builder()
+                        .name("smaPeriod")
+                        .type(ParameterType.INTEGER)
+                        .min(5)
+                        .max(100)
+                        .defaultValue(10)
+                        .build(),
+                    ParameterDefinition.builder()
+                        .name("emaPeriod")
+                        .type(ParameterType.INTEGER)
+                        .min(5)
+                        .max(100)
+                        .defaultValue(30)
+                        .build()))
+            .build();
+
+    ConfigurableStrategyFactory factory = new ConfigurableStrategyFactory(config);
+
+    // Create two strategies with different parameters
+    ConfigurableStrategyParameters params1 =
+        ConfigurableStrategyParameters.newBuilder()
+            .putIntValues("smaPeriod", 10)
+            .putIntValues("emaPeriod", 30)
+            .build();
+    Strategy strategy1 = factory.createStrategy(testSeries, params1);
+
+    ConfigurableStrategyParameters params2 =
+        ConfigurableStrategyParameters.newBuilder()
+            .putIntValues("smaPeriod", 5)
+            .putIntValues("emaPeriod", 50)
+            .build();
+    Strategy strategy2 = factory.createStrategy(testSeries, params2);
+
+    // Count differences in signals
+    int differences = 0;
+    for (int i = 60; i < testSeries.getBarCount(); i++) {
+      if (strategy1.shouldEnter(i) != strategy2.shouldEnter(i)) {
+        differences++;
+      }
+      if (strategy1.shouldExit(i) != strategy2.shouldExit(i)) {
+        differences++;
+      }
+    }
+
+    // Different parameters should produce different signals (at least some of the time)
+    assertTrue(
+        "Different parameters should produce at least some different signals", differences > 0);
+  }
+}

--- a/src/test/java/com/verlumen/tradestream/strategies/configurable/StrategyConfigLoaderTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/configurable/StrategyConfigLoaderTest.java
@@ -1,0 +1,172 @@
+package com.verlumen.tradestream.strategies.configurable;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+import org.junit.Test;
+
+/** Tests for StrategyConfigLoader verifying YAML and JSON parsing. */
+public class StrategyConfigLoaderTest {
+
+  private static final String YAML_CONTENT =
+      "name: SMA_EMA_CROSSOVER\n"
+          + "description: Simple Moving Average crosses Exponential Moving Average\n"
+          + "complexity: SIMPLE\n"
+          + "source: MIGRATED\n"
+          + "sourceStrategy:"
+          + " com.verlum.tradestream.strategies.smaemacrossover.SmaEmaCrossoverStrategyFactory\n"
+          + "\n"
+          + "indicators:\n"
+          + "  - id: sma\n"
+          + "    type: SMA\n"
+          + "    input: close\n"
+          + "    params:\n"
+          + "      period: \"${smaPeriod}\"\n"
+          + "  - id: ema\n"
+          + "    type: EMA\n"
+          + "    input: close\n"
+          + "    params:\n"
+          + "      period: \"${emaPeriod}\"\n"
+          + "\n"
+          + "entryConditions:\n"
+          + "  - type: CROSSED_UP\n"
+          + "    indicator: sma\n"
+          + "    params:\n"
+          + "      crosses: ema\n"
+          + "\n"
+          + "exitConditions:\n"
+          + "  - type: CROSSED_DOWN\n"
+          + "    indicator: sma\n"
+          + "    params:\n"
+          + "      crosses: ema\n"
+          + "\n"
+          + "parameters:\n"
+          + "  - name: smaPeriod\n"
+          + "    type: INTEGER\n"
+          + "    min: 5\n"
+          + "    max: 50\n"
+          + "    defaultValue: 20\n"
+          + "  - name: emaPeriod\n"
+          + "    type: INTEGER\n"
+          + "    min: 5\n"
+          + "    max: 50\n"
+          + "    defaultValue: 50\n";
+
+  @Test
+  public void testParseYaml() {
+    StrategyConfig config = StrategyConfigLoader.parseYaml(YAML_CONTENT);
+
+    assertNotNull("Config should not be null", config);
+    assertEquals("SMA_EMA_CROSSOVER", config.getName());
+    assertEquals(
+        "Simple Moving Average crosses Exponential Moving Average", config.getDescription());
+    assertEquals("SIMPLE", config.getComplexity());
+    assertEquals("MIGRATED", config.getSource());
+  }
+
+  @Test
+  public void testParseYamlIndicators() {
+    StrategyConfig config = StrategyConfigLoader.parseYaml(YAML_CONTENT);
+
+    List<IndicatorConfig> indicators = config.getIndicators();
+    assertNotNull("Indicators should not be null", indicators);
+    assertEquals(2, indicators.size());
+
+    IndicatorConfig sma = indicators.get(0);
+    assertEquals("sma", sma.getId());
+    assertEquals("SMA", sma.getType());
+    assertEquals("close", sma.getInput());
+    assertEquals("${smaPeriod}", sma.getParams().get("period"));
+
+    IndicatorConfig ema = indicators.get(1);
+    assertEquals("ema", ema.getId());
+    assertEquals("EMA", ema.getType());
+    assertEquals("close", ema.getInput());
+    assertEquals("${emaPeriod}", ema.getParams().get("period"));
+  }
+
+  @Test
+  public void testParseYamlConditions() {
+    StrategyConfig config = StrategyConfigLoader.parseYaml(YAML_CONTENT);
+
+    List<ConditionConfig> entryConditions = config.getEntryConditions();
+    assertNotNull("Entry conditions should not be null", entryConditions);
+    assertEquals(1, entryConditions.size());
+
+    ConditionConfig entry = entryConditions.get(0);
+    assertEquals("CROSSED_UP", entry.getType());
+    assertEquals("sma", entry.getIndicator());
+    assertEquals("ema", entry.getParams().get("crosses"));
+
+    List<ConditionConfig> exitConditions = config.getExitConditions();
+    assertNotNull("Exit conditions should not be null", exitConditions);
+    assertEquals(1, exitConditions.size());
+
+    ConditionConfig exit = exitConditions.get(0);
+    assertEquals("CROSSED_DOWN", exit.getType());
+    assertEquals("sma", exit.getIndicator());
+    assertEquals("ema", exit.getParams().get("crosses"));
+  }
+
+  @Test
+  public void testParseYamlParameters() {
+    StrategyConfig config = StrategyConfigLoader.parseYaml(YAML_CONTENT);
+
+    List<ParameterDefinition> parameters = config.getParameters();
+    assertNotNull("Parameters should not be null", parameters);
+    assertEquals(2, parameters.size());
+
+    ParameterDefinition smaPeriod = parameters.get(0);
+    assertEquals("smaPeriod", smaPeriod.getName());
+    assertEquals(ParameterType.INTEGER, smaPeriod.getType());
+    assertEquals(5, smaPeriod.getMin().intValue());
+    assertEquals(50, smaPeriod.getMax().intValue());
+    assertEquals(20, smaPeriod.getDefaultValue().intValue());
+
+    ParameterDefinition emaPeriod = parameters.get(1);
+    assertEquals("emaPeriod", emaPeriod.getName());
+    assertEquals(ParameterType.INTEGER, emaPeriod.getType());
+    assertEquals(5, emaPeriod.getMin().intValue());
+    assertEquals(50, emaPeriod.getMax().intValue());
+    assertEquals(50, emaPeriod.getDefaultValue().intValue());
+  }
+
+  @Test
+  public void testParseJsonEquivalent() {
+    // Parse JSON with same structure
+    String jsonContent =
+        "{"
+            + "\"name\": \"SMA_EMA_CROSSOVER\","
+            + "\"description\": \"Simple Moving Average crosses Exponential Moving Average\","
+            + "\"complexity\": \"SIMPLE\","
+            + "\"source\": \"MIGRATED\""
+            + "}";
+
+    StrategyConfig config = StrategyConfigLoader.parseJson(jsonContent);
+
+    assertNotNull("Config should not be null", config);
+    assertEquals("SMA_EMA_CROSSOVER", config.getName());
+    assertEquals(
+        "Simple Moving Average crosses Exponential Moving Average", config.getDescription());
+    assertEquals("SIMPLE", config.getComplexity());
+    assertEquals("MIGRATED", config.getSource());
+  }
+
+  @Test
+  public void testToJsonAndBack() {
+    StrategyConfig original = StrategyConfigLoader.parseYaml(YAML_CONTENT);
+
+    // Convert to JSON and back
+    String json = StrategyConfigLoader.toJson(original);
+    StrategyConfig restored = StrategyConfigLoader.parseJson(json);
+
+    assertEquals(original.getName(), restored.getName());
+    assertEquals(original.getDescription(), restored.getDescription());
+    assertEquals(original.getComplexity(), restored.getComplexity());
+    assertEquals(original.getSource(), restored.getSource());
+    assertEquals(original.getIndicators().size(), restored.getIndicators().size());
+    assertEquals(original.getEntryConditions().size(), restored.getEntryConditions().size());
+    assertEquals(original.getExitConditions().size(), restored.getExitConditions().size());
+    assertEquals(original.getParameters().size(), restored.getParameters().size());
+  }
+}

--- a/third_party/java/BUILD
+++ b/third_party/java/BUILD
@@ -352,3 +352,11 @@ java_library(
         "@tradestream_maven//:org_json_json",
     ],
 )
+
+java_library(
+    name = "snakeyaml",
+    visibility = ["//visibility:public"],
+    exports = [
+        "@tradestream_maven//:org_yaml_snakeyaml",
+    ],
+)


### PR DESCRIPTION
## Summary
- Add YAML parsing capability to the strategy config system
- Support loading strategy specifications from YAML files
- Add validation tests comparing config-based vs hardcoded strategies

## Changes
- Add SnakeYAML 2.2 as a Maven dependency
- Extend `StrategyConfigLoader` with:
  - `loadYaml()` - load from file path
  - `loadYamlResource()` - load from classpath resource
  - `parseYaml()` - parse from string
  - `load()` / `loadResource()` - auto-detect format based on extension
- Update `loadAll()` to support both `.yaml/.yml` and `.json` files
- Add comprehensive unit tests for YAML parsing (6 tests)
- Add validation tests verifying config-based strategies match hardcoded behavior (3 tests)

## Why
The 10 existing YAML strategy configs in `src/main/resources/strategies/` couldn't be loaded at runtime because the loader only supported JSON. This unblocks Week 2 sprint work for issue #1462.

## Test plan
- [x] All 9 new tests pass (`StrategyConfigLoaderTest`, `ConfigBasedVsHardcodedValidationTest`)
- [x] All existing configurable module tests pass
- [x] Config-based SMA_EMA_CROSSOVER strategy produces identical signals to hardcoded implementation

Closes #1462 (partial - YAML loading support)

🤖 Generated with [Claude Code](https://claude.com/claude-code)