### PR TITLE
feat: add 15 YAML strategy configs for configurable strategy system

### DIFF
--- a/src/main/resources/strategies/adx_dmi.yaml
+++ b/src/main/resources/strategies/adx_dmi.yaml
@@ -1,0 +1,47 @@
+name: ADX_DMI
+description: ADX with Directional Movement Index - trades strong trends when +DI crosses -DI
+complexity: SIMPLE
+source: MIGRATED
+sourceStrategy: com.verlum.tradestream.strategies.adxdmi.AdxDmiStrategyFactory
+
+indicators:
+  - id: adx
+    type: ADX
+    params:
+      period: "${adxPeriod}"
+  - id: plusDI
+    type: PLUS_DI
+    params:
+      period: "${diPeriod}"
+  - id: minusDI
+    type: MINUS_DI
+    params:
+      period: "${diPeriod}"
+
+entryConditions:
+  - type: OVER_CONSTANT
+    indicator: adx
+    params:
+      threshold: 25
+  - type: CROSSED_UP
+    indicator: plusDI
+    params:
+      crosses: minusDI
+
+exitConditions:
+  - type: CROSSED_DOWN
+    indicator: plusDI
+    params:
+      crosses: minusDI
+
+parameters:
+  - name: adxPeriod
+    type: INTEGER
+    min: 10
+    max: 30
+    defaultValue: 14
+  - name: diPeriod
+    type: INTEGER
+    min: 10
+    max: 30
+    defaultValue: 14

--- a/src/main/resources/strategies/adx_stochastic.yaml
+++ b/src/main/resources/strategies/adx_stochastic.yaml
@@ -1,0 +1,57 @@
+name: ADX_STOCHASTIC
+description: ADX trend filter with Stochastic Oscillator - enters on strong trends when oversold
+complexity: SIMPLE
+source: MIGRATED
+sourceStrategy: com.verlum.tradestream.strategies.adxstochastic.AdxStochasticStrategyFactory
+
+indicators:
+  - id: adx
+    type: ADX
+    params:
+      period: "${adxPeriod}"
+  - id: stochasticK
+    type: STOCHASTIC_K
+    params:
+      period: "${stochasticKPeriod}"
+
+entryConditions:
+  - type: OVER_CONSTANT
+    indicator: adx
+    params:
+      threshold: 20
+  - type: UNDER_CONSTANT
+    indicator: stochasticK
+    params:
+      threshold: "${oversoldThreshold}"
+
+exitConditions:
+  - type: UNDER_CONSTANT
+    indicator: adx
+    params:
+      threshold: 20
+  - type: OVER_CONSTANT
+    indicator: stochasticK
+    params:
+      threshold: "${overboughtThreshold}"
+
+parameters:
+  - name: adxPeriod
+    type: INTEGER
+    min: 10
+    max: 30
+    defaultValue: 14
+  - name: stochasticKPeriod
+    type: INTEGER
+    min: 5
+    max: 21
+    defaultValue: 14
+  - name: overboughtThreshold
+    type: INTEGER
+    min: 70
+    max: 90
+    defaultValue: 80
+  - name: oversoldThreshold
+    type: INTEGER
+    min: 10
+    max: 30
+    defaultValue: 20

--- a/src/main/resources/strategies/aroon_mfi.yaml
+++ b/src/main/resources/strategies/aroon_mfi.yaml
@@ -1,0 +1,61 @@
+name: AROON_MFI
+description: Aroon with Money Flow Index - enters on Aroon Up crossing Down when oversold
+complexity: MEDIUM
+source: MIGRATED
+sourceStrategy: com.verlumen.tradestream.strategies.aroonmfi.AroonMfiStrategyFactory
+
+indicators:
+  - id: aroonUp
+    type: AROON_UP
+    params:
+      period: "${aroonPeriod}"
+  - id: aroonDown
+    type: AROON_DOWN
+    params:
+      period: "${aroonPeriod}"
+  - id: mfi
+    type: MFI
+    params:
+      period: "${mfiPeriod}"
+
+entryConditions:
+  - type: CROSSED_UP
+    indicator: aroonUp
+    params:
+      crosses: aroonDown
+  - type: UNDER_CONSTANT
+    indicator: mfi
+    params:
+      threshold: "${oversoldThreshold}"
+
+exitConditions:
+  - type: OVER_INDICATOR
+    indicator: aroonUp
+    params:
+      other: aroonDown
+  - type: OVER_CONSTANT
+    indicator: mfi
+    params:
+      threshold: "${overboughtThreshold}"
+
+parameters:
+  - name: aroonPeriod
+    type: INTEGER
+    min: 15
+    max: 35
+    defaultValue: 25
+  - name: mfiPeriod
+    type: INTEGER
+    min: 7
+    max: 21
+    defaultValue: 14
+  - name: overboughtThreshold
+    type: INTEGER
+    min: 70
+    max: 90
+    defaultValue: 80
+  - name: oversoldThreshold
+    type: INTEGER
+    min: 10
+    max: 30
+    defaultValue: 20

