### PR TITLE
chore: add minimal CLAUDE.md for project-specific AI configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,14 @@
+# TradeStream AI Configuration
+
+Project rules are defined in `.cursorrules`. Follow those guidelines for all development work.
+
+## Skills
+
+Use `.claude/skills/priority-issue-resolution/SKILL.md` for autonomous issue resolution workflows.
+
+## Quick Reference
+
+- Build: `bazel build //...`
+- Test: `bazel test //...`
+- Format Java: Run google-java-format before commits
+- Format Kotlin: Run ktlint before commits


### PR DESCRIPTION
## Summary
- Adds a minimal `CLAUDE.md` file for TradeStream-specific AI configuration
- References `.cursorrules` which already contains comprehensive project rules
- Points to the `priority-issue-resolution` skill for complex workflows
- Prevents context bloat from inheriting unrelated parent directory configurations

## Context
The TradeStream project rules are well-defined in `.cursorrules` (235 lines). This PR adds a minimal `CLAUDE.md` (14 lines) that:
1. Directs AI assistants to follow `.cursorrules` for all development
2. References the existing skill for autonomous workflows
3. Provides quick command reference

This ensures only TradeStream-specific context is used during AI-assisted development, reducing unnecessary context consumption.

## Test plan
- [ ] PR passes CI checks
- [ ] CLAUDE.md is readable and references correct files

🤖 Generated with [Claude Code](https://claude.com/claude-code)