### PR TITLE
feat: add standalone Backtesting Service with gRPC API (#1558)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,6 +15,7 @@ bazel_dep(name = "rules_jvm_external", version = "6.5")
 bazel_dep(name = "rules_kotlin", version = "2.1.3")
 bazel_dep(name = "rules_oci", version = "2.2.6")
 bazel_dep(name = "rules_python", version = "1.4.1")
+bazel_dep(name = "grpc-java", version = "1.75.0")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(
@@ -95,6 +96,12 @@ maven.install(
         "org.postgresql:postgresql:42.7.6",
         "org.ta4j:ta4j-core:0.17",
         "org.yaml:snakeyaml:2.2",
+
+        # gRPC Dependencies
+        "io.grpc:grpc-netty-shaded:1.75.0",
+        "io.grpc:grpc-protobuf:1.75.0",
+        "io.grpc:grpc-stub:1.75.0",
+        "io.grpc:grpc-services:1.75.0",
 
         # Test Dependencies
         "com.google.inject.extensions:guice-testlib:7.0.0",

--- a/protos/BUILD
+++ b/protos/BUILD
@@ -1,5 +1,6 @@
 load("@com_google_protobuf//bazel:java_proto_library.bzl", "java_proto_library")
 load("@com_google_protobuf//bazel:py_proto_library.bzl", "py_proto_library")
+load("@grpc-java//:java_grpc_library.bzl", "java_grpc_library")
 
 proto_library(
     name = "backtesting_proto",
@@ -15,6 +16,13 @@ java_proto_library(
     name = "backtesting_java_proto",
     visibility = ["//visibility:public"],
     deps = [":backtesting_proto"],
+)
+
+java_grpc_library(
+    name = "backtesting_java_grpc",
+    srcs = [":backtesting_proto"],
+    visibility = ["//visibility:public"],
+    deps = [":backtesting_java_proto"],
 )
 
 py_proto_library(

--- a/src/main/java/com/verlumen/tradestream/backtesting/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtesting/BUILD
@@ -50,6 +50,19 @@ kt_jvm_library(
 )
 
 kt_jvm_library(
+    name = "remote_backtest_runner",
+    srcs = ["RemoteBacktestRunner.kt"],
+    deps = [
+        ":backtest_runner",
+        "//protos:backtesting_java_grpc",
+        "//protos:backtesting_java_proto",
+        "//third_party/java:flogger",
+        "//third_party/java:grpc_stub",
+        "//third_party/java:guice",
+    ],
+)
+
+kt_jvm_library(
     name = "backtesting_module",
     srcs = ["BacktestingModule.kt"],
     deps = [

--- a/src/main/java/com/verlumen/tradestream/backtesting/RemoteBacktestRunner.kt
+++ b/src/main/java/com/verlumen/tradestream/backtesting/RemoteBacktestRunner.kt
@@ -1,0 +1,154 @@
+package com.verlumen.tradestream.backtesting
+
+import com.google.common.flogger.FluentLogger
+import com.google.inject.Inject
+import com.google.inject.name.Named
+import io.grpc.ManagedChannel
+import io.grpc.ManagedChannelBuilder
+import io.grpc.StatusRuntimeException
+import java.util.concurrent.TimeUnit
+
+/**
+ * Remote implementation of BacktestRunner that calls the Backtesting gRPC Service.
+ *
+ * This client enables the Strategy Discovery Pipeline (running on Java 17/Flink)
+ * to offload backtesting to the standalone Backtesting Service (running on Java 21).
+ *
+ * Usage:
+ * 1. Create with Guice injection (preferred):
+ *    ```kotlin
+ *    @Inject
+ *    constructor(
+ *        @Named("backtesting.service.host") host: String,
+ *        @Named("backtesting.service.port") port: Int
+ *    )
+ *    ```
+ *
+ * 2. Create directly:
+ *    ```kotlin
+ *    RemoteBacktestRunner.create("localhost", 50051)
+ *    ```
+ */
+class RemoteBacktestRunner
+    @Inject
+    constructor(
+        @Named("backtesting.service.host") private val host: String,
+        @Named("backtesting.service.port") private val port: Int,
+    ) : BacktestRunner {
+        companion object {
+            private val logger = FluentLogger.forEnclosingClass()
+            private const val DEFAULT_DEADLINE_SECONDS = 60L
+
+            /**
+             * Factory method for creating a RemoteBacktestRunner.
+             */
+            @JvmStatic
+            fun create(
+                host: String,
+                port: Int,
+            ): RemoteBacktestRunner = RemoteBacktestRunner(host, port)
+        }
+
+        private val channel: ManagedChannel by lazy {
+            logger.atInfo().log("Creating gRPC channel to %s:%d", host, port)
+            ManagedChannelBuilder
+                .forAddress(host, port)
+                .usePlaintext() // TODO: Configure TLS for production
+                .build()
+        }
+
+        private val blockingStub: BacktestingServiceGrpc.BacktestingServiceBlockingStub by lazy {
+            BacktestingServiceGrpc.newBlockingStub(channel)
+        }
+
+        override fun runBacktest(request: BacktestRequest): BacktestResult {
+            try {
+                logger.atFine().log(
+                    "Sending backtest request: strategy=%s, candles=%d",
+                    request.strategy.strategyName,
+                    request.candlesCount,
+                )
+
+                val result =
+                    blockingStub
+                        .withDeadlineAfter(DEFAULT_DEADLINE_SECONDS, TimeUnit.SECONDS)
+                        .runBacktest(request)
+
+                logger.atFine().log(
+                    "Received backtest result: sharpe=%.4f, score=%.4f",
+                    result.sharpeRatio,
+                    result.strategyScore,
+                )
+
+                return result
+            } catch (e: StatusRuntimeException) {
+                logger.atWarning().withCause(e).log(
+                    "gRPC call failed: status=%s, description=%s",
+                    e.status.code,
+                    e.status.description,
+                )
+                // Return a default result with negative infinity score for failed backtests
+                return BacktestResult
+                    .newBuilder()
+                    .setStrategyScore(Double.NEGATIVE_INFINITY)
+                    .build()
+            }
+        }
+
+        /**
+         * Runs batch backtests for multiple parameter sets of the same strategy.
+         * This is optimized for GA fitness evaluation where many parameter combinations
+         * need to be tested against the same candle data.
+         *
+         * @param request Batch backtest request containing candles and multiple strategies
+         * @return Batch result containing all individual backtest results
+         */
+        fun runBatchBacktest(request: BatchBacktestRequest): BatchBacktestResult {
+            try {
+                logger.atFine().log(
+                    "Sending batch backtest request: strategy=%s, batch_size=%d, candles=%d",
+                    request.strategyName,
+                    request.strategiesCount,
+                    request.candlesCount,
+                )
+
+                val result =
+                    blockingStub
+                        .withDeadlineAfter(DEFAULT_DEADLINE_SECONDS * 2, TimeUnit.SECONDS) // Double deadline for batch
+                        .runBatchBacktest(request)
+
+                logger.atFine().log(
+                    "Received batch backtest result: %d results",
+                    result.resultsCount,
+                )
+
+                return result
+            } catch (e: StatusRuntimeException) {
+                logger.atWarning().withCause(e).log(
+                    "Batch gRPC call failed: status=%s, description=%s",
+                    e.status.code,
+                    e.status.description,
+                )
+                // Return empty results for failed batch
+                return BatchBacktestResult.getDefaultInstance()
+            }
+        }
+
+        /**
+         * Shuts down the gRPC channel gracefully.
+         */
+        fun shutdown() {
+            logger.atInfo().log("Shutting down gRPC channel")
+            try {
+                channel.shutdown()
+                if (!channel.awaitTermination(5, TimeUnit.SECONDS)) {
+                    logger.atWarning().log("Channel did not terminate in time, forcing shutdown")
+                    channel.shutdownNow()
+                }
+            } catch (e: InterruptedException) {
+                logger.atWarning().log("Shutdown interrupted")
+                channel.shutdownNow()
+                Thread.currentThread().interrupt()
+            }
+        }
+    }

--- a/src/main/java/com/verlumen/tradestream/backtestingservice/BUILD
+++ b/src/main/java/com/verlumen/tradestream/backtestingservice/BUILD
@@ -1,0 +1,50 @@
+load("@rules_java//java:defs.bzl", "java_binary")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+
+package(default_visibility = ["//visibility:public"])
+
+kt_jvm_library(
+    name = "backtesting_grpc_service",
+    srcs = ["BacktestingGrpcService.kt"],
+    deps = [
+        "//protos:backtesting_java_grpc",
+        "//protos:backtesting_java_proto",
+        "//src/main/java/com/verlumen/tradestream/backtesting:backtest_runner",
+        "//third_party/java:flogger",
+        "//third_party/java:grpc_stub",
+        "//third_party/java:guice",
+    ],
+)
+
+kt_jvm_library(
+    name = "backtesting_service_module",
+    srcs = ["BacktestingServiceModule.kt"],
+    deps = [
+        ":backtesting_grpc_service",
+        "//src/main/java/com/verlumen/tradestream/backtesting:backtesting_module",
+        "//third_party/java:guice",
+    ],
+)
+
+kt_jvm_library(
+    name = "backtest_service_server_lib",
+    srcs = ["BacktestServiceServer.kt"],
+    deps = [
+        ":backtesting_grpc_service",
+        ":backtesting_service_module",
+        "//third_party/java:argparse4j",
+        "//third_party/java:flogger",
+        "//third_party/java:grpc_netty_shaded",
+        "//third_party/java:grpc_services",
+        "//third_party/java:guice",
+    ],
+)
+
+java_binary(
+    name = "backtest_service_server",
+    main_class = "com.verlumen.tradestream.backtestingservice.BacktestServiceServer",
+    runtime_deps = [
+        ":backtest_service_server_lib",
+        ":backtesting_service_module",
+    ],
+)

--- a/src/main/java/com/verlumen/tradestream/backtestingservice/BacktestServiceServer.kt
+++ b/src/main/java/com/verlumen/tradestream/backtestingservice/BacktestServiceServer.kt
@@ -1,0 +1,143 @@
+package com.verlumen.tradestream.backtestingservice
+
+import com.google.common.flogger.FluentLogger
+import com.google.inject.Guice
+import com.google.inject.Inject
+import com.verlumen.tradestream.backtestingservice.BacktestingGrpcService
+import com.verlumen.tradestream.backtestingservice.BacktestingServiceModule
+import io.grpc.Server
+import io.grpc.ServerBuilder
+import io.grpc.protobuf.services.HealthStatusManager
+import io.grpc.protobuf.services.ProtoReflectionService
+import net.sourceforge.argparse4j.ArgumentParsers
+import net.sourceforge.argparse4j.inf.ArgumentParserException
+import java.util.concurrent.TimeUnit
+
+/**
+ * Standalone gRPC server for the Backtesting Service.
+ *
+ * This server provides backtesting functionality via gRPC, enabling the
+ * Strategy Discovery Pipeline (running on Java 17/Flink) to offload
+ * backtesting to this service (capable of running on Java 21 with ta4j 0.22+).
+ *
+ * Features:
+ * - Single backtest execution
+ * - Batch backtest for GA fitness evaluation
+ * - Health checking for Kubernetes readiness/liveness probes
+ * - gRPC reflection for debugging with grpcurl
+ */
+class BacktestServiceServer
+    @Inject
+    constructor(
+        private val backtestingService: BacktestingGrpcService,
+    ) {
+        companion object {
+            private val logger = FluentLogger.forEnclosingClass()
+            private const val DEFAULT_PORT = 50051
+
+            @JvmStatic
+            fun main(args: Array<String>) {
+                val parser =
+                    ArgumentParsers
+                        .newFor("BacktestServiceServer")
+                        .build()
+                        .defaultHelp(true)
+                        .description("Backtesting Service gRPC Server")
+
+                parser
+                    .addArgument("--port")
+                    .type(Integer::class.java)
+                    .setDefault(DEFAULT_PORT)
+                    .help("Port to listen on")
+
+                try {
+                    val ns = parser.parseArgs(args)
+                    val port = ns.getInt("port")
+
+                    val injector = Guice.createInjector(BacktestingServiceModule())
+                    val server = injector.getInstance(BacktestServiceServer::class.java)
+                    server.start(port)
+                    server.blockUntilShutdown()
+                } catch (e: ArgumentParserException) {
+                    parser.handleError(e)
+                    System.exit(1)
+                }
+            }
+        }
+
+        private var server: Server? = null
+        private val healthStatusManager = HealthStatusManager()
+
+        /**
+         * Starts the gRPC server on the specified port.
+         */
+        fun start(port: Int) {
+            server =
+                ServerBuilder
+                    .forPort(port)
+                    .addService(backtestingService)
+                    .addService(healthStatusManager.healthService)
+                    .addService(ProtoReflectionService.newInstance())
+                    .build()
+                    .start()
+
+            logger.atInfo().log("Backtesting Service started on port %d", port)
+
+            // Mark service as serving
+            healthStatusManager.setStatus(
+                "verlumen.tradestream.backtesting.BacktestingService",
+                io.grpc.health.v1.HealthCheckResponse.ServingStatus.SERVING,
+            )
+
+            // Add shutdown hook
+            Runtime.getRuntime().addShutdownHook(
+                Thread {
+                    logger.atInfo().log("Shutting down gRPC server due to JVM shutdown")
+                    stop()
+                },
+            )
+        }
+
+        /**
+         * Stops the gRPC server gracefully.
+         */
+        fun stop() {
+            server?.let { s ->
+                logger.atInfo().log("Initiating graceful shutdown")
+
+                // Mark service as not serving
+                healthStatusManager.setStatus(
+                    "verlumen.tradestream.backtesting.BacktestingService",
+                    io.grpc.health.v1.HealthCheckResponse.ServingStatus.NOT_SERVING,
+                )
+
+                // Shutdown the service
+                backtestingService.shutdown()
+
+                // Shutdown the server
+                s.shutdown()
+                try {
+                    if (!s.awaitTermination(30, TimeUnit.SECONDS)) {
+                        logger.atWarning().log("Server did not terminate in time, forcing shutdown")
+                        s.shutdownNow()
+                        if (!s.awaitTermination(5, TimeUnit.SECONDS)) {
+                            logger.atSevere().log("Server did not terminate after force shutdown")
+                        }
+                    }
+                } catch (e: InterruptedException) {
+                    logger.atWarning().log("Shutdown interrupted")
+                    s.shutdownNow()
+                    Thread.currentThread().interrupt()
+                }
+
+                logger.atInfo().log("Server shutdown complete")
+            }
+        }
+
+        /**
+         * Blocks until the server is terminated.
+         */
+        fun blockUntilShutdown() {
+            server?.awaitTermination()
+        }
+    }

--- a/src/main/java/com/verlumen/tradestream/backtestingservice/BacktestingGrpcService.kt
+++ b/src/main/java/com/verlumen/tradestream/backtestingservice/BacktestingGrpcService.kt
@@ -1,0 +1,164 @@
+package com.verlumen.tradestream.backtestingservice
+
+import com.google.common.flogger.FluentLogger
+import com.google.inject.Inject
+import com.verlumen.tradestream.backtesting.BacktestRequest
+import com.verlumen.tradestream.backtesting.BacktestResult
+import com.verlumen.tradestream.backtesting.BacktestRunner
+import com.verlumen.tradestream.backtesting.BacktestingServiceGrpc
+import com.verlumen.tradestream.backtesting.BatchBacktestRequest
+import com.verlumen.tradestream.backtesting.BatchBacktestResult
+import io.grpc.Status
+import io.grpc.stub.StreamObserver
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+/**
+ * gRPC service implementation for the Backtesting Service.
+ *
+ * This service wraps the existing BacktestRunner to provide gRPC-based access
+ * to backtesting functionality, enabling the Strategy Discovery Pipeline
+ * (running on Java 17/Flink) to call this service (running on Java 21).
+ */
+class BacktestingGrpcService
+    @Inject
+    constructor(
+        private val backtestRunner: BacktestRunner,
+    ) : BacktestingServiceGrpc.BacktestingServiceImplBase() {
+        companion object {
+            private val logger = FluentLogger.forEnclosingClass()
+            private const val BATCH_THREAD_POOL_SIZE = 8
+        }
+
+        private val batchExecutor = Executors.newFixedThreadPool(BATCH_THREAD_POOL_SIZE)
+
+        /**
+         * Runs a single backtest for the given strategy and candle data.
+         */
+        override fun runBacktest(
+            request: BacktestRequest,
+            responseObserver: StreamObserver<BacktestResult>,
+        ) {
+            try {
+                logger.atFine().log(
+                    "Running backtest for strategy: %s with %d candles",
+                    request.strategy.strategyName,
+                    request.candlesCount,
+                )
+
+                val result = backtestRunner.runBacktest(request)
+
+                logger.atFine().log(
+                    "Backtest completed: strategy=%s, sharpe=%.4f, score=%.4f",
+                    request.strategy.strategyName,
+                    result.sharpeRatio,
+                    result.strategyScore,
+                )
+
+                responseObserver.onNext(result)
+                responseObserver.onCompleted()
+            } catch (e: IllegalArgumentException) {
+                logger.atWarning().withCause(e).log("Invalid backtest request")
+                responseObserver.onError(
+                    Status.INVALID_ARGUMENT
+                        .withDescription(e.message)
+                        .withCause(e)
+                        .asRuntimeException(),
+                )
+            } catch (e: Exception) {
+                logger.atSevere().withCause(e).log("Backtest failed unexpectedly")
+                responseObserver.onError(
+                    Status.INTERNAL
+                        .withDescription("Backtest failed: ${e.message}")
+                        .withCause(e)
+                        .asRuntimeException(),
+                )
+            }
+        }
+
+        /**
+         * Runs batch backtests for multiple parameter sets of the same strategy.
+         * This is optimized for GA fitness evaluation where many parameter combinations
+         * need to be tested against the same candle data.
+         */
+        override fun runBatchBacktest(
+            request: BatchBacktestRequest,
+            responseObserver: StreamObserver<BatchBacktestResult>,
+        ) {
+            try {
+                logger.atFine().log(
+                    "Running batch backtest: strategy=%s, batch_size=%d, candles=%d",
+                    request.strategyName,
+                    request.strategiesCount,
+                    request.candlesCount,
+                )
+
+                // Execute backtests in parallel using the thread pool
+                val futures =
+                    request.strategiesList.map { strategy ->
+                        batchExecutor.submit<BacktestResult> {
+                            val singleRequest =
+                                BacktestRequest
+                                    .newBuilder()
+                                    .addAllCandles(request.candlesList)
+                                    .setStrategy(strategy)
+                                    .build()
+                            backtestRunner.runBacktest(singleRequest)
+                        }
+                    }
+
+                // Collect results
+                val results =
+                    futures.map { future ->
+                        try {
+                            future.get(60, TimeUnit.SECONDS)
+                        } catch (e: Exception) {
+                            logger.atWarning().withCause(e).log("Single backtest in batch failed")
+                            // Return a default result with negative infinity score for failed backtests
+                            BacktestResult
+                                .newBuilder()
+                                .setStrategyScore(Double.NEGATIVE_INFINITY)
+                                .build()
+                        }
+                    }
+
+                val batchResult =
+                    BatchBacktestResult
+                        .newBuilder()
+                        .addAllResults(results)
+                        .build()
+
+                logger.atFine().log(
+                    "Batch backtest completed: %d results",
+                    batchResult.resultsCount,
+                )
+
+                responseObserver.onNext(batchResult)
+                responseObserver.onCompleted()
+            } catch (e: Exception) {
+                logger.atSevere().withCause(e).log("Batch backtest failed")
+                responseObserver.onError(
+                    Status.INTERNAL
+                        .withDescription("Batch backtest failed: ${e.message}")
+                        .withCause(e)
+                        .asRuntimeException(),
+                )
+            }
+        }
+
+        /**
+         * Shuts down the batch executor service.
+         */
+        fun shutdown() {
+            logger.atInfo().log("Shutting down batch executor")
+            batchExecutor.shutdown()
+            try {
+                if (!batchExecutor.awaitTermination(30, TimeUnit.SECONDS)) {
+                    batchExecutor.shutdownNow()
+                }
+            } catch (e: InterruptedException) {
+                batchExecutor.shutdownNow()
+                Thread.currentThread().interrupt()
+            }
+        }
+    }

--- a/src/main/java/com/verlumen/tradestream/backtestingservice/BacktestingServiceModule.kt
+++ b/src/main/java/com/verlumen/tradestream/backtestingservice/BacktestingServiceModule.kt
@@ -1,0 +1,20 @@
+package com.verlumen.tradestream.backtestingservice
+
+import com.google.inject.AbstractModule
+import com.verlumen.tradestream.backtesting.BacktestingModule
+
+/**
+ * Guice module for the Backtesting Service.
+ *
+ * This module wires up all dependencies required for the standalone
+ * Backtesting gRPC Service.
+ */
+class BacktestingServiceModule : AbstractModule() {
+    override fun configure() {
+        // Install the core backtesting module for BacktestRunner
+        install(BacktestingModule())
+
+        // Bind the gRPC service
+        bind(BacktestingGrpcService::class.java)
+    }
+}

--- a/third_party/java/BUILD
+++ b/third_party/java/BUILD
@@ -360,3 +360,36 @@ java_library(
         "@tradestream_maven//:org_yaml_snakeyaml",
     ],
 )
+
+# gRPC Dependencies
+java_library(
+    name = "grpc_netty_shaded",
+    visibility = ["//visibility:public"],
+    exports = [
+        "@tradestream_maven//:io_grpc_grpc_netty_shaded",
+    ],
+)
+
+java_library(
+    name = "grpc_protobuf",
+    visibility = ["//visibility:public"],
+    exports = [
+        "@tradestream_maven//:io_grpc_grpc_protobuf",
+    ],
+)
+
+java_library(
+    name = "grpc_stub",
+    visibility = ["//visibility:public"],
+    exports = [
+        "@tradestream_maven//:io_grpc_grpc_stub",
+    ],
+)
+
+java_library(
+    name = "grpc_services",
+    visibility = ["//visibility:public"],
+    exports = [
+        "@tradestream_maven//:io_grpc_grpc_services",
+    ],
+)


### PR DESCRIPTION
## Summary
- Implements standalone gRPC backtesting service for decoupled architecture
- Adds `BacktestingGrpcService` wrapping existing `BacktestRunner` with gRPC interface
- Creates `BacktestServiceServer` for standalone deployment with health checks
- Provides `RemoteBacktestRunner` client for Strategy Discovery Pipeline integration

## Root Cause
The Strategy Discovery Pipeline (Java 17/Flink) needs to offload backtesting to a dedicated service that can run Java 21 with ta4j 0.22+ without version conflicts.

## Implementation Details

### New Components
| Component | Description |
|-----------|-------------|
| `BacktestingGrpcService` | gRPC service implementation wrapping `BacktestRunner` |
| `BacktestServiceServer` | Standalone server with argparse, health checks, reflection |
| `RemoteBacktestRunner` | Client implementing `BacktestRunner` interface for remote calls |
| `BacktestingServiceModule` | Guice DI module for wiring dependencies |

### gRPC APIs
- `runBacktest(BacktestRequest)` → `BacktestResult` - Single strategy backtest
- `runBatchBacktest(BatchBacktestRequest)` → `BatchBacktestResult` - Batch for GA fitness

### Infrastructure Changes
- Added `grpc-java` bazel dependency (v1.75.0)
- Added gRPC Maven artifacts to MODULE.bazel
- Created `java_grpc_library` target in protos/BUILD

## Test Plan
- [ ] `bazel build //src/main/java/com/verlumen/tradestream/backtestingservice:all` passes
- [ ] `bazel build //src/main/java/com/verlumen/tradestream/backtesting:remote_backtest_runner` passes
- [ ] CI builds and tests pass
- [ ] Server starts: `bazel run //src/main/java/com/verlumen/tradestream/backtestingservice:backtest_service_server`

## Usage

### Start Server
```bash
bazel run //src/main/java/com/verlumen/tradestream/backtestingservice:backtest_service_server -- --port 50051
```

### Test with grpcurl
```bash
grpcurl -plaintext localhost:50051 list
grpcurl -plaintext localhost:50051 grpc.health.v1.Health/Check
```

Closes #1558

🤖 Generated with [Claude Code](https://claude.com/claude-code)