--- a/src/main/resources/strategies/atr_cci.yaml
+++ b/src/main/resources/strategies/atr_cci.yaml
@@ -1,0 +1,52 @@
+name: ATR_CCI
+description: ATR volatility filter with CCI momentum - enters when CCI oversold and volatility rising
+complexity: SIMPLE
+source: MIGRATED
+sourceStrategy: com.verlum.tradestream.strategies.atrcci.AtrCciStrategyFactory
+
+indicators:
+  - id: atr
+    type: ATR
+    params:
+      period: "${atrPeriod}"
+  - id: cci
+    type: CCI
+    params:
+      period: "${cciPeriod}"
+  - id: previousAtr
+    type: PREVIOUS
+    params:
+      indicator: atr
+      n: 1
+
+entryConditions:
+  - type: OVER_CONSTANT
+    indicator: cci
+    params:
+      threshold: -100
+  - type: OVER_INDICATOR
+    indicator: atr
+    params:
+      other: previousAtr
+
+exitConditions:
+  - type: UNDER_CONSTANT
+    indicator: cci
+    params:
+      threshold: 100
+  - type: UNDER_INDICATOR
+    indicator: atr
+    params:
+      other: previousAtr
+
+parameters:
+  - name: atrPeriod
+    type: INTEGER
+    min: 7
+    max: 21
+    defaultValue: 14
+  - name: cciPeriod
+    type: INTEGER
+    min: 14
+    max: 28
+    defaultValue: 20

--- a/src/main/resources/strategies/awesome_oscillator.yaml
+++ b/src/main/resources/strategies/awesome_oscillator.yaml
@@ -1,0 +1,36 @@
+name: AWESOME_OSCILLATOR
+description: Awesome Oscillator zero-line crossover - enters when AO crosses above zero
+complexity: SIMPLE
+source: MIGRATED
+sourceStrategy: com.verlum.tradestream.strategies.awesomeoscillator.AwesomeOscillatorStrategyFactory
+
+indicators:
+  - id: ao
+    type: AWESOME_OSCILLATOR
+    params:
+      shortPeriod: "${shortPeriod}"
+      longPeriod: "${longPeriod}"
+
+entryConditions:
+  - type: CROSSED_UP_CONSTANT
+    indicator: ao
+    params:
+      threshold: 0
+
+exitConditions:
+  - type: CROSSED_DOWN_CONSTANT
+    indicator: ao
+    params:
+      threshold: 0
+
+parameters:
+  - name: shortPeriod
+    type: INTEGER
+    min: 3
+    max: 10
+    defaultValue: 5
+  - name: longPeriod
+    type: INTEGER
+    min: 20
+    max: 50
+    defaultValue: 34

--- a/src/main/resources/strategies/bband_williams_r.yaml
+++ b/src/main/resources/strategies/bband_williams_r.yaml
@@ -1,0 +1,60 @@
+name: BBAND_WILLIAMS_R
+description: Bollinger Bands with Williams %R - enters at lower band when oversold
+complexity: MEDIUM
+source: MIGRATED
+sourceStrategy: com.verlum.tradestream.strategies.bbandwr.BbandWRStrategyFactory
+
+indicators:
+  - id: closePrice
+    type: CLOSE_PRICE
+  - id: bbUpper
+    type: BOLLINGER_UPPER
+    params:
+      period: "${bbandsPeriod}"
+      k: "${stdDevMultiplier}"
+  - id: bbLower
+    type: BOLLINGER_LOWER
+    params:
+      period: "${bbandsPeriod}"
+      k: "${stdDevMultiplier}"
+  - id: williamsR
+    type: WILLIAMS_R
+    params:
+      period: "${wrPeriod}"
+
+entryConditions:
+  - type: UNDER_INDICATOR
+    indicator: closePrice
+    params:
+      other: bbLower
+  - type: UNDER_CONSTANT
+    indicator: williamsR
+    params:
+      threshold: -80
+
+exitConditions:
+  - type: OVER_INDICATOR
+    indicator: closePrice
+    params:
+      other: bbUpper
+  - type: OVER_CONSTANT
+    indicator: williamsR
+    params:
+      threshold: -20
+
+parameters:
+  - name: bbandsPeriod
+    type: INTEGER
+    min: 10
+    max: 30
+    defaultValue: 20
+  - name: wrPeriod
+    type: INTEGER
+    min: 7
+    max: 21
+    defaultValue: 14
+  - name: stdDevMultiplier
+    type: DOUBLE
+    min: 1.5
+    max: 3.0
+    defaultValue: 2.0

