### PR TITLE
feat(kafka): add SASL_SSL authentication support

### DIFF
--- a/charts/tradestream/templates/strategy-consumer.yaml
+++ b/charts/tradestream/templates/strategy-consumer.yaml
@@ -42,6 +42,17 @@ spec:
                   value: "{{ .Values.strategyConsumer.config.kafkaGroupId }}"
                 - name: KAFKA_AUTO_OFFSET_RESET
                   value: "{{ .Values.strategyConsumer.config.kafkaAutoOffsetReset }}"
+                # Kafka Security Configuration
+                - name: KAFKA_SECURITY_PROTOCOL
+                  value: "{{ .Values.strategyConsumer.config.kafkaSecurityProtocol }}"
+                {{- if .Values.strategyConsumer.config.kafkaSaslMechanism }}
+                - name: KAFKA_SASL_MECHANISM
+                  value: "{{ .Values.strategyConsumer.config.kafkaSaslMechanism }}"
+                {{- end }}
+                {{- if .Values.strategyConsumer.config.kafkaSaslJaasConfig }}
+                - name: KAFKA_SASL_JAAS_CONFIG
+                  value: "{{ .Values.strategyConsumer.config.kafkaSaslJaasConfig }}"
+                {{- end }}
                 # PostgreSQL Configuration
                 - name: POSTGRES_HOST
                   value: {{ tpl .Values.strategyConsumer.database.host . | quote }}
@@ -75,6 +86,13 @@ spec:
                 - "--kafka_topic=$(KAFKA_TOPIC)"
                 - "--kafka_group_id=$(KAFKA_GROUP_ID)"
                 - "--kafka_auto_offset_reset=$(KAFKA_AUTO_OFFSET_RESET)"
+                - "--kafka_security_protocol=$(KAFKA_SECURITY_PROTOCOL)"
+                {{- if .Values.strategyConsumer.config.kafkaSaslMechanism }}
+                - "--kafka_sasl_mechanism=$(KAFKA_SASL_MECHANISM)"
+                {{- end }}
+                {{- if .Values.strategyConsumer.config.kafkaSaslJaasConfig }}
+                - "--kafka_sasl_jaas_config=$(KAFKA_SASL_JAAS_CONFIG)"
+                {{- end }}
                 - "--postgres_host=$(POSTGRES_HOST)"
                 - "--postgres_port=$(POSTGRES_PORT)"
                 - "--postgres_database=$(POSTGRES_DATABASE)"

--- a/charts/tradestream/templates/strategy-discovery-pipeline.yaml
+++ b/charts/tradestream/templates/strategy-discovery-pipeline.yaml
@@ -61,6 +61,17 @@ spec:
                 secretKeyRef:
                   name: {{ tpl .Values.strategyDiscoveryPipeline.database.passwordSecret.name . }}
                   key: {{ .Values.strategyDiscoveryPipeline.database.passwordSecret.key }}
+            # Kafka security settings (read by Java/Kotlin via System.getenv)
+            - name: KAFKA_SECURITY_PROTOCOL
+              value: {{ .Values.strategyConsumer.config.kafkaSecurityProtocol | default "PLAINTEXT" | quote }}
+            {{- if .Values.strategyConsumer.config.kafkaSaslMechanism }}
+            - name: KAFKA_SASL_MECHANISM
+              value: {{ .Values.strategyConsumer.config.kafkaSaslMechanism | quote }}
+            {{- end }}
+            {{- if .Values.strategyConsumer.config.kafkaSaslJaasConfig }}
+            - name: KAFKA_SASL_JAAS_CONFIG
+              value: {{ .Values.strategyConsumer.config.kafkaSaslJaasConfig | quote }}
+            {{- end }}
             # Secret for InfluxDB token
             - name: INFLUXDB_TOKEN
               valueFrom:

