### PR TITLE
fix: use bitnamilegacy Docker images for Helm chart dependencies (#1530)

### DIFF
--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -1,3 +1,10 @@
+# Global settings - required for using bitnamilegacy images
+global:
+  security:
+    # Allow using bitnamilegacy images (Bitnami moved free images there)
+    # See: https://github.com/bitnami/charts/issues/30850
+    allowInsecureImages: true
+
 # Flink Kubernetes Operator - controls whether to install the operator as a dependency
 # Set to false if installing the operator separately (e.g., for webhook timing issues)
 flink-kubernetes-operator:


### PR DESCRIPTION
## Summary
- Bitnami moved public container images from `docker.io/bitnami` to `docker.io/bitnamilegacy`
- Updated Kafka, Redis, and PostgreSQL image configurations to use the legacy repository
- This unblocks CI's "Deploy and Test" step which was failing with `manifest unknown` errors

## Changes
| Service | Old Image | New Image |
|---------|-----------|-----------|
| Kafka | bitnami/kafka (chart default) | bitnamilegacy/kafka:4.0.0-debian-12-r10 |
| Redis | bitnami/redis (chart default) | bitnamilegacy/redis:8.2.1-debian-12-r0 |
| PostgreSQL | bitnami/postgresql:17 | bitnamilegacy/postgresql:17.6.0-debian-12-r4 |

## Root Cause
Bitnami discontinued hosting free container images at `docker.io/bitnami` and relocated them to `docker.io/bitnamilegacy`. See [bitnami/charts#36325](https://github.com/bitnami/charts/issues/36325).

## Test plan
- [ ] Helm lint passes
- [ ] CI Deploy and Test completes without image pull errors
- [ ] All pods start successfully with the new images

Closes #1530

🤖 Generated with [Claude Code](https://claude.com/claude-code)