### PR TITLE
fix: migrate PostgresStrategyRepository to string-based strategy names (#1514)

### DIFF
--- a/src/main/java/com/verlumen/tradestream/discovery/PostgresStrategyRepository.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/PostgresStrategyRepository.kt
@@ -150,15 +150,12 @@ class PostgresStrategyRepository
                 com.google.protobuf.Any
                     .parseFrom(bytes)
 
-            // Build Strategy proto
+            // Build Strategy proto using string-based strategy name
             val strategy =
                 com.verlumen.tradestream.strategies.Strategy
                     .newBuilder()
-                    .setTypeValue(
-                        com.verlumen.tradestream.strategies.StrategyType
-                            .valueOf(strategyType)
-                            .number,
-                    ).setParameters(parametersAny)
+                    .setStrategyName(strategyType)
+                    .setParameters(parametersAny)
                     .build()
 
             // Build DiscoveredStrategy proto

--- a/src/main/java/com/verlumen/tradestream/discovery/StrategyCsvUtil.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/StrategyCsvUtil.kt
@@ -18,9 +18,13 @@ object StrategyCsvUtil {
                     "SHA-256",
                 ).digest(parametersAny.toByteArray())
                 .joinToString("") { "%02x".format(it) }
+
+        // Prefer strategyName if set, fall back to type.name for backwards compatibility
+        val strategyName = element.strategy.strategyName.ifEmpty { element.strategy.type.name }
+
         return listOf(
             element.symbol,
-            element.strategy.type.name,
+            strategyName,
             wrappedJson,
             element.score.toString(),
             hash,

--- a/src/test/java/com/verlumen/tradestream/discovery/PostgresStrategyRepositoryTest.kt
+++ b/src/test/java/com/verlumen/tradestream/discovery/PostgresStrategyRepositoryTest.kt
@@ -7,7 +7,6 @@ import com.verlumen.tradestream.sql.BulkCopierFactory
 import com.verlumen.tradestream.sql.DataSourceConfig
 import com.verlumen.tradestream.sql.DataSourceFactory
 import com.verlumen.tradestream.strategies.Strategy
-import com.verlumen.tradestream.strategies.StrategyType
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.doNothing
@@ -64,7 +63,7 @@ class PostgresStrategyRepositoryTest {
         val strategy =
             Strategy
                 .newBuilder()
-                .setType(StrategyType.SMA_RSI)
+                .setStrategyName("SMA_RSI")
                 .setParameters(Any.getDefaultInstance())
                 .build()
         val discovered =


### PR DESCRIPTION
## Summary
- Replace `setTypeValue()` with `setStrategyName()` in Strategy.Builder
- Update `StrategyCsvUtil` to prefer `strategyName` over deprecated type enum
- Update tests to use string-based strategy names

## Root Cause
Part of the StrategyType enum removal epic (#1505). The PostgresStrategyRepository and related utilities were still using the deprecated enum-based API.

## Test plan
- [x] PostgresStrategyRepositoryTest passes
- [ ] CI checks pass

Closes #1514

🤖 Generated with [Claude Code](https://claude.com/claude-code)