--- a/src/main/resources/strategies/cmf_zero_line.yaml
+++ b/src/main/resources/strategies/cmf_zero_line.yaml
@@ -1,0 +1,30 @@
+name: CMF_ZERO_LINE
+description: Chaikin Money Flow zero-line crossover - enters when CMF crosses above zero
+complexity: SIMPLE
+source: MIGRATED
+sourceStrategy: com.verlum.tradestream.strategies.cmfzeroline.CmfZeroLineStrategyFactory
+
+indicators:
+  - id: cmf
+    type: CMF
+    params:
+      period: "${period}"
+
+entryConditions:
+  - type: CROSSED_UP_CONSTANT
+    indicator: cmf
+    params:
+      threshold: 0
+
+exitConditions:
+  - type: CROSSED_DOWN_CONSTANT
+    indicator: cmf
+    params:
+      threshold: 0
+
+parameters:
+  - name: period
+    type: INTEGER
+    min: 10
+    max: 30
+    defaultValue: 20

--- a/src/main/resources/strategies/cmo_mfi.yaml
+++ b/src/main/resources/strategies/cmo_mfi.yaml
@@ -1,0 +1,47 @@
+name: CMO_MFI
+description: Chande Momentum Oscillator with Money Flow Index - momentum and volume confirmation
+complexity: MEDIUM
+source: MIGRATED
+sourceStrategy: com.verlumen.tradestream.strategies.cmomfi.CmoMfiStrategyFactory
+
+indicators:
+  - id: cmo
+    type: CMO
+    params:
+      period: "${cmoPeriod}"
+  - id: mfi
+    type: MFI
+    params:
+      period: "${mfiPeriod}"
+
+entryConditions:
+  - type: CROSSED_UP_CONSTANT
+    indicator: cmo
+    params:
+      threshold: 0
+  - type: UNDER_CONSTANT
+    indicator: mfi
+    params:
+      threshold: 20
+
+exitConditions:
+  - type: CROSSED_DOWN_CONSTANT
+    indicator: cmo
+    params:
+      threshold: 0
+  - type: OVER_CONSTANT
+    indicator: mfi
+    params:
+      threshold: 80
+
+parameters:
+  - name: cmoPeriod
+    type: INTEGER
+    min: 7
+    max: 21
+    defaultValue: 14
+  - name: mfiPeriod
+    type: INTEGER
+    min: 7
+    max: 21
+    defaultValue: 14

--- a/src/main/resources/strategies/donchian_breakout.yaml
+++ b/src/main/resources/strategies/donchian_breakout.yaml
@@ -1,0 +1,36 @@
+name: DONCHIAN_BREAKOUT
+description: Donchian Channel breakout - enters when price breaks above highest high
+complexity: SIMPLE
+source: MIGRATED
+sourceStrategy: com.verlum.tradestream.strategies.donchianbreakout.DonchianBreakoutStrategyFactory
+
+indicators:
+  - id: closePrice
+    type: CLOSE_PRICE
+  - id: upperChannel
+    type: HIGHEST_HIGH
+    params:
+      period: "${donchianPeriod}"
+  - id: lowerChannel
+    type: LOWEST_LOW
+    params:
+      period: "${donchianPeriod}"
+
+entryConditions:
+  - type: OVER_INDICATOR
+    indicator: closePrice
+    params:
+      other: upperChannel
+
+exitConditions:
+  - type: UNDER_INDICATOR
+    indicator: closePrice
+    params:
+      other: lowerChannel
+
+parameters:
+  - name: donchianPeriod
+    type: INTEGER
+    min: 10
+    max: 50
+    defaultValue: 20

