### PR TITLE
fix: add throws Exception to AdxStochasticConfigTest methods

### DIFF
--- a/src/test/java/com/verlumen/tradestream/strategies/adxstochastic/AdxStochasticConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/adxstochastic/AdxStochasticConfigTest.java
@@ -52,14 +52,14 @@ public class AdxStochasticConfigTest {
   }
 
   @Test
-  public void createStrategy_returnsValidStrategy() {
+  public void createStrategy_returnsValidStrategy() throws Exception {
     Strategy strategy = factory.createStrategy(series, factory.getDefaultParameters());
     assertThat(strategy).isNotNull();
     assertThat(strategy.getName()).isEqualTo("ADX_STOCHASTIC");
   }
 
   @Test
-  public void strategy_canEvaluateSignals() {
+  public void strategy_canEvaluateSignals() throws Exception {
     Strategy strategy = factory.createStrategy(series, factory.getDefaultParameters());
     for (int i = 50; i < series.getBarCount(); i++) {
       strategy.shouldEnter(i);


### PR DESCRIPTION
## Summary
- Fix compilation error in AdxStochasticConfigTest by adding `throws Exception` to test methods that call `factory.createStrategy()`

## Test plan
- CI should pass after this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)