### PR TITLE
build: add BUILD file for strategy YAML resources

### DIFF
--- a/src/main/resources/BUILD
+++ b/src/main/resources/BUILD
@@ -1,0 +1,5 @@
+filegroup(
+    name = "strategies",
+    srcs = glob(["strategies/*.yaml"]),
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
## Summary
- Adds a BUILD file in src/main/resources to expose strategy YAML configs as a filegroup
- Required for config-based strategy tests to load YAML resources via classpath

## Test plan
- [ ] Verify bazel query can find the target: `bazel query //src/main/resources:strategies`

🤖 Generated with [Claude Code](https://claude.com/claude-code)