### PR TITLE
refactor: update GAEngineFactory to use string-based strategy lookup (#1512)

### DIFF
--- a/src/main/java/com/verlumen/tradestream/discovery/GAEngineFactoryImpl.java
+++ b/src/main/java/com/verlumen/tradestream/discovery/GAEngineFactoryImpl.java
@@ -2,7 +2,7 @@ package com.verlumen.tradestream.discovery;
 
 import com.google.inject.Inject;
 import com.verlumen.tradestream.strategies.StrategySpec;
-import com.verlumen.tradestream.strategies.StrategySpecsKt;
+import com.verlumen.tradestream.strategies.StrategySpecs;
 import io.jenetics.Chromosome;
 import io.jenetics.DoubleChromosome;
 import io.jenetics.Genotype;
@@ -33,7 +33,7 @@ final class GAEngineFactoryImpl implements GAEngineFactory {
 
     // Build and return the GA engine with the specified settings
     return Engine.builder(
-            fitnessFunctionFactory.create(params.getStrategyType(), params.getCandlesList()), gtf)
+            fitnessFunctionFactory.create(params.getStrategyName(), params.getCandlesList()), gtf)
         .populationSize(getPopulationSize(params))
         .selector(new TournamentSelector<>(GAConstants.TOURNAMENT_SIZE))
         .alterers(
@@ -50,14 +50,14 @@ final class GAEngineFactoryImpl implements GAEngineFactory {
    */
   private Genotype<?> createGenotype(GAEngineParams params) {
     try {
-      StrategySpec spec = StrategySpecsKt.getSpec(params.getStrategyType());
+      StrategySpec spec = StrategySpecs.getSpec(params.getStrategyName());
       ParamConfig config = spec.getParamConfig();
 
       // Get the chromosomes from the parameter configuration
       List<? extends NumericChromosome<?, ?>> numericChromosomes = config.initialChromosomes();
 
       if (numericChromosomes.isEmpty()) {
-        logger.warning("No chromosomes defined for strategy type: " + params.getStrategyType());
+        logger.warning("No chromosomes defined for strategy: " + params.getStrategyName());
         return Genotype.of(DoubleChromosome.of(0.0, 1.0));
       }
 
@@ -102,8 +102,8 @@ final class GAEngineFactoryImpl implements GAEngineFactory {
       }
     } catch (Exception e) {
       logger.warning(
-          "Error creating genotype for strategy type "
-              + params.getStrategyType()
+          "Error creating genotype for strategy "
+              + params.getStrategyName()
               + ": "
               + e.getMessage());
       // Fallback to a simple genotype with a single chromosome

--- a/src/main/java/com/verlumen/tradestream/discovery/GAEngineParams.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/GAEngineParams.kt
@@ -5,11 +5,19 @@ import com.verlumen.tradestream.strategies.StrategyType
 import java.io.Serializable
 
 data class GAEngineParams(
-    val strategyType: StrategyType,
+    val strategyName: String,
     val candlesList: List<Candle>,
     val populationSize: Int,
 ) : Serializable {
     companion object {
         private const val serialVersionUID = 1L
     }
+
+    /**
+     * Gets the strategy type from the strategy name.
+     * @deprecated Use [strategyName] directly instead
+     */
+    @Deprecated("Use strategyName directly")
+    val strategyType: StrategyType
+        get() = StrategyType.valueOf(strategyName)
 }

--- a/src/main/java/com/verlumen/tradestream/discovery/RunGADiscoveryFn.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/RunGADiscoveryFn.kt
@@ -65,10 +65,10 @@ class RunGADiscoveryFn :
             return
         }
 
-        // 2) Build GAEngineParams
+        // 2) Build GAEngineParams using string-based strategy name
         val engineParams =
             GAEngineParams(
-                strategyType = discoveryRequest.strategyType,
+                strategyName = discoveryRequest.strategyType.name,
                 candlesList = candles,
                 populationSize = discoveryRequest.gaConfig.populationSize,
             )

--- a/src/test/java/com/verlumen/tradestream/discovery/GAEngineFactoryImplTest.java
+++ b/src/test/java/com/verlumen/tradestream/discovery/GAEngineFactoryImplTest.java
@@ -11,7 +11,6 @@ import com.google.inject.Inject;
 import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import com.verlumen.tradestream.marketdata.Candle;
-import com.verlumen.tradestream.strategies.StrategyType;
 import io.jenetics.Genotype;
 import io.jenetics.engine.Engine;
 import java.util.List;
@@ -38,10 +37,10 @@ public class GAEngineFactoryImplTest {
 
   @Before
   public void setUp() {
-    // Setup a basic test request using GAEngineParams
+    // Setup a basic test request using GAEngineParams with string-based strategy name
     testParams =
         new GAEngineParams(
-            StrategyType.SMA_RSI,
+            "SMA_RSI",
             ImmutableList.of(Candle.newBuilder().build()), // Add a dummy candle list
             20);
 
@@ -52,7 +51,7 @@ public class GAEngineFactoryImplTest {
     // This is critical - create should never return null
     Function<Genotype<?>, Double> dummyFunction =
         genotype -> 1.0; // Just return a constant value for testing
-    when(mockFitnessFunctionFactory.create(any(StrategyType.class), any(List.class)))
+    when(mockFitnessFunctionFactory.create(any(String.class), any(List.class)))
         .thenReturn(dummyFunction);
 
     // Inject dependencies
@@ -75,7 +74,7 @@ public class GAEngineFactoryImplTest {
     // Arrange
     int customSize = 42;
     GAEngineParams customParams =
-        new GAEngineParams(testParams.getStrategyType(), testParams.getCandlesList(), customSize);
+        new GAEngineParams(testParams.getStrategyName(), testParams.getCandlesList(), customSize);
 
     // Act
     Engine<?, Double> engine = engineFactory.createEngine(customParams);
@@ -90,7 +89,7 @@ public class GAEngineFactoryImplTest {
   public void createEngine_withZeroPopulationSize_usesDefaultSize() {
     // Arrange
     GAEngineParams zeroSizeParams =
-        new GAEngineParams(testParams.getStrategyType(), testParams.getCandlesList(), 0);
+        new GAEngineParams(testParams.getStrategyName(), testParams.getCandlesList(), 0);
 
     // Act
     Engine<?, Double> engine = engineFactory.createEngine(zeroSizeParams);


### PR DESCRIPTION
## Summary
- Migrate `GAEngineParams` to use `strategyName: String` instead of `StrategyType` enum
- Add deprecated `strategyType` property for backwards compatibility
- Update `GAEngineFactoryImpl` to use string-based APIs
- Update all call sites

## Changes
- `GAEngineParams.kt` - primary field is now `strategyName: String`
- `GAEngineFactoryImpl.java` - uses `StrategySpecs.getSpec(strategyName)`
- `RunGADiscoveryFn.kt` - passes `strategyType.name` as `strategyName`
- `GAEngineFactoryImplTest.java` - updated to use string-based params

## Test plan
- [x] All 12 discovery tests pass
- [x] Bazel build succeeds
- [x] No breaking changes (deprecated property maintains backwards compatibility)

This completes Phase 2.4 of Epic #1505 (Remove StrategyType Enum).

Closes #1512

🤖 Generated with [Claude Code](https://claude.com/claude-code)