--- a/src/main/resources/strategies/elder_ray_ma.yaml
+++ b/src/main/resources/strategies/elder_ray_ma.yaml
@@ -1,0 +1,46 @@
+name: ELDER_RAY_MA
+description: Elder Ray with EMA - enters when Bull Power crosses above zero
+complexity: SIMPLE
+source: MIGRATED
+sourceStrategy: com.verlumen.tradestream.strategies.elderrayma.ElderRayMAStrategyFactory
+
+indicators:
+  - id: closePrice
+    type: CLOSE_PRICE
+  - id: highPrice
+    type: HIGH_PRICE
+  - id: lowPrice
+    type: LOW_PRICE
+  - id: ema
+    type: EMA
+    params:
+      period: "${emaPeriod}"
+  - id: bullPower
+    type: DIFFERENCE
+    params:
+      first: highPrice
+      second: ema
+  - id: bearPower
+    type: DIFFERENCE
+    params:
+      first: lowPrice
+      second: ema
+
+entryConditions:
+  - type: CROSSED_UP_CONSTANT
+    indicator: bullPower
+    params:
+      threshold: 0
+
+exitConditions:
+  - type: CROSSED_DOWN_CONSTANT
+    indicator: bearPower
+    params:
+      threshold: 0
+
+parameters:
+  - name: emaPeriod
+    type: INTEGER
+    min: 10
+    max: 30
+    defaultValue: 20

--- a/src/main/resources/strategies/ema_macd.yaml
+++ b/src/main/resources/strategies/ema_macd.yaml
@@ -1,0 +1,46 @@
+name: EMA_MACD
+description: EMA-based MACD - enters when MACD crosses above signal line
+complexity: SIMPLE
+source: MIGRATED
+sourceStrategy: com.verlumen.tradestream.strategies.emamacd.EmaMacdStrategyFactory
+
+indicators:
+  - id: macd
+    type: MACD
+    params:
+      shortPeriod: "${shortEmaPeriod}"
+      longPeriod: "${longEmaPeriod}"
+  - id: signalLine
+    type: EMA
+    input: macd
+    params:
+      period: "${signalPeriod}"
+
+entryConditions:
+  - type: CROSSED_UP
+    indicator: macd
+    params:
+      crosses: signalLine
+
+exitConditions:
+  - type: CROSSED_DOWN
+    indicator: macd
+    params:
+      crosses: signalLine
+
+parameters:
+  - name: shortEmaPeriod
+    type: INTEGER
+    min: 8
+    max: 16
+    defaultValue: 12
+  - name: longEmaPeriod
+    type: INTEGER
+    min: 20
+    max: 32
+    defaultValue: 26
+  - name: signalPeriod
+    type: INTEGER
+    min: 6
+    max: 12
+    defaultValue: 9

--- a/src/main/resources/strategies/klinger_volume.yaml
+++ b/src/main/resources/strategies/klinger_volume.yaml
@@ -1,0 +1,46 @@
+name: KLINGER_VOLUME
+description: Klinger Volume Oscillator with signal line - volume-based trend indicator
+complexity: MEDIUM
+source: MIGRATED
+sourceStrategy: com.verlum.tradestream.strategies.klingervolume.KlingerVolumeStrategyFactory
+
+indicators:
+  - id: kvo
+    type: KLINGER_VOLUME_OSCILLATOR
+    params:
+      shortPeriod: "${shortPeriod}"
+      longPeriod: "${longPeriod}"
+  - id: signalLine
+    type: EMA
+    input: kvo
+    params:
+      period: "${signalPeriod}"
+
+entryConditions:
+  - type: CROSSED_UP
+    indicator: kvo
+    params:
+      crosses: signalLine
+
+exitConditions:
+  - type: CROSSED_DOWN
+    indicator: kvo
+    params:
+      crosses: signalLine
+
+parameters:
+  - name: shortPeriod
+    type: INTEGER
+    min: 5
+    max: 20
+    defaultValue: 10
+  - name: longPeriod
+    type: INTEGER
+    min: 20
+    max: 50
+    defaultValue: 35
+  - name: signalPeriod
+    type: INTEGER
+    min: 5
+    max: 15
+    defaultValue: 10

--- a/src/main/resources/strategies/mass_index.yaml
+++ b/src/main/resources/strategies/mass_index.yaml
@@ -1,0 +1,40 @@
+name: MASS_INDEX
+description: Mass Index reversal bulge strategy - identifies trend reversals via range expansion
+complexity: MEDIUM
+source: MIGRATED
+sourceStrategy: com.verlum.tradestream.strategies.massindex.MassIndexStrategyFactory
+
+indicators:
+  - id: massIndex
+    type: MASS_INDEX
+    params:
+      emaPeriod: "${emaPeriod}"
+      sumPeriod: "${sumPeriod}"
+
+entryConditions:
+  - type: CROSSED_DOWN_CONSTANT
+    indicator: massIndex
+    params:
+      threshold: 26.5
+
+exitConditions:
+  - type: CROSSED_UP_CONSTANT
+    indicator: massIndex
+    params:
+      threshold: 27
+  - type: CROSSED_DOWN_CONSTANT
+    indicator: massIndex
+    params:
+      threshold: 25
+
+parameters:
+  - name: emaPeriod
+    type: INTEGER
+    min: 5
+    max: 15
+    defaultValue: 9
+  - name: sumPeriod
+    type: INTEGER
+    min: 15
+    max: 35
+    defaultValue: 25

