### PR TITLE
refactor: remove deprecated source field from strategy YAML files

### DIFF
--- a/src/main/resources/strategies/adx_dmi.yaml
+++ b/src/main/resources/strategies/adx_dmi.yaml
@@ -1,7 +1,6 @@
 name: ADX_DMI
 description: ADX with Directional Movement Index - trades strong trends when +DI crosses -DI
 complexity: SIMPLE
-source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.adxdmi.AdxDmiStrategyFactory
 parameterMessageType: com.verlumen.tradestream.strategies.AdxDmiParameters
 

--- a/src/main/resources/strategies/adx_stochastic.yaml
+++ b/src/main/resources/strategies/adx_stochastic.yaml
@@ -1,7 +1,6 @@
 name: ADX_STOCHASTIC
 description: ADX trend filter with Stochastic Oscillator - enters on strong trends when oversold
 complexity: SIMPLE
-source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.adxstochastic.AdxStochasticStrategyFactory
 parameterMessageType: com.verlumen.tradestream.strategies.AdxStochasticParameters
 

--- a/src/main/resources/strategies/aroon_mfi.yaml
+++ b/src/main/resources/strategies/aroon_mfi.yaml
@@ -1,7 +1,6 @@
 name: AROON_MFI
 description: Aroon with Money Flow Index - enters on Aroon Up crossing Down when oversold
 complexity: MEDIUM
-source: MIGRATED
 sourceStrategy: com.verlumen.tradestream.strategies.aroonmfi.AroonMfiStrategyFactory
 parameterMessageType: com.verlumen.tradestream.strategies.AroonMfiParameters
 

--- a/src/main/resources/strategies/atr_cci.yaml
+++ b/src/main/resources/strategies/atr_cci.yaml
@@ -1,7 +1,6 @@
 name: ATR_CCI
 description: ATR volatility filter with CCI momentum - enters when CCI oversold and volatility rising
 complexity: SIMPLE
-source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.atrcci.AtrCciStrategyFactory
 parameterMessageType: com.verlumen.tradestream.strategies.AtrCciParameters
 

--- a/src/main/resources/strategies/awesome_oscillator.yaml
+++ b/src/main/resources/strategies/awesome_oscillator.yaml
@@ -1,7 +1,6 @@
 name: AWESOME_OSCILLATOR
 description: Awesome Oscillator zero-line crossover - enters when AO crosses above zero
 complexity: SIMPLE
-source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.awesomeoscillator.AwesomeOscillatorStrategyFactory
 parameterMessageType: com.verlumen.tradestream.strategies.AwesomeOscillatorParameters
 

--- a/src/main/resources/strategies/bband_williams_r.yaml
+++ b/src/main/resources/strategies/bband_williams_r.yaml
@@ -1,7 +1,6 @@
 name: BBAND_WILLIAMS_R
 description: Bollinger Bands with Williams %R - enters at lower band when oversold
 complexity: MEDIUM
-source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.bbandwr.BbandWRStrategyFactory
 parameterMessageType: com.verlumen.tradestream.strategies.BbandWRParameters
 

--- a/src/main/resources/strategies/chaikin_oscillator.yaml
+++ b/src/main/resources/strategies/chaikin_oscillator.yaml
@@ -1,7 +1,6 @@
 name: CHAIKIN_OSCILLATOR
 description: Chaikin Oscillator crosses zero line
 complexity: SIMPLE
-source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.chaikinoscillator.ChaikinOscillatorStrategyFactory
 parameterMessageType: com.verlumen.tradestream.strategies.ChaikinOscillatorParameters
 

--- a/src/main/resources/strategies/cmf_zero_line.yaml
+++ b/src/main/resources/strategies/cmf_zero_line.yaml
@@ -1,7 +1,6 @@
 name: CMF_ZERO_LINE
 description: Chaikin Money Flow zero-line crossover - enters when CMF crosses above zero
 complexity: SIMPLE
-source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.cmfzeroline.CmfZeroLineStrategyFactory
 parameterMessageType: com.verlumen.tradestream.strategies.CmfZeroLineParameters
 

--- a/src/main/resources/strategies/cmo_mfi.yaml
+++ b/src/main/resources/strategies/cmo_mfi.yaml
@@ -1,7 +1,6 @@
 name: CMO_MFI
 description: Chande Momentum Oscillator with Money Flow Index - momentum and volume confirmation
 complexity: MEDIUM
