### PR TITLE
fix: handle multiline output in google-java-format workflow

### DIFF
--- a/.github/workflows/format-java-code.yaml
+++ b/.github/workflows/format-java-code.yaml
@@ -16,13 +16,13 @@ jobs:
       - name: Get changed Java files
         id: changed-files
         run: |
-          # Get list of changed Java files in this PR
-          CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRT origin/main...HEAD | grep '\.java$' || true)
+          # Get list of changed Java files in this PR (space-separated, single line)
+          CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRT origin/main...HEAD | grep '\.java$' | tr '\n' ' ' | sed 's/ $//' || true)
           if [ -z "$CHANGED_FILES" ]; then
             echo "files=" >> $GITHUB_OUTPUT
             echo "has_java_files=false" >> $GITHUB_OUTPUT
           else
-            # Convert to space-separated list for the action
+            # Output space-separated list for the action
             echo "files=$CHANGED_FILES" >> $GITHUB_OUTPUT
             echo "has_java_files=true" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
## Summary
- Fixes GITHUB_OUTPUT format error when passing multiline file lists
- Converts newline-separated file list to space-separated single line

## Root Cause
The previous fix (#1500) outputted files with newlines, which caused:
```
##[error]Unable to process file command 'output' successfully.
##[error]Invalid format 'src/test/java/...'
```

## Fix
- Use `tr '\n' ' '` to convert newlines to spaces
- Remove trailing space with `sed 's/ $//'`

## Test plan
- [ ] CI workflow runs successfully
- [ ] File list is correctly space-separated

🤖 Generated with [Claude Code](https://claude.com/claude-code)