### PR TITLE
feat(backtesting): migrate from HTTP to gRPC

### DIFF
--- a/protos/backtesting.proto
+++ b/protos/backtesting.proto
@@ -13,11 +13,32 @@ import "protos/strategies.proto";
 //       Backtest Service
 // =========================
 
+// gRPC service for running backtests
+service BacktestingService {
+  // Run a single backtest
+  rpc RunBacktest(BacktestRequest) returns (BacktestResult);
+
+  // Run multiple backtests with different parameter sets
+  rpc RunBatchBacktest(BatchBacktestRequest) returns (BatchBacktestResult);
+}
+
 // The universal backtest request: includes candle data, strategy type,
 // and an Any for the specific parameters (e.g. SmaRsiParameters).
 message BacktestRequest {
   repeated marketdata.Candle candles = 1;
   strategies.Strategy strategy = 2;
+}
+
+// Request for batch backtesting with multiple parameter sets
+message BatchBacktestRequest {
+  repeated marketdata.Candle candles = 1;
+  string strategy_name = 2;
+  repeated strategies.Strategy strategies = 3;
+}
+
+// Response containing multiple backtest results
+message BatchBacktestResult {
+  repeated BacktestResult results = 1;
 }
 
 // The final result from a single backtest

--- a/services/backtesting/BUILD
+++ b/services/backtesting/BUILD
@@ -32,6 +32,9 @@ py_library(
     srcs = ["backtesting_service.py"],
     deps = [
         ":vectorbt_runner_lib",
+        "//protos:backtesting_py_proto",
+        "//protos:marketdata_py_proto",
+        "//protos:strategies_py_proto",
         "//third_party/python:grpcio",
         "//third_party/python:numpy",
         "//third_party/python:pandas",

--- a/services/backtesting/main.py
+++ b/services/backtesting/main.py
@@ -2,17 +2,15 @@
 """
 VectorBT Backtesting Microservice Entry Point.
 
-Provides both gRPC and HTTP/REST interfaces for backtesting.
+Provides a gRPC interface for high-performance backtesting.
 """
 
 import argparse
-import json
 import logging
+import signal
 import sys
-from http.server import HTTPServer, BaseHTTPRequestHandler
-from typing import Dict, Any
 
-from services.backtesting.backtesting_service import BacktestingServiceImpl
+from services.backtesting.backtesting_service import create_grpc_server
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
@@ -20,154 +18,29 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
-class BacktestHTTPHandler(BaseHTTPRequestHandler):
-    """HTTP handler for REST interface (for testing without gRPC)."""
-
-    service: BacktestingServiceImpl = None
-
-    def do_POST(self):
-        """Handle POST requests."""
-        if self.path == "/backtest":
-            self._handle_backtest()
-        elif self.path == "/batch":
-            self._handle_batch()
-        elif self.path == "/health":
-            self._handle_health()
-        else:
-            self._send_error(404, "Not found")
-
-    def do_GET(self):
-        """Handle GET requests."""
-        if self.path == "/health":
-            self._handle_health()
-        elif self.path == "/indicators":
-            self._handle_list_indicators()
-        else:
-            self._send_error(404, "Not found")
-
-    def _handle_backtest(self):
-        """Handle single backtest request."""
-        try:
-            content_length = int(self.headers.get("Content-Length", 0))
-            body = self.rfile.read(content_length)
-            request = json.loads(body.decode("utf-8"))
-
-            result = self.service.run_backtest(request)
-
-            self._send_json(200, result)
-        except ValueError as e:
-            self._send_error(400, str(e))
-        except Exception as e:
-            logger.exception("Backtest failed")
-            self._send_error(500, str(e))
-
-    def _handle_batch(self):
-        """Handle batch backtest request."""
-        try:
-            content_length = int(self.headers.get("Content-Length", 0))
-            body = self.rfile.read(content_length)
-            request = json.loads(body.decode("utf-8"))
-
-            candles = request.get("candles", [])
-            strategy_name = request.get("strategyName", "")
-            parameter_sets = request.get("parameterSets", [])
-
-            results = self.service.run_batch_backtest(
-                candles, strategy_name, parameter_sets
-            )
-
-            self._send_json(200, {"results": results})
-        except ValueError as e:
-            self._send_error(400, str(e))
-        except Exception as e:
-            logger.exception("Batch backtest failed")
-            self._send_error(500, str(e))
-
-    def _handle_health(self):
-        """Handle health check."""
-        self._send_json(200, {"status": "healthy", "service": "vectorbt-backtesting"})
-
-    def _handle_list_indicators(self):
-        """List available indicators."""
-        from indicator_registry import get_default_registry
-
-        indicators = get_default_registry().list_indicators()
-        self._send_json(200, {"indicators": indicators})
-
-    def _send_json(self, status: int, data: Dict[str, Any]):
-        """Send JSON response."""
-        response = json.dumps(data).encode("utf-8")
-        self.send_response(status)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", len(response))
-        self.end_headers()
-        self.wfile.write(response)
-
-    def _send_error(self, status: int, message: str):
-        """Send error response."""
-        self._send_json(status, {"error": message})
-
-    def log_message(self, format: str, *args):
-        """Override to use Python logging."""
-        logger.info("%s - %s", self.address_string(), format % args)
-
-
-def run_http_server(port: int, service: BacktestingServiceImpl):
-    """Run the HTTP server."""
-    BacktestHTTPHandler.service = service
-    server = HTTPServer(("0.0.0.0", port), BacktestHTTPHandler)
-    logger.info("HTTP server listening on port %d", port)
-    logger.info("  POST /backtest - Run single backtest")
-    logger.info("  POST /batch - Run batch backtests")
-    logger.info("  GET /health - Health check")
-    logger.info("  GET /indicators - List available indicators")
-    server.serve_forever()
-
-
-def run_grpc_server(port: int):
-    """Run the gRPC server."""
-    try:
-        import grpc
-        from concurrent import futures
-
-        server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
-        # Add service when protobuf stubs are generated
-        server.add_insecure_port(f"[::]:{port}")
-        server.start()
-        logger.info(f"gRPC server listening on port {port}")
-        server.wait_for_termination()
-    except ImportError:
-        logger.error("gRPC not available. Install grpcio.")
-        sys.exit(1)
-
-
 def main():
     parser = argparse.ArgumentParser(description="VectorBT Backtesting Microservice")
-    parser.add_argument("--port", type=int, default=8080, help="Server port")
-    parser.add_argument("--grpc-port", type=int, default=50051, help="gRPC port")
-    parser.add_argument(
-        "--mode", choices=["http", "grpc", "both"], default="http", help="Server mode"
-    )
+    parser.add_argument("--port", type=int, default=50051, help="gRPC server port")
     args = parser.parse_args()
 
     logger.info("Initializing VectorBT Backtesting Service...")
-    service = BacktestingServiceImpl()
-    logger.info("Service initialized successfully")
 
-    if args.mode == "http":
-        run_http_server(args.port, service)
-    elif args.mode == "grpc":
-        run_grpc_server(args.grpc_port)
-    else:
-        # Run both in separate threads
-        import threading
+    server = create_grpc_server(args.port)
+    server.start()
+    logger.info(f"gRPC server listening on port {args.port}")
+    logger.info("Service ready to accept backtest requests")
 
-        http_thread = threading.Thread(
-            target=run_http_server, args=(args.port, service)
-        )
-        http_thread.daemon = True
-        http_thread.start()
-        run_grpc_server(args.grpc_port)
+    # Handle shutdown gracefully
+    def shutdown(signum, frame):
+        logger.info("Shutting down server...")
+        server.stop(grace=5)
+        sys.exit(0)
+
+    signal.signal(signal.SIGTERM, shutdown)
+    signal.signal(signal.SIGINT, shutdown)
+
+    # Block until terminated
+    server.wait_for_termination()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Migrate backtesting microservice from HTTP to gRPC
- Add service definition to `protos/backtesting.proto`
- Implement `BacktestingServicer` using generic RPC handler pattern
- Remove HTTP server code, simplify `main.py`

## Changes

| File | Description |
|------|-------------|
| `protos/backtesting.proto` | Add `BacktestingService` with `RunBacktest` and `RunBatchBacktest` RPCs |
| `backtesting_service.py` | Implement gRPC servicer with proto message handling |
| `main.py` | Simplified to gRPC-only server |
| `BUILD` | Add proto dependencies |

## Technical Details

Uses `grpc.GenericRpcHandler` to implement the service without requiring generated `_pb2_grpc.py` stubs. This avoids Bazel complexity while still providing full gRPC functionality.

## Test plan
- [ ] Run `bazel test //services/backtesting:test_vectorbt_runner`
- [ ] Verify gRPC server starts: `bazel run //services/backtesting:app`
- [ ] Test with grpcurl or similar gRPC client

Resolves #1628

🤖 Generated with [Claude Code](https://claude.com/claude-code)