-source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.cmomfi.CmoMfiStrategyFactory
 parameterMessageType: com.verlumen.tradestream.strategies.CmoMfiParameters
 

--- a/src/main/resources/strategies/dema_tema_crossover.yaml
+++ b/src/main/resources/strategies/dema_tema_crossover.yaml
@@ -1,7 +1,6 @@
 name: DEMA_TEMA_CROSSOVER
 description: Double EMA crosses Triple EMA
 complexity: SIMPLE
-source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.dematemacrossover.DemaTemaCrossoverStrategyFactory
 parameterMessageType: com.verlumen.tradestream.strategies.DemaTemaCrossoverParameters
 

--- a/src/main/resources/strategies/donchian_breakout.yaml
+++ b/src/main/resources/strategies/donchian_breakout.yaml
@@ -1,7 +1,6 @@
 name: DONCHIAN_BREAKOUT
 description: Donchian Channel breakout - enters when price breaks above highest high
 complexity: SIMPLE
-source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.donchianbreakout.DonchianBreakoutStrategyFactory
 parameterMessageType: com.verlumen.tradestream.strategies.DonchianBreakoutParameters
 

--- a/src/main/resources/strategies/double_ema_crossover.yaml
+++ b/src/main/resources/strategies/double_ema_crossover.yaml
@@ -1,7 +1,6 @@
 name: DOUBLE_EMA_CROSSOVER
 description: Short EMA crosses Long EMA
 complexity: SIMPLE
-source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.doubleemacrossover.DoubleEmaCrossoverStrategyFactory
 parameterMessageType: com.verlumen.tradestream.strategies.DoubleEmaCrossoverParameters
 

--- a/src/main/resources/strategies/elder_ray_ma.yaml
+++ b/src/main/resources/strategies/elder_ray_ma.yaml
@@ -1,7 +1,6 @@
 name: ELDER_RAY_MA
 description: Elder Ray with EMA - enters when Bull Power crosses above zero
 complexity: SIMPLE
-source: MIGRATED
 sourceStrategy: com.verlumen.tradestream.strategies.elderrayma.ElderRayMAStrategyFactory
 parameterMessageType: com.verlumen.tradestream.strategies.ElderRayMAParameters
 

--- a/src/main/resources/strategies/ema_macd.yaml
+++ b/src/main/resources/strategies/ema_macd.yaml
@@ -1,7 +1,6 @@
 name: EMA_MACD
 description: EMA-based MACD - enters when MACD crosses above signal line
 complexity: SIMPLE
-source: MIGRATED
 sourceStrategy: com.verlumen.tradestream.strategies.emamacd.EmaMacdStrategyFactory
 parameterMessageType: com.verlumen.tradestream.strategies.EmaMacdParameters
 

--- a/src/main/resources/strategies/klinger_volume.yaml
+++ b/src/main/resources/strategies/klinger_volume.yaml
@@ -1,7 +1,6 @@
 name: KLINGER_VOLUME
 description: Klinger Volume Oscillator with signal line - volume-based trend indicator
 complexity: MEDIUM
-source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.klingervolume.KlingerVolumeStrategyFactory
 parameterMessageType: com.verlumen.tradestream.strategies.KlingerVolumeParameters
 

--- a/src/main/resources/strategies/macd_crossover.yaml
+++ b/src/main/resources/strategies/macd_crossover.yaml
@@ -1,7 +1,6 @@
 name: MACD_CROSSOVER
 description: MACD crosses Signal Line
 complexity: SIMPLE
-source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.macdcrossover.MacdCrossoverStrategyFactory
 parameterMessageType: com.verlumen.tradestream.strategies.MacdCrossoverParameters
 

--- a/src/main/resources/strategies/mass_index.yaml
+++ b/src/main/resources/strategies/mass_index.yaml
@@ -1,7 +1,6 @@
 name: MASS_INDEX
 description: Mass Index reversal bulge strategy - identifies trend reversals via range expansion
 complexity: MEDIUM
-source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.massindex.MassIndexStrategyFactory
 parameterMessageType: com.verlumen.tradestream.strategies.MassIndexParameters
 

--- a/src/main/resources/strategies/momentum_sma_crossover.yaml
+++ b/src/main/resources/strategies/momentum_sma_crossover.yaml
@@ -1,7 +1,6 @@
 name: MOMENTUM_SMA_CROSSOVER
 description: Momentum crosses its SMA
 complexity: SIMPLE