--- a/charts/tradestream/values.yaml
+++ b/charts/tradestream/values.yaml
@@ -390,6 +390,12 @@ strategyConsumer:
     kafkaTopic: "discovered-strategies"
     kafkaGroupId: "strategy_consumer_group"
     kafkaAutoOffsetReset: "latest"
+    # Kafka Security Configuration
+    # Set kafkaSecurityProtocol to "SASL_SSL" for production
+    kafkaSecurityProtocol: "PLAINTEXT"
+    kafkaSaslMechanism: ""
+    # kafkaSaslJaasConfig should be set via a Secret in production
+    kafkaSaslJaasConfig: ""
     # Processing Configuration
     batchSize: 100
     pollTimeoutMs: 1000

--- a/services/strategy_consumer/kafka_consumer.py
+++ b/services/strategy_consumer/kafka_consumer.py
@@ -65,17 +65,12 @@ class StrategyKafkaConsumer:
         self.max_poll_interval_ms = max_poll_interval_ms
 
         # Security settings: use explicit params, then env vars, then defaults
-        self.security_protocol = (
-            security_protocol
-            or os.environ.get("KAFKA_SECURITY_PROTOCOL", "PLAINTEXT")
+        self.security_protocol = security_protocol or os.environ.get(
+            "KAFKA_SECURITY_PROTOCOL", "PLAINTEXT"
         )
-        self.sasl_mechanism = (
-            sasl_mechanism
-            or os.environ.get("KAFKA_SASL_MECHANISM")
-        )
-        self.sasl_jaas_config = (
-            sasl_jaas_config
-            or os.environ.get("KAFKA_SASL_JAAS_CONFIG")
+        self.sasl_mechanism = sasl_mechanism or os.environ.get("KAFKA_SASL_MECHANISM")
+        self.sasl_jaas_config = sasl_jaas_config or os.environ.get(
+            "KAFKA_SASL_JAAS_CONFIG"
         )
 
         self.consumer: Optional[KafkaConsumer] = None

--- a/services/strategy_consumer/kafka_consumer.py
+++ b/services/strategy_consumer/kafka_consumer.py
@@ -6,6 +6,7 @@ Reads discovered strategies from the Kafka topic and processes them.
 import asyncio
 import json
 import logging
+import os
 import time
 from typing import List, Optional, Callable, Awaitable
 
@@ -48,6 +49,9 @@ class StrategyKafkaConsumer:
         heartbeat_interval_ms: int = 3000,
         max_poll_records: int = 500,
         max_poll_interval_ms: int = 300000,
+        security_protocol: Optional[str] = None,
+        sasl_mechanism: Optional[str] = None,
+        sasl_jaas_config: Optional[str] = None,
     ):
         self.bootstrap_servers = bootstrap_servers
         self.topic = topic
@@ -59,6 +63,20 @@ class StrategyKafkaConsumer:
         self.heartbeat_interval_ms = heartbeat_interval_ms
         self.max_poll_records = max_poll_records
         self.max_poll_interval_ms = max_poll_interval_ms
+
+        # Security settings: use explicit params, then env vars, then defaults
+        self.security_protocol = (
+            security_protocol
+            or os.environ.get("KAFKA_SECURITY_PROTOCOL", "PLAINTEXT")
+        )
+        self.sasl_mechanism = (
+            sasl_mechanism
+            or os.environ.get("KAFKA_SASL_MECHANISM")
+        )
+        self.sasl_jaas_config = (
+            sasl_jaas_config
+            or os.environ.get("KAFKA_SASL_JAAS_CONFIG")
+        )
 
         self.consumer: Optional[KafkaConsumer] = None
         self.is_running = False
@@ -72,8 +90,7 @@ class StrategyKafkaConsumer:
         try:
             logging.info(f"Connecting to Kafka at {self.bootstrap_servers}")
 
-            self.consumer = KafkaConsumer(
-                self.topic,
+            consumer_kwargs = dict(
                 bootstrap_servers=self.bootstrap_servers,
                 group_id=self.group_id,
                 auto_offset_reset=self.auto_offset_reset,
@@ -83,8 +100,25 @@ class StrategyKafkaConsumer:
                 heartbeat_interval_ms=self.heartbeat_interval_ms,
                 max_poll_records=self.max_poll_records,
                 max_poll_interval_ms=self.max_poll_interval_ms,
-                # Remove UTF-8 deserializers - we'll handle binary data directly
+                security_protocol=self.security_protocol,
                 consumer_timeout_ms=1000,  # 1 second timeout for polling
+            )
+
+            # Add SASL settings when using SASL_SSL or SASL_PLAINTEXT
+            if self.security_protocol in ("SASL_SSL", "SASL_PLAINTEXT"):
+                if self.sasl_mechanism:
+                    consumer_kwargs["sasl_mechanism"] = self.sasl_mechanism
+                if self.sasl_jaas_config:
+                    # Parse JAAS config to extract username/password for kafka-python
+                    username, password = _parse_jaas_config(self.sasl_jaas_config)
+                    if username:
+                        consumer_kwargs["sasl_plain_username"] = username
+                    if password:
+                        consumer_kwargs["sasl_plain_password"] = password
+
+            self.consumer = KafkaConsumer(
+                self.topic,
+                **consumer_kwargs,
             )
 
             logging.info(f"Successfully connected to Kafka topic: {self.topic}")
@@ -345,3 +379,26 @@ class StrategyKafkaConsumer:
         except Exception as e:
             logging.error(f"Failed to get topic info: {e}")
             return {"topic": self.topic, "error": str(e)}
+
+
+def _parse_jaas_config(jaas_config: str) -> tuple:
+    """Parse a JAAS config string to extract username and password.
+
+    Expects format like:
+    org.apache.kafka.common.security.plain.PlainLoginModule required
+    username="user" password="pass";
+
+    Returns:
+        Tuple of (username, password), either may be None.
+    """
+    username = None
+    password = None
+    import re
+
+    username_match = re.search(r'username="([^"]*)"', jaas_config)
+    password_match = re.search(r'password="([^"]*)"', jaas_config)
+    if username_match:
+        username = username_match.group(1)
+    if password_match:
+        password = password_match.group(1)
+    return username, password

--- a/services/strategy_consumer/kafka_consumer_test.py
+++ b/services/strategy_consumer/kafka_consumer_test.py
@@ -13,7 +13,7 @@ from google.protobuf import any_pb2
 from google.protobuf import timestamp_pb2
 import datetime
 
-from services.strategy_consumer.kafka_consumer import StrategyKafkaConsumer
+from services.strategy_consumer.kafka_consumer import StrategyKafkaConsumer, _parse_jaas_config
 
 
 class TestStrategyKafkaConsumer:
@@ -253,3 +253,58 @@ class TestStrategyKafkaConsumer:
         assert result["topic"] == "test-topic"
         assert "error" in result
         assert result["error"] == "Test error"
+
+    def test_init_with_security_protocol(self):
+        """Test consumer initialization with SASL_SSL security."""
+        consumer = StrategyKafkaConsumer(
+            bootstrap_servers="kafka.example.com:9093",
+            topic="test-topic",
+            security_protocol="SASL_SSL",
+            sasl_mechanism="SCRAM-SHA-256",
+            sasl_jaas_config='org.apache.kafka.common.security.scram.ScramLoginModule required username="user" password="pass";',
+        )
+        assert consumer.security_protocol == "SASL_SSL"
+        assert consumer.sasl_mechanism == "SCRAM-SHA-256"
+        assert "user" in consumer.sasl_jaas_config
+
+    @patch.dict("os.environ", {"KAFKA_SECURITY_PROTOCOL": "SASL_SSL", "KAFKA_SASL_MECHANISM": "PLAIN"})
+    def test_init_security_from_env(self):
+        """Test consumer picks up security settings from environment."""
+        consumer = StrategyKafkaConsumer(
+            bootstrap_servers="localhost:9092",
+            topic="test-topic",
+        )
+        assert consumer.security_protocol == "SASL_SSL"
+        assert consumer.sasl_mechanism == "PLAIN"
+
+    def test_init_defaults_to_plaintext(self):
+        """Test consumer defaults to PLAINTEXT when no env vars set."""
+        consumer = StrategyKafkaConsumer(
+            bootstrap_servers="localhost:9092",
+            topic="test-topic",
+        )
+        assert consumer.security_protocol == "PLAINTEXT"
+
+
+class TestParseJaasConfig:
+    """Test cases for _parse_jaas_config helper."""
+
+    def test_parse_plain_login_module(self):
+        """Test parsing standard JAAS config."""
+        jaas = 'org.apache.kafka.common.security.plain.PlainLoginModule required username="myuser" password="mypass";'
+        username, password = _parse_jaas_config(jaas)
+        assert username == "myuser"
+        assert password == "mypass"
+
+    def test_parse_scram_login_module(self):
+        """Test parsing SCRAM JAAS config."""
+        jaas = 'org.apache.kafka.common.security.scram.ScramLoginModule required username="admin" password="secret123";'
+        username, password = _parse_jaas_config(jaas)
+        assert username == "admin"
+        assert password == "secret123"
+
+    def test_parse_empty_string(self):
+        """Test parsing empty JAAS config."""
+        username, password = _parse_jaas_config("")
+        assert username is None
+        assert password is None

--- a/services/strategy_consumer/kafka_consumer_test.py
+++ b/services/strategy_consumer/kafka_consumer_test.py
@@ -13,7 +13,10 @@ from google.protobuf import any_pb2
 from google.protobuf import timestamp_pb2
 import datetime
 
-from services.strategy_consumer.kafka_consumer import StrategyKafkaConsumer, _parse_jaas_config
+from services.strategy_consumer.kafka_consumer import (
+    StrategyKafkaConsumer,
+    _parse_jaas_config,
+)
 
 
 class TestStrategyKafkaConsumer:
@@ -267,7 +270,10 @@ class TestStrategyKafkaConsumer:
         assert consumer.sasl_mechanism == "SCRAM-SHA-256"
         assert "user" in consumer.sasl_jaas_config
 
-    @patch.dict("os.environ", {"KAFKA_SECURITY_PROTOCOL": "SASL_SSL", "KAFKA_SASL_MECHANISM": "PLAIN"})
+    @patch.dict(
+        "os.environ",
+        {"KAFKA_SECURITY_PROTOCOL": "SASL_SSL", "KAFKA_SASL_MECHANISM": "PLAIN"},
+    )
     def test_init_security_from_env(self):
         """Test consumer picks up security settings from environment."""
         consumer = StrategyKafkaConsumer(

--- a/services/strategy_consumer/main.py
+++ b/services/strategy_consumer/main.py
@@ -40,6 +40,24 @@ flags.DEFINE_string(
     "latest",
     "Kafka auto offset reset policy (earliest/latest).",
 )
+flags.DEFINE_string(
+    "kafka_security_protocol",
+    None,
+    "Kafka security protocol (PLAINTEXT, SASL_SSL, etc.). "
+    "Falls back to KAFKA_SECURITY_PROTOCOL env var, then PLAINTEXT.",
+)
+flags.DEFINE_string(
+    "kafka_sasl_mechanism",
+    None,
+    "Kafka SASL mechanism (PLAIN, SCRAM-SHA-256, SCRAM-SHA-512). "
+    "Falls back to KAFKA_SASL_MECHANISM env var.",
+)
+flags.DEFINE_string(
+    "kafka_sasl_jaas_config",
+    None,
+    "Kafka SASL JAAS configuration string. "
+    "Falls back to KAFKA_SASL_JAAS_CONFIG env var.",
+)
 
 # PostgreSQL Configuration Flags
 flags.DEFINE_string(
@@ -141,6 +159,9 @@ class StrategyConsumerService:
             topic=FLAGS.kafka_topic,
             group_id=FLAGS.kafka_group_id,
             auto_offset_reset=FLAGS.kafka_auto_offset_reset,
+            security_protocol=FLAGS.kafka_security_protocol,
+            sasl_mechanism=FLAGS.kafka_sasl_mechanism,
+            sasl_jaas_config=FLAGS.kafka_sasl_jaas_config,
         )
 
         # Connect to Kafka

--- a/src/main/java/com/verlumen/tradestream/discovery/KafkaDiscoveryRequestSource.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/KafkaDiscoveryRequestSource.kt
@@ -37,22 +37,22 @@ class KafkaDiscoveryRequestSource
             if (!securityProtocol.isNullOrEmpty()) {
                 kafkaRead =
                     kafkaRead.updateConsumerProperties(
-                    mapOf("security.protocol" to securityProtocol) as Map<String, Any>
-                )
+                        mapOf("security.protocol" to securityProtocol) as Map<String, Any>,
+                    )
             }
             val saslMechanism = System.getenv("KAFKA_SASL_MECHANISM")
             if (!saslMechanism.isNullOrEmpty()) {
                 kafkaRead =
                     kafkaRead.updateConsumerProperties(
-                    mapOf("sasl.mechanism" to saslMechanism) as Map<String, Any>
-                )
+                        mapOf("sasl.mechanism" to saslMechanism) as Map<String, Any>,
+                    )
             }
             val saslJaasConfig = System.getenv("KAFKA_SASL_JAAS_CONFIG")
             if (!saslJaasConfig.isNullOrEmpty()) {
                 kafkaRead =
                     kafkaRead.updateConsumerProperties(
-                    mapOf("sasl.jaas.config" to saslJaasConfig) as Map<String, Any>
-                )
+                        mapOf("sasl.jaas.config" to saslJaasConfig) as Map<String, Any>,
+                    )
             }
 
             return input.pipeline

