### PR TITLE
fix(security): restrict HTTP bindings to localhost by default

### DIFF
--- a/charts/tradestream/templates/market-mcp.yaml
+++ b/charts/tradestream/templates/market-mcp.yaml
@@ -55,6 +55,7 @@ spec:
             - "--redis_port=$(REDIS_PORT)"
             - "--mcp_transport=$(MCP_TRANSPORT)"
             - "--mcp_port=$(MCP_PORT)"
+            - "--mcp_host=0.0.0.0"
           resources:
             {{- toYaml .Values.marketMcp.resources | nindent 12 }}
 ---

--- a/charts/tradestream/templates/paper-trading.yaml
+++ b/charts/tradestream/templates/paper-trading.yaml
@@ -45,6 +45,7 @@ spec:
             - "--mcp_market_url=$(MCP_MARKET_URL)"
             - "--mcp_signal_url=$(MCP_SIGNAL_URL)"
             - "--port={{ .Values.paperTrading.config.port }}"
+            - "--host=0.0.0.0"
           livenessProbe:
             httpGet:
               path: /health

--- a/charts/tradestream/templates/signal-mcp.yaml
+++ b/charts/tradestream/templates/signal-mcp.yaml
@@ -58,6 +58,7 @@ spec:
             - "--redis_port=$(REDIS_PORT)"
             - "--mcp_transport=$(MCP_TRANSPORT)"
             - "--mcp_port=$(MCP_PORT)"
+            - "--mcp_host=0.0.0.0"
           resources:
             {{- toYaml .Values.signalMcp.resources | nindent 12 }}
 ---

--- a/charts/tradestream/templates/strategy-mcp.yaml
+++ b/charts/tradestream/templates/strategy-mcp.yaml
@@ -48,6 +48,7 @@ spec:
             - "--postgres_password=$(POSTGRES_PASSWORD)"
             - "--mcp_transport={{ .Values.strategyMcp.mcpTransport | default "stdio" }}"
             - "--mcp_port={{ .Values.strategyMcp.service.port | default 8080 }}"
+            - "--mcp_host=0.0.0.0"
           resources:
             {{- toYaml .Values.strategyMcp.resources | nindent 12 }}
 ---

--- a/services/agent_gateway/main.py
+++ b/services/agent_gateway/main.py
@@ -230,7 +230,7 @@ async def publish_event(event: dict):
 
 
 def main():
-    host = os.environ.get("API_HOST", "0.0.0.0")
+    host = os.environ.get("API_HOST", "127.0.0.1")
     port = int(os.environ.get("API_PORT", "8080"))
     uvicorn.run(app, host=host, port=port, log_level="info")
 

--- a/services/market_mcp/main.py
+++ b/services/market_mcp/main.py
@@ -29,6 +29,7 @@ flags.DEFINE_integer("redis_port", 6379, "Redis port.")
 # MCP Configuration Flags
 flags.DEFINE_string("mcp_transport", "stdio", "MCP transport type (stdio or sse).")
 flags.DEFINE_integer("mcp_port", 8080, "MCP server port (for SSE transport).")
+flags.DEFINE_string("mcp_host", "127.0.0.1", "MCP server host.")
 
 
 async def main_async() -> None:
@@ -96,7 +97,7 @@ async def main_async() -> None:
 
             config = uvicorn.Config(
                 starlette_app,
-                host="0.0.0.0",
+                host=FLAGS.mcp_host,
                 port=FLAGS.mcp_port,
             )
             server = uvicorn.Server(config)

--- a/services/paper_trading/main.py
+++ b/services/paper_trading/main.py
@@ -19,6 +19,7 @@ flags.DEFINE_string("postgres_password", "", "PostgreSQL password")
 flags.DEFINE_string("mcp_market_url", "http://localhost:8081", "Market MCP server URL")
 flags.DEFINE_string("mcp_signal_url", "http://localhost:8082", "Signal MCP server URL")
 flags.DEFINE_integer("port", 8090, "HTTP server port")
