### PR TITLE
refactor: remove deprecated source/sourceStrategy fields from StrategyConfig (#1524)

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/configurable/StrategyConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/configurable/StrategyConfig.java
@@ -14,8 +14,6 @@ public final class StrategyConfig implements Serializable {
   private String name;
   private String description;
   private String complexity;
-  private String source;
-  private String sourceStrategy;
   private String parameterMessageType;
 
   private List<IndicatorConfig> indicators;
@@ -29,8 +27,6 @@ public final class StrategyConfig implements Serializable {
       String name,
       String description,
       String complexity,
-      String source,
-      String sourceStrategy,
       String parameterMessageType,
       List<IndicatorConfig> indicators,
       List<ConditionConfig> entryConditions,
@@ -39,8 +35,6 @@ public final class StrategyConfig implements Serializable {
     this.name = name;
     this.description = description;
     this.complexity = complexity;
-    this.source = source;
-    this.sourceStrategy = sourceStrategy;
     this.parameterMessageType = parameterMessageType;
     this.indicators = indicators;
     this.entryConditions = entryConditions;
@@ -70,22 +64,6 @@ public final class StrategyConfig implements Serializable {
 
   public void setComplexity(String complexity) {
     this.complexity = complexity;
-  }
-
-  public String getSource() {
-    return source;
-  }
-
-  public void setSource(String source) {
-    this.source = source;
-  }
-
-  public String getSourceStrategy() {
-    return sourceStrategy;
-  }
-
-  public void setSourceStrategy(String sourceStrategy) {
-    this.sourceStrategy = sourceStrategy;
   }
 
   public String getParameterMessageType() {
@@ -136,8 +114,6 @@ public final class StrategyConfig implements Serializable {
     return Objects.equals(name, that.name)
         && Objects.equals(description, that.description)
         && Objects.equals(complexity, that.complexity)
-        && Objects.equals(source, that.source)
-        && Objects.equals(sourceStrategy, that.sourceStrategy)
         && Objects.equals(parameterMessageType, that.parameterMessageType)
         && Objects.equals(indicators, that.indicators)
         && Objects.equals(entryConditions, that.entryConditions)
@@ -151,8 +127,6 @@ public final class StrategyConfig implements Serializable {
         name,
         description,
         complexity,
-        source,
-        sourceStrategy,
         parameterMessageType,
         indicators,
         entryConditions,
@@ -171,12 +145,6 @@ public final class StrategyConfig implements Serializable {
         + '\''
         + ", complexity='"
         + complexity
-        + '\''
-        + ", source='"
-        + source
-        + '\''
-        + ", sourceStrategy='"
-        + sourceStrategy
         + '\''
         + ", parameterMessageType='"
         + parameterMessageType
@@ -200,8 +168,6 @@ public final class StrategyConfig implements Serializable {
     private String name;
     private String description;
     private String complexity;
-    private String source;
-    private String sourceStrategy;
     private String parameterMessageType;
     private List<IndicatorConfig> indicators;
     private List<ConditionConfig> entryConditions;
@@ -222,16 +188,6 @@ public final class StrategyConfig implements Serializable {
 
     public Builder complexity(String complexity) {
       this.complexity = complexity;
-      return this;
-    }
-
-    public Builder source(String source) {
-      this.source = source;
-      return this;
-    }
-
-    public Builder sourceStrategy(String sourceStrategy) {
-      this.sourceStrategy = sourceStrategy;
       return this;
     }
 
@@ -265,8 +221,6 @@ public final class StrategyConfig implements Serializable {
           name,
           description,
           complexity,
-          source,
-          sourceStrategy,
           parameterMessageType,
           indicators,
           entryConditions,

--- a/src/test/java/com/verlumen/tradestream/strategies/StrategyRegistryTest.kt
+++ b/src/test/java/com/verlumen/tradestream/strategies/StrategyRegistryTest.kt
@@ -124,7 +124,6 @@ class StrategyRegistryTest {
             .name(name)
             .description("Test strategy $name")
             .complexity("SIMPLE")
-            .source("TEST")
             .indicators(emptyList())
             .entryConditions(emptyList())
             .exitConditions(emptyList())

--- a/src/test/java/com/verlumen/tradestream/strategies/configurable/ConfigBasedVsHardcodedValidationTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/configurable/ConfigBasedVsHardcodedValidationTest.java
@@ -65,7 +65,6 @@ public class ConfigBasedVsHardcodedValidationTest {
             .name("SMA_EMA_CROSSOVER_CONFIG")
             .description("Config-based SMA/EMA crossover for validation")
             .complexity("SIMPLE")
-            .source("CONFIG")
             .indicators(
                 List.of(
                     IndicatorConfig.builder()
@@ -168,7 +167,6 @@ public class ConfigBasedVsHardcodedValidationTest {
         "name: SMA_EMA_CROSSOVER\n"
             + "description: SMA crosses EMA\n"
             + "complexity: SIMPLE\n"
-            + "source: MIGRATED\n"
             + "\n"
             + "indicators:\n"
             + "  - id: sma\n"

--- a/src/test/java/com/verlumen/tradestream/strategies/configurable/ConfigurableStrategyFactoryTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/configurable/ConfigurableStrategyFactoryTest.java
@@ -46,7 +46,6 @@ public class ConfigurableStrategyFactoryTest {
             .name("SMA_EMA_CROSSOVER_CONFIG")
             .description("SMA crosses EMA - config based")
             .complexity("SIMPLE")
-            .source("CONFIG")
             .indicators(
                 List.of(
                     IndicatorConfig.builder()
@@ -121,7 +120,6 @@ public class ConfigurableStrategyFactoryTest {
             .name("RSI_OVERSOLD_OVERBOUGHT")
             .description("Buy when RSI oversold, sell when overbought")
             .complexity("SIMPLE")
-            .source("CONFIG")
             .indicators(
                 List.of(
                     IndicatorConfig.builder()
@@ -171,7 +169,6 @@ public class ConfigurableStrategyFactoryTest {
             .name("MACD_CROSSOVER_CONFIG")
             .description("MACD crosses signal line")
             .complexity("MEDIUM")
-            .source("CONFIG")
             .indicators(
                 List.of(
                     IndicatorConfig.builder()
@@ -243,7 +240,6 @@ public class ConfigurableStrategyFactoryTest {
             .name("CUSTOM_PARAM_TEST")
             .description("Test custom parameters")
             .complexity("SIMPLE")
-            .source("CONFIG")
             .indicators(
                 List.of(
                     IndicatorConfig.builder()

--- a/src/test/java/com/verlumen/tradestream/strategies/configurable/StrategyConfigLoaderTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/configurable/StrategyConfigLoaderTest.java
@@ -12,9 +12,6 @@ public class StrategyConfigLoaderTest {
       "name: SMA_EMA_CROSSOVER\n"
           + "description: Simple Moving Average crosses Exponential Moving Average\n"
           + "complexity: SIMPLE\n"
-          + "source: MIGRATED\n"
-          + "sourceStrategy:"
-          + " com.verlum.tradestream.strategies.smaemacrossover.SmaEmaCrossoverStrategyFactory\n"
           + "parameterMessageType:"
           + " com.verlumen.tradestream.strategies.SmaEmaCrossoverParameters\n"
           + "\n"
@@ -63,7 +60,6 @@ public class StrategyConfigLoaderTest {
     assertEquals(
         "Simple Moving Average crosses Exponential Moving Average", config.getDescription());
     assertEquals("SIMPLE", config.getComplexity());
-    assertEquals("MIGRATED", config.getSource());
     assertEquals(
         "com.verlumen.tradestream.strategies.SmaEmaCrossoverParameters",
         config.getParameterMessageType());
@@ -143,8 +139,7 @@ public class StrategyConfigLoaderTest {
         "{"
             + "\"name\": \"SMA_EMA_CROSSOVER\","
             + "\"description\": \"Simple Moving Average crosses Exponential Moving Average\","
-            + "\"complexity\": \"SIMPLE\","
-            + "\"source\": \"MIGRATED\""
+            + "\"complexity\": \"SIMPLE\""
             + "}";
 
     StrategyConfig config = StrategyConfigLoader.parseJson(jsonContent);
@@ -154,7 +149,6 @@ public class StrategyConfigLoaderTest {
     assertEquals(
         "Simple Moving Average crosses Exponential Moving Average", config.getDescription());
     assertEquals("SIMPLE", config.getComplexity());
-    assertEquals("MIGRATED", config.getSource());
   }
 
   @Test
@@ -168,7 +162,6 @@ public class StrategyConfigLoaderTest {
     assertEquals(original.getName(), restored.getName());
     assertEquals(original.getDescription(), restored.getDescription());
     assertEquals(original.getComplexity(), restored.getComplexity());
-    assertEquals(original.getSource(), restored.getSource());
     assertEquals(original.getParameterMessageType(), restored.getParameterMessageType());
     assertEquals(original.getIndicators().size(), restored.getIndicators().size());
     assertEquals(original.getEntryConditions().size(), restored.getEntryConditions().size());


### PR DESCRIPTION
## Summary
- Remove deprecated `source` and `sourceStrategy` fields from `StrategyConfig.java`
- These were migration artifacts that served no functional purpose
- No code reads these fields - getters existed but were never called
- YAML files don't need to reference the original Java factories

## Changes
- Remove field declarations, getters/setters, constructor parameters
- Update `equals()`, `hashCode()`, `toString()`
- Remove Builder methods
- Update all test files to remove `.source()` calls and assertions

## Test plan
- [x] All 125 strategy tests pass locally
- [x] Bazel build succeeds
- [x] No remaining references to source/sourceStrategy

Closes #1524

🤖 Generated with [Claude Code](https://claude.com/claude-code)