--- a/src/main/java/com/verlumen/tradestream/discovery/KafkaDiscoveryRequestSource.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/KafkaDiscoveryRequestSource.kt
@@ -23,16 +23,39 @@ class KafkaDiscoveryRequestSource
         private val deserializeFn: DeserializeStrategyDiscoveryRequestFn,
         @Assisted private val options: StrategyDiscoveryPipelineOptions,
     ) : DiscoveryRequestSource() {
-        override fun expand(input: PBegin): PCollection<StrategyDiscoveryRequest> =
-            input.pipeline
+        override fun expand(input: PBegin): PCollection<StrategyDiscoveryRequest> {
+            var kafkaRead =
+                KafkaIO
+                    .read<String, ByteArray>()
+                    .withBootstrapServers(options.kafkaBootstrapServers)
+                    .withTopic(options.strategyDiscoveryRequestTopic)
+                    .withKeyDeserializer(StringDeserializer::class.java)
+                    .withValueDeserializer(ByteArrayDeserializer::class.java)
+
+            // Apply security settings from environment variables
+            val securityProtocol = System.getenv("KAFKA_SECURITY_PROTOCOL")
+            if (!securityProtocol.isNullOrEmpty()) {
+                kafkaRead = kafkaRead.updateConsumerProperties(
+                    mapOf("security.protocol" to securityProtocol) as Map<String, Any>
+                )
+            }
+            val saslMechanism = System.getenv("KAFKA_SASL_MECHANISM")
+            if (!saslMechanism.isNullOrEmpty()) {
+                kafkaRead = kafkaRead.updateConsumerProperties(
+                    mapOf("sasl.mechanism" to saslMechanism) as Map<String, Any>
+                )
+            }
+            val saslJaasConfig = System.getenv("KAFKA_SASL_JAAS_CONFIG")
+            if (!saslJaasConfig.isNullOrEmpty()) {
+                kafkaRead = kafkaRead.updateConsumerProperties(
+                    mapOf("sasl.jaas.config" to saslJaasConfig) as Map<String, Any>
+                )
+            }
+
+            return input.pipeline
                 .apply(
                     "ReadDiscoveryRequestsFromKafka",
-                    KafkaIO
-                        .read<String, ByteArray>()
-                        .withBootstrapServers(options.kafkaBootstrapServers)
-                        .withTopic(options.strategyDiscoveryRequestTopic)
-                        .withKeyDeserializer(StringDeserializer::class.java)
-                        .withValueDeserializer(ByteArrayDeserializer::class.java),
+                    kafkaRead,
                 ).apply(
                     "ExtractKVFromRecord",
                     MapElements.via(
@@ -41,4 +64,5 @@ class KafkaDiscoveryRequestSource
                         },
                     ),
                 ).apply("DeserializeProtoRequests", ParDo.of(deserializeFn))
+        }
     }

