### PR TITLE
feat: add parameterMessageType field to StrategyConfig (#1506)

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/configurable/StrategyConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/configurable/StrategyConfig.java
@@ -16,6 +16,7 @@ public final class StrategyConfig implements Serializable {
   private String complexity;
   private String source;
   private String sourceStrategy;
+  private String parameterMessageType;
 
   private List<IndicatorConfig> indicators;
   private List<ConditionConfig> entryConditions;
@@ -30,6 +31,7 @@ public final class StrategyConfig implements Serializable {
       String complexity,
       String source,
       String sourceStrategy,
+      String parameterMessageType,
       List<IndicatorConfig> indicators,
       List<ConditionConfig> entryConditions,
       List<ConditionConfig> exitConditions,
@@ -39,6 +41,7 @@ public final class StrategyConfig implements Serializable {
     this.complexity = complexity;
     this.source = source;
     this.sourceStrategy = sourceStrategy;
+    this.parameterMessageType = parameterMessageType;
     this.indicators = indicators;
     this.entryConditions = entryConditions;
     this.exitConditions = exitConditions;
@@ -85,6 +88,14 @@ public final class StrategyConfig implements Serializable {
     this.sourceStrategy = sourceStrategy;
   }
 
+  public String getParameterMessageType() {
+    return parameterMessageType;
+  }
+
+  public void setParameterMessageType(String parameterMessageType) {
+    this.parameterMessageType = parameterMessageType;
+  }
+
   public List<IndicatorConfig> getIndicators() {
     return indicators;
   }
@@ -127,6 +138,7 @@ public final class StrategyConfig implements Serializable {
         && Objects.equals(complexity, that.complexity)
         && Objects.equals(source, that.source)
         && Objects.equals(sourceStrategy, that.sourceStrategy)
+        && Objects.equals(parameterMessageType, that.parameterMessageType)
         && Objects.equals(indicators, that.indicators)
         && Objects.equals(entryConditions, that.entryConditions)
         && Objects.equals(exitConditions, that.exitConditions)
@@ -141,6 +153,7 @@ public final class StrategyConfig implements Serializable {
         complexity,
         source,
         sourceStrategy,
+        parameterMessageType,
         indicators,
         entryConditions,
         exitConditions,
@@ -165,6 +178,9 @@ public final class StrategyConfig implements Serializable {
         + ", sourceStrategy='"
         + sourceStrategy
         + '\''
+        + ", parameterMessageType='"
+        + parameterMessageType
+        + '\''
         + ", indicators="
         + indicators
         + ", entryConditions="
@@ -186,6 +202,7 @@ public final class StrategyConfig implements Serializable {
     private String complexity;
     private String source;
     private String sourceStrategy;
+    private String parameterMessageType;
     private List<IndicatorConfig> indicators;
     private List<ConditionConfig> entryConditions;
     private List<ConditionConfig> exitConditions;
@@ -218,6 +235,11 @@ public final class StrategyConfig implements Serializable {
       return this;
     }
 
+    public Builder parameterMessageType(String parameterMessageType) {
+      this.parameterMessageType = parameterMessageType;
+      return this;
+    }
+
     public Builder indicators(List<IndicatorConfig> indicators) {
       this.indicators = indicators;
       return this;
@@ -245,6 +267,7 @@ public final class StrategyConfig implements Serializable {
           complexity,
           source,
           sourceStrategy,
+          parameterMessageType,
           indicators,
           entryConditions,
           exitConditions,

--- a/src/main/resources/strategies/chaikin_oscillator.yaml
+++ b/src/main/resources/strategies/chaikin_oscillator.yaml
@@ -3,6 +3,7 @@ description: Chaikin Oscillator crosses zero line
 complexity: SIMPLE
 source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.chaikinoscillator.ChaikinOscillatorStrategyFactory
+parameterMessageType: com.verlumen.tradestream.strategies.ChaikinOscillatorParameters
 
 indicators:
   - id: chaikin

--- a/src/main/resources/strategies/dema_tema_crossover.yaml
+++ b/src/main/resources/strategies/dema_tema_crossover.yaml
@@ -3,6 +3,7 @@ description: Double EMA crosses Triple EMA
 complexity: SIMPLE
 source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.dematemacrossover.DemaTemaCrossoverStrategyFactory
+parameterMessageType: com.verlumen.tradestream.strategies.DemaTemaCrossoverParameters
 
 indicators:
   - id: dema

--- a/src/main/resources/strategies/double_ema_crossover.yaml
+++ b/src/main/resources/strategies/double_ema_crossover.yaml
@@ -3,6 +3,7 @@ description: Short EMA crosses Long EMA
 complexity: SIMPLE
 source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.doubleemacrossover.DoubleEmaCrossoverStrategyFactory
+parameterMessageType: com.verlumen.tradestream.strategies.DoubleEmaCrossoverParameters
 
 indicators:
   - id: shortEma

--- a/src/main/resources/strategies/macd_crossover.yaml
+++ b/src/main/resources/strategies/macd_crossover.yaml
@@ -3,6 +3,7 @@ description: MACD crosses Signal Line
 complexity: SIMPLE
 source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.macdcrossover.MacdCrossoverStrategyFactory
+parameterMessageType: com.verlumen.tradestream.strategies.MacdCrossoverParameters
 
 indicators:
   - id: macd

--- a/src/main/resources/strategies/momentum_sma_crossover.yaml
+++ b/src/main/resources/strategies/momentum_sma_crossover.yaml
@@ -3,6 +3,7 @@ description: Momentum crosses its SMA
 complexity: SIMPLE
 source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.momentumsmacrossover.MomentumSmaCrossoverStrategyFactory
+parameterMessageType: com.verlumen.tradestream.strategies.MomentumSmaCrossoverParameters
 
 indicators:
   - id: momentum

--- a/src/main/resources/strategies/obv_ema.yaml
+++ b/src/main/resources/strategies/obv_ema.yaml
@@ -3,6 +3,7 @@ description: On Balance Volume crosses its EMA
 complexity: SIMPLE
 source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.obvema.ObvEmaStrategyFactory
+parameterMessageType: com.verlumen.tradestream.strategies.ObvEmaParameters
 
 indicators:
   - id: obv

--- a/src/main/resources/strategies/roc_ma_crossover.yaml
+++ b/src/main/resources/strategies/roc_ma_crossover.yaml
@@ -3,6 +3,7 @@ description: Rate of Change crosses its Moving Average
 complexity: SIMPLE
 source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.rocma.RocMaCrossoverStrategyFactory
+parameterMessageType: com.verlumen.tradestream.strategies.RocMaCrossoverParameters
 
 indicators:
   - id: roc

--- a/src/main/resources/strategies/rsi_ema_crossover.yaml
+++ b/src/main/resources/strategies/rsi_ema_crossover.yaml
@@ -3,6 +3,7 @@ description: RSI crosses its EMA with overbought/oversold filters
 complexity: SIMPLE
 source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.rsiemacrossover.RsiEmaCrossoverStrategyFactory
+parameterMessageType: com.verlumen.tradestream.strategies.RsiEmaCrossoverParameters
 
 indicators:
   - id: rsi

--- a/src/main/resources/strategies/sma_ema_crossover.yaml
+++ b/src/main/resources/strategies/sma_ema_crossover.yaml
@@ -3,6 +3,7 @@ description: Simple Moving Average crosses Exponential Moving Average
 complexity: SIMPLE
 source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.smaemacrossover.SmaEmaCrossoverStrategyFactory
+parameterMessageType: com.verlumen.tradestream.strategies.SmaEmaCrossoverParameters
 
 indicators:
   - id: sma

--- a/src/main/resources/strategies/triple_ema_crossover.yaml
+++ b/src/main/resources/strategies/triple_ema_crossover.yaml
@@ -3,6 +3,7 @@ description: Triple EMA crossover strategy using short, medium, and long periods
 complexity: MEDIUM
 source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.tripleemacrossover.TripleEmaCrossoverStrategyFactory
+parameterMessageType: com.verlumen.tradestream.strategies.TripleEmaCrossoverParameters
 
 indicators:
   - id: shortEma

--- a/src/test/java/com/verlumen/tradestream/strategies/configurable/StrategyConfigLoaderTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/configurable/StrategyConfigLoaderTest.java
@@ -15,6 +15,8 @@ public class StrategyConfigLoaderTest {
           + "source: MIGRATED\n"
           + "sourceStrategy:"
           + " com.verlum.tradestream.strategies.smaemacrossover.SmaEmaCrossoverStrategyFactory\n"
+          + "parameterMessageType:"
+          + " com.verlumen.tradestream.strategies.SmaEmaCrossoverParameters\n"
           + "\n"
           + "indicators:\n"
           + "  - id: sma\n"
@@ -62,6 +64,9 @@ public class StrategyConfigLoaderTest {
         "Simple Moving Average crosses Exponential Moving Average", config.getDescription());
     assertEquals("SIMPLE", config.getComplexity());
     assertEquals("MIGRATED", config.getSource());
+    assertEquals(
+        "com.verlumen.tradestream.strategies.SmaEmaCrossoverParameters",
+        config.getParameterMessageType());
   }
 
   @Test
@@ -164,6 +169,7 @@ public class StrategyConfigLoaderTest {
     assertEquals(original.getDescription(), restored.getDescription());
     assertEquals(original.getComplexity(), restored.getComplexity());
     assertEquals(original.getSource(), restored.getSource());
+    assertEquals(original.getParameterMessageType(), restored.getParameterMessageType());
     assertEquals(original.getIndicators().size(), restored.getIndicators().size());
     assertEquals(original.getEntryConditions().size(), restored.getEntryConditions().size());
     assertEquals(original.getExitConditions().size(), restored.getExitConditions().size());


### PR DESCRIPTION
## Summary
- Add `parameterMessageType` field to `StrategyConfig.java` for type-safe parameter deserialization
- Update all 10 strategy YAML files with correct proto message type references (e.g., `com.verlumen.tradestream.strategies.MacdCrossoverParameters`)
- Add unit tests for the new field parsing

## Root Cause
Part of Epic #1505 - Migration from static `StrategyType` enum to dynamic string-based strategy identification. The `parameterMessageType` field enables runtime type-safe deserialization of strategy parameters without relying on the hardcoded enum.

## Changes
| File | Change |
|------|--------|
| `StrategyConfig.java` | Added `parameterMessageType` field with getter/setter, builder support, equals/hashCode/toString |
| `*.yaml` (10 files) | Added `parameterMessageType` with fully qualified proto message class names |
| `StrategyConfigLoaderTest.java` | Added assertions for parameterMessageType parsing |

## Test plan
- [x] Unit tests pass (`bazel test //src/test/java/com/verlumen/tradestream/strategies/configurable:StrategyConfigLoaderTest`)
- [x] YAML parsing works with new field
- [x] JSON round-trip preserves parameterMessageType

Closes #1506

🤖 Generated with [Claude Code](https://claude.com/claude-code)