### PR TITLE
feat: add strategy_name field to Strategy proto message (#1508)

### DIFF
--- a/protos/strategies.proto
+++ b/protos/strategies.proto
@@ -8,8 +8,17 @@ option java_package = "com.verlumen.tradestream.strategies";
 import "google/protobuf/any.proto";
 
 message Strategy {
-  StrategyType type = 1;
+  // Deprecated: Use strategy_name instead for new code.
+  // Kept for backwards compatibility during migration.
+  StrategyType type = 1 [deprecated = true];
+
+  // Parameters for the strategy, type depends on strategy_name/type.
   google.protobuf.Any parameters = 2;
+
+  // String-based strategy identifier (e.g., "MACD_CROSSOVER").
+  // New code should use this field instead of the deprecated type enum.
+  // During migration, set both type and strategy_name for compatibility.
+  string strategy_name = 3;
 }
 
 enum StrategyType {


### PR DESCRIPTION
## Summary

- Adds `strategy_name` string field (field 3) to `Strategy` proto message
- Marks `type` enum field as deprecated with clear migration guidance
- Part of Phase 1 migration away from `StrategyType` enum (#1505)

## Changes

**Before:**
```protobuf
message Strategy {
  StrategyType type = 1;
  google.protobuf.Any parameters = 2;
}
```

**After:**
```protobuf
message Strategy {
  // Deprecated: Use strategy_name instead for new code.
  StrategyType type = 1 [deprecated = true];
  google.protobuf.Any parameters = 2;
  // String-based strategy identifier (e.g., "MACD_CROSSOVER")
  string strategy_name = 3;
}
```

## Migration Notes

- New code should set both `type` and `strategy_name` for backward compatibility
- Reading code should prefer `strategy_name` if present, fall back to `type.name()`
- After migration is complete, `type` can be removed in a future breaking change

## Test Plan

- [x] Proto compiles successfully
- [x] Java bindings generated with `getStrategyName()` / `setStrategyName()` methods
- [x] Deprecation warning shows for `type` field usage
- [x] All existing tests pass

Closes #1508

🤖 Generated with [Claude Code](https://claude.com/claude-code)