--- a/src/main/java/com/verlumen/tradestream/discovery/KafkaDiscoveryRequestSource.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/KafkaDiscoveryRequestSource.kt
@@ -35,19 +35,22 @@ class KafkaDiscoveryRequestSource
             // Apply security settings from environment variables
             val securityProtocol = System.getenv("KAFKA_SECURITY_PROTOCOL")
             if (!securityProtocol.isNullOrEmpty()) {
-                kafkaRead = kafkaRead.updateConsumerProperties(
+                kafkaRead =
+                    kafkaRead.updateConsumerProperties(
                     mapOf("security.protocol" to securityProtocol) as Map<String, Any>
                 )
             }
             val saslMechanism = System.getenv("KAFKA_SASL_MECHANISM")
             if (!saslMechanism.isNullOrEmpty()) {
-                kafkaRead = kafkaRead.updateConsumerProperties(
+                kafkaRead =
+                    kafkaRead.updateConsumerProperties(
                     mapOf("sasl.mechanism" to saslMechanism) as Map<String, Any>
                 )
             }
             val saslJaasConfig = System.getenv("KAFKA_SASL_JAAS_CONFIG")
             if (!saslJaasConfig.isNullOrEmpty()) {
-                kafkaRead = kafkaRead.updateConsumerProperties(
+                kafkaRead =
+                    kafkaRead.updateConsumerProperties(
                     mapOf("sasl.jaas.config" to saslJaasConfig) as Map<String, Any>
                 )
             }

--- a/src/main/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToKafkaFn.kt
+++ b/src/main/java/com/verlumen/tradestream/discovery/WriteDiscoveredStrategiesToKafkaFn.kt
@@ -57,6 +57,18 @@ class WriteDiscoveredStrategiesToKafkaFn
 
                     // Ordering guarantee
                     put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1)
+
+                    // Security settings from environment variables
+                    val securityProtocol = System.getenv("KAFKA_SECURITY_PROTOCOL") ?: "PLAINTEXT"
+                    put("security.protocol", securityProtocol)
+                    val saslMechanism = System.getenv("KAFKA_SASL_MECHANISM")
+                    if (!saslMechanism.isNullOrEmpty()) {
+                        put("sasl.mechanism", saslMechanism)
+                    }
+                    val saslJaasConfig = System.getenv("KAFKA_SASL_JAAS_CONFIG")
+                    if (!saslJaasConfig.isNullOrEmpty()) {
+                        put("sasl.jaas.config", saslJaasConfig)
+                    }
                 }
 
             kafkaProducer = KafkaProducer(props)

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaDefaults.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaDefaults.java
@@ -32,7 +32,16 @@ public final class KafkaDefaults {
       "org.apache.kafka.common.serialization.ByteArraySerializer";
 
   /** Protocol used to communicate with brokers (e.g., PLAINTEXT, SASL_SSL) */
-  public static final String SECURITY_PROTOCOL = "PLAINTEXT";
+  public static final String SECURITY_PROTOCOL =
+      System.getenv().getOrDefault("KAFKA_SECURITY_PROTOCOL", "PLAINTEXT");
+
+  /** SASL mechanism (e.g., PLAIN, SCRAM-SHA-256, SCRAM-SHA-512) */
+  public static final String SASL_MECHANISM =
+      System.getenv().getOrDefault("KAFKA_SASL_MECHANISM", "");
+
+  /** SASL JAAS configuration string */
+  public static final String SASL_JAAS_CONFIG =
+      System.getenv().getOrDefault("KAFKA_SASL_JAAS_CONFIG", "");
 
   // Private constructor to prevent instantiation
   private KafkaDefaults() {

--- a/src/main/java/com/verlumen/tradestream/kafka/KafkaProperties.java
+++ b/src/main/java/com/verlumen/tradestream/kafka/KafkaProperties.java
@@ -26,8 +26,8 @@ public record KafkaProperties(
         KafkaDefaults.KEY_SERIALIZER,
         KafkaDefaults.VALUE_SERIALIZER,
         KafkaDefaults.SECURITY_PROTOCOL,
-        "",
-        "",
+        KafkaDefaults.SASL_MECHANISM,
+        KafkaDefaults.SASL_JAAS_CONFIG,
         KafkaDefaults.ACKS,
         KafkaDefaults.LINGER_MS,
         KafkaDefaults.RETRIES);
@@ -45,8 +45,12 @@ public record KafkaProperties(
     kafkaProperties.setProperty("key.serializer", keySerializer);
     kafkaProperties.setProperty("value.serializer", valueSerializer);
     kafkaProperties.setProperty("security.protocol", securityProtocol);
-    kafkaProperties.setProperty("sasl.mechanism", saslMechanism);
-    kafkaProperties.setProperty("sasl.jaas.config", saslJaasConfig);
+    if (!saslMechanism.isEmpty()) {
+      kafkaProperties.setProperty("sasl.mechanism", saslMechanism);
+    }
+    if (!saslJaasConfig.isEmpty()) {
+      kafkaProperties.setProperty("sasl.jaas.config", saslJaasConfig);
+    }
     return kafkaProperties;
   }
 }

--- a/src/test/java/com/verlumen/tradestream/kafka/KafkaPropertiesTest.java
+++ b/src/test/java/com/verlumen/tradestream/kafka/KafkaPropertiesTest.java
@@ -95,7 +95,8 @@ public class KafkaPropertiesTest {
             "org.apache.kafka.common.serialization.ByteArraySerializer",
             "SASL_SSL",
             "SCRAM-SHA-256",
-            "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"user\" password=\"pass\";",
+            "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"user\""
+                + " password=\"pass\";",
             "all",
             50,
             5);
@@ -106,8 +107,7 @@ public class KafkaPropertiesTest {
     // Assert
     assertThat(kafkaProps.getProperty("security.protocol")).isEqualTo("SASL_SSL");
     assertThat(kafkaProps.getProperty("sasl.mechanism")).isEqualTo("SCRAM-SHA-256");
-    assertThat(kafkaProps.getProperty("sasl.jaas.config"))
-        .contains("ScramLoginModule");
+    assertThat(kafkaProps.getProperty("sasl.jaas.config")).contains("ScramLoginModule");
   }
 
   @Test

--- a/src/test/java/com/verlumen/tradestream/kafka/KafkaPropertiesTest.java
+++ b/src/test/java/com/verlumen/tradestream/kafka/KafkaPropertiesTest.java
@@ -82,4 +82,57 @@ public class KafkaPropertiesTest {
     assertThat(kafkaProps.getProperty("retries")).isEqualTo("5");
     assertThat(kafkaProps.getProperty("linger.ms")).isEqualTo("50");
   }
+
+  @Test
+  public void kafkaProperties_withSaslSsl_includesSaslProperties() {
+    // Arrange
+    KafkaProperties supplier =
+        new KafkaProperties(
+            16384,
+            "kafka.example.com:9093",
+            33554432,
+            "org.apache.kafka.common.serialization.StringSerializer",
+            "org.apache.kafka.common.serialization.ByteArraySerializer",
+            "SASL_SSL",
+            "SCRAM-SHA-256",
+            "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"user\" password=\"pass\";",
+            "all",
+            50,
+            5);
+
+    // Act
+    Properties kafkaProps = supplier.get();
+
+    // Assert
+    assertThat(kafkaProps.getProperty("security.protocol")).isEqualTo("SASL_SSL");
+    assertThat(kafkaProps.getProperty("sasl.mechanism")).isEqualTo("SCRAM-SHA-256");
+    assertThat(kafkaProps.getProperty("sasl.jaas.config"))
+        .contains("ScramLoginModule");
+  }
+
+  @Test
+  public void kafkaProperties_withPlaintext_omitsSaslProperties() {
+    // Arrange
+    KafkaProperties supplier =
+        new KafkaProperties(
+            16384,
+            "localhost:9092",
+            33554432,
+            "org.apache.kafka.common.serialization.StringSerializer",
+            "org.apache.kafka.common.serialization.ByteArraySerializer",
+            "PLAINTEXT",
+            "",
+            "",
+            "all",
+            50,
+            5);
+
+    // Act
+    Properties kafkaProps = supplier.get();
+
+    // Assert
+    assertThat(kafkaProps.getProperty("security.protocol")).isEqualTo("PLAINTEXT");
+    assertThat(kafkaProps.containsKey("sasl.mechanism")).isFalse();
+    assertThat(kafkaProps.containsKey("sasl.jaas.config")).isFalse();
+  }
 }


### PR DESCRIPTION
## Summary

- Addresses **P1 audit finding S4**: Kafka uses PLAINTEXT security protocol
- Configures all Kafka producers and consumers (Java, Kotlin, Python) to support **SASL_SSL** authentication via environment variables
- Defaults to PLAINTEXT for local dev; production deployments set `KAFKA_SECURITY_PROTOCOL=SASL_SSL` via Helm values
- SASL properties (`sasl.mechanism`, `sasl.jaas.config`) are only included when non-empty, preventing invalid configs in PLAINTEXT mode

### Components updated
| Component | Language | Change |
|-----------|----------|--------|
| `KafkaDefaults` | Java | Read `KAFKA_SECURITY_PROTOCOL`, `KAFKA_SASL_MECHANISM`, `KAFKA_SASL_JAAS_CONFIG` from env |
| `KafkaProperties` | Java | Conditionally set SASL properties |
| `WriteDiscoveredStrategiesToKafkaFn` | Kotlin | Apply security env vars to producer |
| `KafkaDiscoveryRequestSource` | Kotlin | Apply security env vars to Beam KafkaIO consumer |
| `kafka_consumer.py` | Python | Accept security params via constructor/env, parse JAAS for kafka-python |
| `main.py` | Python | Add `--kafka_security_protocol`, `--kafka_sasl_mechanism`, `--kafka_sasl_jaas_config` flags |
| Helm charts | YAML | Add security config values and template env vars |

## Test plan

- [x] Java unit tests: verify SASL_SSL properties are set correctly, PLAINTEXT omits SASL props
- [x] Python unit tests: verify security protocol from constructor, env vars, and JAAS config parsing
- [ ] CI builds and tests pass
- [ ] Deploy to staging with `kafkaSecurityProtocol: SASL_SSL` and verify Kafka connectivity

🤖 Generated with [Claude Code](https://claude.com/claude-code)