### PR TITLE
fix: add missing parameterMessageType to strategy YAML files

### DIFF
--- a/src/main/resources/strategies/adx_dmi.yaml
+++ b/src/main/resources/strategies/adx_dmi.yaml
@@ -3,6 +3,7 @@ description: ADX with Directional Movement Index - trades strong trends when +DI
 complexity: SIMPLE
 source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.adxdmi.AdxDmiStrategyFactory
+parameterMessageType: com.verlumen.tradestream.strategies.AdxDmiParameters
 
 indicators:
   - id: adx

--- a/src/main/resources/strategies/adx_stochastic.yaml
+++ b/src/main/resources/strategies/adx_stochastic.yaml
@@ -3,6 +3,7 @@ description: ADX trend filter with Stochastic Oscillator - enters on strong tren
 complexity: SIMPLE
 source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.adxstochastic.AdxStochasticStrategyFactory
+parameterMessageType: com.verlumen.tradestream.strategies.AdxStochasticParameters
 
 indicators:
   - id: adx

--- a/src/main/resources/strategies/aroon_mfi.yaml
+++ b/src/main/resources/strategies/aroon_mfi.yaml
@@ -3,6 +3,7 @@ description: Aroon with Money Flow Index - enters on Aroon Up crossing Down when
 complexity: MEDIUM
 source: MIGRATED
 sourceStrategy: com.verlumen.tradestream.strategies.aroonmfi.AroonMfiStrategyFactory
+parameterMessageType: com.verlumen.tradestream.strategies.AroonMfiParameters
 
 indicators:
   - id: aroonUp

--- a/src/main/resources/strategies/atr_cci.yaml
+++ b/src/main/resources/strategies/atr_cci.yaml
@@ -3,6 +3,7 @@ description: ATR volatility filter with CCI momentum - enters when CCI oversold 
 complexity: SIMPLE
 source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.atrcci.AtrCciStrategyFactory
+parameterMessageType: com.verlumen.tradestream.strategies.AtrCciParameters
 
 indicators:
   - id: atr

--- a/src/main/resources/strategies/awesome_oscillator.yaml
+++ b/src/main/resources/strategies/awesome_oscillator.yaml
@@ -3,6 +3,7 @@ description: Awesome Oscillator zero-line crossover - enters when AO crosses abo
 complexity: SIMPLE
 source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.awesomeoscillator.AwesomeOscillatorStrategyFactory
+parameterMessageType: com.verlumen.tradestream.strategies.AwesomeOscillatorParameters
 
 indicators:
   - id: ao

--- a/src/main/resources/strategies/bband_williams_r.yaml
+++ b/src/main/resources/strategies/bband_williams_r.yaml
@@ -3,6 +3,7 @@ description: Bollinger Bands with Williams %R - enters at lower band when overso
 complexity: MEDIUM
 source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.bbandwr.BbandWRStrategyFactory
+parameterMessageType: com.verlumen.tradestream.strategies.BbandWRParameters
 
 indicators:
   - id: closePrice

--- a/src/main/resources/strategies/cmf_zero_line.yaml
+++ b/src/main/resources/strategies/cmf_zero_line.yaml
@@ -3,6 +3,7 @@ description: Chaikin Money Flow zero-line crossover - enters when CMF crosses ab
 complexity: SIMPLE
 source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.cmfzeroline.CmfZeroLineStrategyFactory
+parameterMessageType: com.verlumen.tradestream.strategies.CmfZeroLineParameters
 
 indicators:
   - id: cmf

--- a/src/main/resources/strategies/cmo_mfi.yaml
+++ b/src/main/resources/strategies/cmo_mfi.yaml
@@ -2,7 +2,8 @@ name: CMO_MFI
 description: Chande Momentum Oscillator with Money Flow Index - momentum and volume confirmation
 complexity: MEDIUM
 source: MIGRATED
-sourceStrategy: com.verlumen.tradestream.strategies.cmomfi.CmoMfiStrategyFactory
+sourceStrategy: com.verlum.tradestream.strategies.cmomfi.CmoMfiStrategyFactory
+parameterMessageType: com.verlumen.tradestream.strategies.CmoMfiParameters
 
 indicators:
   - id: cmo

--- a/src/main/resources/strategies/donchian_breakout.yaml
+++ b/src/main/resources/strategies/donchian_breakout.yaml
@@ -3,6 +3,7 @@ description: Donchian Channel breakout - enters when price breaks above highest 
 complexity: SIMPLE
 source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.donchianbreakout.DonchianBreakoutStrategyFactory
+parameterMessageType: com.verlumen.tradestream.strategies.DonchianBreakoutParameters
 
 indicators:
   - id: closePrice