+flags.DEFINE_string("host", "127.0.0.1", "HTTP server host")
 
 
 def main(argv):
@@ -58,7 +59,7 @@ def main(argv):
     signal.signal(signal.SIGTERM, shutdown_handler)
 
     logging.info("Paper Trading service starting on port %d", FLAGS.port)
-    flask_app.run(host="0.0.0.0", port=FLAGS.port)
+    flask_app.run(host=FLAGS.host, port=FLAGS.port)
 
 
 if __name__ == "__main__":

--- a/services/signal_mcp/main.py
+++ b/services/signal_mcp/main.py
@@ -31,6 +31,7 @@ flags.DEFINE_integer("redis_port", 6379, "Redis port.")
 # MCP Configuration Flags
 flags.DEFINE_string("mcp_transport", "stdio", "MCP transport type (stdio or sse).")
 flags.DEFINE_integer("mcp_port", 8080, "MCP server port (for SSE transport).")
+flags.DEFINE_string("mcp_host", "127.0.0.1", "MCP server host.")
 
 
 async def main_async() -> None:
@@ -99,7 +100,7 @@ async def main_async() -> None:
 
             config = uvicorn.Config(
                 starlette_app,
-                host="0.0.0.0",
+                host=FLAGS.mcp_host,
                 port=FLAGS.mcp_port,
             )
             server = uvicorn.Server(config)

--- a/services/strategy_mcp/main.py
+++ b/services/strategy_mcp/main.py
@@ -53,6 +53,11 @@ flags.DEFINE_integer(
     8080,
     "MCP server port (for future HTTP/SSE transport).",
 )
+flags.DEFINE_string(
+    "mcp_host",
+    "127.0.0.1",
+    "MCP server host.",
+)
 
 
 async def main_async() -> None:
@@ -115,7 +120,7 @@ async def main_async() -> None:
 
             config = uvicorn.Config(
                 starlette_app,
-                host="0.0.0.0",
+                host=FLAGS.mcp_host,
                 port=FLAGS.mcp_port,
             )
             uvicorn_server = uvicorn.Server(config)

--- a/services/strategy_monitor_api/main.py
+++ b/services/strategy_monitor_api/main.py
@@ -860,7 +860,7 @@ flags.DEFINE_string("postgres_database", "tradestream", "PostgreSQL database")
 flags.DEFINE_string("postgres_username", "postgres", "PostgreSQL username")
 flags.DEFINE_string("postgres_password", "", "PostgreSQL password")
 flags.DEFINE_integer("api_port", 8080, "API server port")
-flags.DEFINE_string("api_host", "0.0.0.0", "API server host")
+flags.DEFINE_string("api_host", "127.0.0.1", "API server host")
 
 # Global database connection parameters
 DB_CONFIG = {}


### PR DESCRIPTION
## Summary
- **P2 Audit Finding S5**: All HTTP services were binding to `0.0.0.0`, exposing them on all network interfaces
- Changed default binding to `127.0.0.1` (localhost) for all 6 HTTP services
- Added configurable host flags/env vars so Kubernetes deployments can override to `0.0.0.0`
- Updated Helm chart templates to explicitly pass `--host=0.0.0.0` / `--mcp_host=0.0.0.0` for pod networking

## Services Updated
| Service | Configuration | Default |
|---------|--------------|---------|
| agent_gateway | `API_HOST` env var | `127.0.0.1` |
| strategy_monitor_api | `--api_host` flag | `127.0.0.1` |
| strategy_mcp | `--mcp_host` flag (new) | `127.0.0.1` |
| signal_mcp | `--mcp_host` flag (new) | `127.0.0.1` |
| market_mcp | `--mcp_host` flag (new) | `127.0.0.1` |
| paper_trading | `--host` flag (new) | `127.0.0.1` |

## Test plan
- [ ] Verify services start correctly in local development (bound to localhost)
- [ ] Verify Kubernetes deployments pass `0.0.0.0` via Helm templates
- [ ] Confirm health checks and inter-service communication work in k8s

🤖 Generated with [Claude Code](https://claude.com/claude-code)