-source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.momentumsmacrossover.MomentumSmaCrossoverStrategyFactory
 parameterMessageType: com.verlumen.tradestream.strategies.MomentumSmaCrossoverParameters
 

--- a/src/main/resources/strategies/obv_ema.yaml
+++ b/src/main/resources/strategies/obv_ema.yaml
@@ -1,7 +1,6 @@
 name: OBV_EMA
 description: On Balance Volume crosses its EMA
 complexity: SIMPLE
-source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.obvema.ObvEmaStrategyFactory
 parameterMessageType: com.verlumen.tradestream.strategies.ObvEmaParameters
 

--- a/src/main/resources/strategies/price_gap.yaml
+++ b/src/main/resources/strategies/price_gap.yaml
@@ -1,7 +1,6 @@
 name: PRICE_GAP
 description: Price Gap with EMA - enters when price crosses above EMA
 complexity: SIMPLE
-source: MIGRATED
 sourceStrategy: com.verlumen.tradestream.strategies.pricegap.PriceGapStrategyFactory
 parameterMessageType: com.verlumen.tradestream.strategies.PriceGapParameters
 

--- a/src/main/resources/strategies/roc_ma_crossover.yaml
+++ b/src/main/resources/strategies/roc_ma_crossover.yaml
@@ -1,7 +1,6 @@
 name: ROC_MA_CROSSOVER
 description: Rate of Change crosses its Moving Average
 complexity: SIMPLE
-source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.rocma.RocMaCrossoverStrategyFactory
 parameterMessageType: com.verlumen.tradestream.strategies.RocMaCrossoverParameters
 

--- a/src/main/resources/strategies/rsi_ema_crossover.yaml
+++ b/src/main/resources/strategies/rsi_ema_crossover.yaml
@@ -1,7 +1,6 @@
 name: RSI_EMA_CROSSOVER
 description: RSI crosses its EMA with overbought/oversold filters
 complexity: SIMPLE
-source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.rsiemacrossover.RsiEmaCrossoverStrategyFactory
 parameterMessageType: com.verlumen.tradestream.strategies.RsiEmaCrossoverParameters
 

--- a/src/main/resources/strategies/sma_ema_crossover.yaml
+++ b/src/main/resources/strategies/sma_ema_crossover.yaml
@@ -1,7 +1,6 @@
 name: SMA_EMA_CROSSOVER
 description: Simple Moving Average crosses Exponential Moving Average
 complexity: SIMPLE
-source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.smaemacrossover.SmaEmaCrossoverStrategyFactory
 parameterMessageType: com.verlumen.tradestream.strategies.SmaEmaCrossoverParameters
 

--- a/src/main/resources/strategies/stochastic_rsi.yaml
+++ b/src/main/resources/strategies/stochastic_rsi.yaml
@@ -1,7 +1,6 @@
 name: STOCHASTIC_RSI
 description: Stochastic RSI - enters when oversold, exits when overbought
 complexity: MEDIUM
-source: MIGRATED
 sourceStrategy: com.verlumen.tradestream.strategies.stochasticsrsi.StochasticRsiStrategyFactory
 parameterMessageType: com.verlumen.tradestream.strategies.StochasticRsiParameters
 

--- a/src/main/resources/strategies/triple_ema_crossover.yaml
+++ b/src/main/resources/strategies/triple_ema_crossover.yaml
@@ -1,7 +1,6 @@
 name: TRIPLE_EMA_CROSSOVER
 description: Triple EMA crossover strategy using short, medium, and long periods
 complexity: MEDIUM
-source: MIGRATED
 sourceStrategy: com.verlum.tradestream.strategies.tripleemacrossover.TripleEmaCrossoverStrategyFactory
 parameterMessageType: com.verlumen.tradestream.strategies.TripleEmaCrossoverParameters
 


### PR DESCRIPTION
## Summary
Removed the deprecated `source: MIGRATED` field from all 25 strategy YAML configuration files.

## Context
- This field was deprecated as part of the StrategyType migration (Epic #1505)
- Issue #1523 removed the field from StrategyConfig.java
- Jackson/SnakeYAML silently ignores unknown fields, so this cleanup is safe

## Files Modified
All 25 files in `src/main/resources/strategies/`

## Test Plan
- [x] Build succeeds (no code changes, just YAML)

Fixes #1547

🤖 Generated with [Claude Code](https://claude.com/claude-code)