--- a/src/main/resources/strategies/elder_ray_ma.yaml
+++ b/src/main/resources/strategies/elder_ray_ma.yaml
@@ -3,6 +3,7 @@ description: Elder Ray with EMA - enters when Bull Power crosses above zero
 complexity: SIMPLE
 source: MIGRATED
 sourceStrategy: com.verlumen.tradestream.strategies.elderrayma.ElderRayMAStrategyFactory
+parameterMessageType: com.verlumen.tradestream.strategies.ElderRayMAParameters
 
 indicators:
   - id: closePrice

--- a/src/main/resources/strategies/ema_macd.yaml
+++ b/src/main/resources/strategies/ema_macd.yaml
@@ -3,6 +3,7 @@ description: EMA-based MACD - enters when MACD crosses above signal line
 complexity: SIMPLE
 source: MIGRATED
 sourceStrategy: com.verlumen.tradestream.strategies.emamacd.EmaMacdStrategyFactory
+parameterMessageType: com.verlumen.tradestream.strategies.EmaMacdParameters
 
 indicators:
   - id: macd

--- a/src/main/resources/strategies/klinger_volume.yaml
+++ b/src/main/resources/strategies/klinger_volume.yaml
@@ -3,6 +3,7 @@ description: Klinger Volume Oscillator with signal line - volume-based trend ind
 complexity: MEDIUM
 source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.klingervolume.KlingerVolumeStrategyFactory
+parameterMessageType: com.verlumen.tradestream.strategies.KlingerVolumeParameters
 
 indicators:
   - id: kvo

--- a/src/main/resources/strategies/mass_index.yaml
+++ b/src/main/resources/strategies/mass_index.yaml
@@ -3,6 +3,7 @@ description: Mass Index reversal bulge strategy - identifies trend reversals via
 complexity: MEDIUM
 source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.massindex.MassIndexStrategyFactory
+parameterMessageType: com.verlumen.tradestream.strategies.MassIndexParameters
 
 indicators:
   - id: massIndex

--- a/src/main/resources/strategies/price_gap.yaml
+++ b/src/main/resources/strategies/price_gap.yaml
@@ -3,6 +3,7 @@ description: Price Gap with EMA - enters when price crosses above EMA
 complexity: SIMPLE
 source: MIGRATED
 sourceStrategy: com.verlumen.tradestream.strategies.pricegap.PriceGapStrategyFactory
+parameterMessageType: com.verlumen.tradestream.strategies.PriceGapParameters
 
 indicators:
   - id: closePrice

--- a/src/main/resources/strategies/stochastic_rsi.yaml
+++ b/src/main/resources/strategies/stochastic_rsi.yaml
@@ -3,6 +3,7 @@ description: Stochastic RSI - enters when oversold, exits when overbought
 complexity: MEDIUM
 source: MIGRATED
 sourceStrategy: com.verlumen.tradestream.strategies.stochasticsrsi.StochasticRsiStrategyFactory
+parameterMessageType: com.verlumen.tradestream.strategies.StochasticRsiParameters
 
 indicators:
   - id: rsi


### PR DESCRIPTION
## Summary
- Added `parameterMessageType` field to 15 YAML strategy config files that were missing it
- This ensures all strategies have proper type information for parameter serialization

## Files Updated
- adx_dmi.yaml (AdxDmiParameters)
- adx_stochastic.yaml (AdxStochasticParameters)
- aroon_mfi.yaml (AroonMfiParameters)
- atr_cci.yaml (AtrCciParameters)
- awesome_oscillator.yaml (AwesomeOscillatorParameters)
- bband_williams_r.yaml (BbandWRParameters)
- cmf_zero_line.yaml (CmfZeroLineParameters)
- cmo_mfi.yaml (CmoMfiParameters)
- donchian_breakout.yaml (DonchianBreakoutParameters)
- elder_ray_ma.yaml (ElderRayMAParameters)
- ema_macd.yaml (EmaMacdParameters)
- klinger_volume.yaml (KlingerVolumeParameters)
- mass_index.yaml (MassIndexParameters)
- price_gap.yaml (PriceGapParameters)
- stochastic_rsi.yaml (StochasticRsiParameters)

## Analysis
Audit of strategies.proto found:
- **61 total parameter message types** defined
- **All are in use** by hardcoded Java strategy factories
- **10 were previously referenced** by YAML config files (now 25 with this PR)
- **No orphaned parameter messages** found

Decision: Keep all parameter messages (Option A from issue) as they provide type safety and schema documentation.

## Test plan
- [x] All 125 strategy tests pass
- [x] Build succeeds

Fixes #1519

🤖 Generated with [Claude Code](https://claude.com/claude-code)