--- a/src/main/resources/strategies/price_gap.yaml
+++ b/src/main/resources/strategies/price_gap.yaml
@@ -1,0 +1,32 @@
+name: PRICE_GAP
+description: Price Gap with EMA - enters when price crosses above EMA
+complexity: SIMPLE
+source: MIGRATED
+sourceStrategy: com.verlumen.tradestream.strategies.pricegap.PriceGapStrategyFactory
+
+indicators:
+  - id: closePrice
+    type: CLOSE_PRICE
+  - id: ema
+    type: EMA
+    params:
+      period: "${period}"
+
+entryConditions:
+  - type: CROSSED_UP
+    indicator: closePrice
+    params:
+      crosses: ema
+
+exitConditions:
+  - type: CROSSED_DOWN
+    indicator: closePrice
+    params:
+      crosses: ema
+
+parameters:
+  - name: period
+    type: INTEGER
+    min: 5
+    max: 20
+    defaultValue: 10

--- a/src/main/resources/strategies/stochastic_rsi.yaml
+++ b/src/main/resources/strategies/stochastic_rsi.yaml
@@ -1,0 +1,54 @@
+name: STOCHASTIC_RSI
+description: Stochastic RSI - enters when oversold, exits when overbought
+complexity: MEDIUM
+source: MIGRATED
+sourceStrategy: com.verlumen.tradestream.strategies.stochasticsrsi.StochasticRsiStrategyFactory
+
+indicators:
+  - id: rsi
+    type: RSI
+    params:
+      period: "${rsiPeriod}"
+  - id: stochasticK
+    type: STOCHASTIC_K
+    params:
+      period: "${stochasticKPeriod}"
+
+entryConditions:
+  - type: OVER_CONSTANT
+    indicator: stochasticK
+    params:
+      threshold: "${oversoldThreshold}"
+
+exitConditions:
+  - type: UNDER_CONSTANT
+    indicator: stochasticK
+    params:
+      threshold: "${overboughtThreshold}"
+
+parameters:
+  - name: rsiPeriod
+    type: INTEGER
+    min: 7
+    max: 21
+    defaultValue: 14
+  - name: stochasticKPeriod
+    type: INTEGER
+    min: 7
+    max: 21
+    defaultValue: 14
+  - name: stochasticDPeriod
+    type: INTEGER
+    min: 2
+    max: 5
+    defaultValue: 3
+  - name: overboughtThreshold
+    type: INTEGER
+    min: 70
+    max: 90
+    defaultValue: 80
+  - name: oversoldThreshold
+    type: INTEGER
+    min: 10
+    max: 30
+    defaultValue: 20


### PR DESCRIPTION
## Summary
- Added 15 new YAML strategy configurations migrated from hardcoded Java implementations
- These strategies work with the ConfigurableStrategyFactory system from PR #1497
- Brings total strategy configs to 25, completing Week 2 sprint target

## Strategy Configs Added
| Strategy | Description | Complexity |
|----------|-------------|------------|
| adx_dmi | ADX with Directional Movement Index | SIMPLE |
| adx_stochastic | ADX trend filter with Stochastic Oscillator | MEDIUM |
| aroon_mfi | Aroon with Money Flow Index | MEDIUM |
| atr_cci | ATR volatility filter with CCI momentum | MEDIUM |
| awesome_oscillator | Awesome Oscillator zero-line crossover | SIMPLE |
| bband_williams_r | Bollinger Bands with Williams %R | MEDIUM |
| cmf_zero_line | Chaikin Money Flow zero-line crossover | SIMPLE |
| cmo_mfi | Chande Momentum Oscillator with MFI | MEDIUM |
| donchian_breakout | Donchian Channel breakout | SIMPLE |
| elder_ray_ma | Elder Ray with EMA | SIMPLE |
| ema_macd | EMA-based MACD strategy | SIMPLE |
| klinger_volume | Klinger Volume Oscillator with signal line | MEDIUM |
| mass_index | Mass Index reversal bulge strategy | MEDIUM |
| price_gap | Price Gap with EMA | SIMPLE |
| stochastic_rsi | Stochastic RSI strategy | MEDIUM |

## Test plan
- [ ] YAML files parse successfully
- [ ] Strategy configs follow established schema
- [ ] No build failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)