### PR TITLE
fix: resolve Deploy and Test CI failures (#1499)

### DIFF
--- a/charts/tradestream/Chart.yaml
+++ b/charts/tradestream/Chart.yaml
@@ -20,6 +20,6 @@ dependencies:
     repository: "oci://registry-1.docker.io/bitnamicharts"
     condition: redis.enabled
   - name: postgresql
-    version: "15.5.35"
+    version: "16.4.2"
     repository: "https://charts.bitnami.com/bitnami"
     condition: postgresql.enabled

--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -107,9 +107,8 @@ kafka:
       limits:
         cpu: "1"
         memory: "2Gi"
-    extraEnvVars:
-      - name: KAFKA_HEAP_OPTS
-        value: "-Xmx1g -Xms1g"
+    # Use heapOpts instead of extraEnvVars to avoid duplicate KAFKA_HEAP_OPTS
+    heapOpts: "-Xmx1g -Xms1g"
 kafkaUi:
   replicaCount: 1
   image:
@@ -223,6 +222,9 @@ redis:
 # PostgreSQL configuration
 postgresql:
   enabled: true
+  image:
+    # Pin to PostgreSQL 17 - the free Bitnami catalog only includes version 17
+    tag: "17"
   auth:
     postgresPassword: "tradestream123" # Change this for production
     username: "postgres"


### PR DESCRIPTION
## Summary
- Fixes PostgreSQL image not found error
- Fixes duplicate KAFKA_HEAP_OPTS error

## Root Cause
1. **PostgreSQL**: The bitnami/postgresql chart 15.5.35 references an image tag (16.4.0-debian-12-r11) that no longer exists. The free Bitnami catalog now only includes PostgreSQL 17+.
2. **Kafka**: Setting KAFKA_HEAP_OPTS via extraEnvVars duplicates the chart's built-in env var.

## Changes

### Chart.yaml
- Updated postgresql chart version: `15.5.35` → `16.4.2`

### values.yaml
- Added `postgresql.image.tag: "17"` to pin to PostgreSQL 17
- Replaced `controller.extraEnvVars` with `controller.heapOpts` for Kafka

## Test plan
- [ ] Helm template renders successfully ✅
- [ ] Deploy and Test CI job passes
- [ ] All other CI checks pass

Closes #1499

🤖 Generated with [Claude Code](https://claude.com/claude-code)