### PR TITLE
Add integration tests for agent LLM loops

### DIFF
--- a/services/agent_gateway/BUILD
+++ b/services/agent_gateway/BUILD
@@ -42,6 +42,20 @@ py_test(
     ],
 )
 
+py_test(
+    name = "llm_integration_test",
+    srcs = [
+        "conftest.py",
+        "llm_integration_test.py",
+    ],
+    deps = [
+        ":agent_gateway_lib",
+        "//third_party/python:httpx",
+        "//third_party/python:pytest",
+        "//third_party/python:pytest_asyncio",
+    ],
+)
+
 py_image_layer(
     name = "layers",
     binary = ":app",

--- a/services/agent_gateway/llm_integration_test.py
+++ b/services/agent_gateway/llm_integration_test.py
@@ -1,0 +1,354 @@
+"""Integration tests for the Agent Gateway event streaming.
+
+Tests the gateway's handling of agent LLM decision events:
+- Event classification from agent_decisions rows
+- SSE streaming with Redis pub/sub
+- Event filtering by agent name and type
+- Error event handling for LLM failures
+"""
+
+import json
+import uuid
+from datetime import datetime, timezone
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.agent_gateway.main import (
+    _row_to_event,
+    _serialize_row,
+    app,
+    publish_event,
+)
+
+_MODULE = "services.agent_gateway.main"
+
+
+class FakeRecord(dict):
+    """Mimics asyncpg.Record for testing."""
+
+    def __init__(self, data):
+        super().__init__(data)
+
+
+def _make_decision_row(**overrides):
+    """Create a realistic agent_decisions row with LLM metadata."""
+    defaults = {
+        "id": uuid.uuid4(),
+        "signal_id": None,
+        "score": Decimal("0.00"),
+        "tier": None,
+        "reasoning": None,
+        "tool_calls": None,
+        "agent_name": "strategy-proposer",
+        "decision_type": "strategy_proposal",
+        "input_context": None,
+        "output": None,
+        "model_used": "anthropic/claude-3-5-sonnet",
+        "latency_ms": 2500,
+        "tokens_used": 1200,
+        "success": True,
+        "error_message": None,
+        "parent_decision_id": None,
+        "created_at": datetime(2026, 3, 10, 14, 0, 0, tzinfo=timezone.utc),
+    }
+    defaults.update(overrides)
+    return FakeRecord(defaults)
+
+
+class TestLlmDecisionEventClassification:
+    """Tests that LLM agent decisions are classified into correct event types."""
+
+    def test_strategy_proposal_with_reasoning(self):
+        """A strategy proposal with reasoning is classified as 'reasoning'."""
+        row = _serialize_row(
+            _make_decision_row(
+                reasoning="Identified gap in volatility strategies using ADX + CCI",
+                model_used="anthropic/claude-3-5-sonnet",
+                tokens_used=1500,
+            )
+        )
+        event = _row_to_event(row)
+        assert event["event_type"] == "reasoning"
+        assert event["model_used"] == "anthropic/claude-3-5-sonnet"
+        assert event["tokens_used"] == 1500
+
+    def test_tool_call_event_overrides_reasoning(self):
+        """When both reasoning and tool_calls exist, tool_call takes priority."""
+        row = _serialize_row(
+            _make_decision_row(
+                reasoning="Calling list_strategy_types to check existing",
+                tool_calls=[
+                    {"name": "list_strategy_types", "arguments": {}, "result": "..."}
+                ],
+            )
+        )
+        event = _row_to_event(row)
+        assert event["event_type"] == "tool_call"
+
+    def test_llm_error_event_preserves_error_message(self):
+        """Failed LLM decisions preserve the error message in events."""
+        row = _serialize_row(
+            _make_decision_row(
+                success=False,
+                error_message="Rate limit exceeded - 429",
+                model_used="anthropic/claude-3-5-sonnet",
+                latency_ms=150,
+                tokens_used=0,
+            )
+        )
+        event = _row_to_event(row)
+        assert event["success"] is False
+        assert event["error_message"] == "Rate limit exceeded - 429"
+        assert event["tokens_used"] == 0
+
+    def test_decision_with_no_llm_metadata(self):
+        """Decision without reasoning/tool_calls/signal is 'decision'."""
+        row = _serialize_row(
+            _make_decision_row(
+                reasoning=None,
+                tool_calls=None,
+                signal_id=None,
+            )
+        )
+        event = _row_to_event(row)
+        assert event["event_type"] == "decision"
+
+    def test_signal_event_takes_highest_priority(self):
+        """Signal events override both reasoning and tool_call classification."""
+        sig_id = uuid.uuid4()
+        row = _serialize_row(
+            _make_decision_row(
+                signal_id=sig_id,
+                reasoning="Generated buy signal",
+                tool_calls=[{"name": "get_candles"}],
+                agent_name="signal-generator",
+            )
+        )
+        event = _row_to_event(row)
+        assert event["event_type"] == "signal"
+        assert event["signal_id"] == str(sig_id)
+
+
+class TestLlmMetadataSerialization:
+    """Tests that LLM metadata (tokens, latency, model) serializes correctly."""
+
+    def test_high_token_count_serializes(self):
+        row = _serialize_row(
+            _make_decision_row(tokens_used=50000, latency_ms=15000)
+        )
+        event = _row_to_event(row)
+        assert event["tokens_used"] == 50000
+        assert event["latency_ms"] == 15000
+
+    def test_decimal_score_converts_to_float(self):
+        row = _serialize_row(_make_decision_row(score=Decimal("0.9234")))
+        assert isinstance(row["score"], float)
+        assert abs(row["score"] - 0.9234) < 1e-6
+
+    def test_uuid_fields_convert_to_string(self):
+        test_id = uuid.uuid4()
+        sig_id = uuid.uuid4()
+        row = _serialize_row(_make_decision_row(id=test_id, signal_id=sig_id))
+        assert row["id"] == str(test_id)
+        assert row["signal_id"] == str(sig_id)
+
+    def test_datetime_converts_to_iso(self):
+        dt = datetime(2026, 3, 10, 14, 30, 0, tzinfo=timezone.utc)
+        row = _serialize_row(_make_decision_row(created_at=dt))
+        assert row["created_at"] == "2026-03-10T14:30:00+00:00"
+
+
+class TestRecentEventsWithLlmFiltering:
+    """Tests for /events/recent endpoint with LLM-specific filtering."""
+
+    @pytest.mark.asyncio
+    async def test_filter_strategy_proposer_events(self):
+        """Filter events by strategy-proposer agent name."""
+        from httpx import ASGITransport, AsyncClient
+
+        mock_rows = [
+            _make_decision_row(
+                reasoning="Proposing new strategy",
+                model_used="anthropic/claude-3-5-sonnet",
+                tokens_used=2000,
+            )
+        ]
+
+        mock_pool = MagicMock()
+        mock_conn = AsyncMock()
+        mock_conn.fetch = AsyncMock(return_value=mock_rows)
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_cm.__aexit__ = AsyncMock(return_value=None)
+        mock_pool.acquire.return_value = mock_cm
+
+        mock_redis = AsyncMock()
+
+        with patch(f"{_MODULE}._db_pool", mock_pool), patch(
+            f"{_MODULE}._redis", mock_redis
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as client:
+                response = await client.get(
+                    "/events/recent?agent_name=strategy-proposer&limit=10"
+                )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["count"] == 1
+        event = data["events"][0]
+        assert event["event_type"] == "reasoning"
+        assert event["model_used"] == "anthropic/claude-3-5-sonnet"
+
+    @pytest.mark.asyncio
+    async def test_filter_tool_call_events(self):
+        """Filter events by tool_call event type."""
+        from httpx import ASGITransport, AsyncClient
+
+        mock_rows = [
+            _make_decision_row(
+                tool_calls=[{"name": "list_strategy_types", "arguments": {}}],
+                reasoning="Calling tool",
+            )
+        ]
+
+        mock_pool = MagicMock()
+        mock_conn = AsyncMock()
+        mock_conn.fetch = AsyncMock(return_value=mock_rows)
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_cm.__aexit__ = AsyncMock(return_value=None)
+        mock_pool.acquire.return_value = mock_cm
+
+        mock_redis = AsyncMock()
+
+        with patch(f"{_MODULE}._db_pool", mock_pool), patch(
+            f"{_MODULE}._redis", mock_redis
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as client:
+                response = await client.get(
+                    "/events/recent?event_type=tool_call&limit=10"
+                )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["count"] == 1
+        assert data["events"][0]["event_type"] == "tool_call"
+
+        # Verify query includes tool_calls filter
+        mock_conn.fetch.assert_called_once()
+        query = mock_conn.fetch.call_args[0][0]
+        assert "tool_calls IS NOT NULL" in query
+
+
+class TestPublishEvent:
+    """Tests for the publish_event function used by agents."""
+
+    @pytest.mark.asyncio
+    async def test_publish_llm_decision_event(self):
+        """Verify agent LLM decision events are published to Redis."""
+        mock_redis = AsyncMock()
+        mock_redis.publish = AsyncMock()
+
+        event = {
+            "event_type": "reasoning",
+            "agent_name": "strategy-proposer",
+            "model_used": "anthropic/claude-3-5-sonnet",
+            "tokens_used": 1500,
+            "reasoning": "Identified gap in volatility strategies",
+        }
+
+        with patch(f"{_MODULE}._redis", mock_redis):
+            await publish_event(event)
+
+        mock_redis.publish.assert_called_once_with(
+            "agent_events", json.dumps(event)
+        )
+
+    @pytest.mark.asyncio
+    async def test_publish_tool_call_event(self):
+        """Verify tool call events include tool details."""
+        mock_redis = AsyncMock()
+        mock_redis.publish = AsyncMock()
+
+        event = {
+            "event_type": "tool_call",
+            "agent_name": "strategy-proposer",
+            "tool_calls": [
+                {"name": "get_top_strategies", "arguments": {"symbol": "BTC-USD"}}
+            ],
+        }
+
+        with patch(f"{_MODULE}._redis", mock_redis):
+            await publish_event(event)
+
+        mock_redis.publish.assert_called_once()
+        published = json.loads(mock_redis.publish.call_args[0][1])
+        assert published["tool_calls"][0]["name"] == "get_top_strategies"
+
+    @pytest.mark.asyncio
+    async def test_publish_skipped_when_redis_none(self):
+        """No error when Redis is not connected."""
+        with patch(f"{_MODULE}._redis", None):
+            # Should not raise
+            await publish_event({"event_type": "test"})
+
+
+class TestSseStreamFiltering:
+    """Tests for SSE stream with agent/event_type filtering."""
+
+    @pytest.mark.asyncio
+    async def test_stream_filters_by_agent_name(self):
+        """SSE stream only yields events matching agent_name filter."""
+        from httpx import ASGITransport, AsyncClient
+
+        mock_redis = AsyncMock()
+        mock_pubsub = AsyncMock()
+
+        async def mock_listen():
+            # Emit two events: one matching, one not
+            yield {
+                "type": "message",
+                "data": json.dumps(
+                    {
+                        "event_type": "reasoning",
+                        "agent_name": "strategy-proposer",
+                        "model_used": "claude-3-5-sonnet",
+                    }
+                ),
+            }
+            yield {
+                "type": "message",
+                "data": json.dumps(
+                    {
+                        "event_type": "signal",
+                        "agent_name": "signal-generator",
+                    }
+                ),
+            }
+
+        mock_pubsub.listen = mock_listen
+        mock_pubsub.subscribe = AsyncMock()
+        mock_pubsub.unsubscribe = AsyncMock()
+        mock_pubsub.aclose = AsyncMock()
+        mock_redis.pubsub.return_value = mock_pubsub
+
+        with patch(f"{_MODULE}._redis", mock_redis):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as client:
+                response = await client.get(
+                    "/events/stream?agent_name=strategy-proposer"
+                )
+
+        assert response.status_code == 200
+        # The SSE response should contain only the strategy-proposer event
+        assert "strategy-proposer" in response.text

--- a/services/agent_gateway/llm_integration_test.py
+++ b/services/agent_gateway/llm_integration_test.py
@@ -135,9 +135,7 @@ class TestLlmMetadataSerialization:
     """Tests that LLM metadata (tokens, latency, model) serializes correctly."""
 
     def test_high_token_count_serializes(self):
-        row = _serialize_row(
-            _make_decision_row(tokens_used=50000, latency_ms=15000)
-        )
+        row = _serialize_row(_make_decision_row(tokens_used=50000, latency_ms=15000))
         event = _row_to_event(row)
         assert event["tokens_used"] == 50000
         assert event["latency_ms"] == 15000
@@ -268,9 +266,7 @@ class TestPublishEvent:
         with patch(f"{_MODULE}._redis", mock_redis):
             await publish_event(event)
 
-        mock_redis.publish.assert_called_once_with(
-            "agent_events", json.dumps(event)
-        )
+        mock_redis.publish.assert_called_once_with("agent_events", json.dumps(event))
 
     @pytest.mark.asyncio
     async def test_publish_tool_call_event(self):

--- a/services/strategy_proposer_agent/BUILD
+++ b/services/strategy_proposer_agent/BUILD
@@ -38,6 +38,17 @@ py_test(
     ],
 )
 
+py_test(
+    name = "llm_integration_test",
+    srcs = ["llm_integration_test.py"],
+    deps = [
+        ":agent_lib",
+        "//third_party/python:openai",
+        "//third_party/python:pytest",
+        "//third_party/python:requests",
+    ],
+)
+
 # --- OCI Image Rules ---
 py_image_layer(
     name = "layers",

--- a/services/strategy_proposer_agent/llm_integration_test.py
+++ b/services/strategy_proposer_agent/llm_integration_test.py
@@ -1,0 +1,390 @@
+"""Integration tests for the Strategy Proposer Agent LLM loop.
+
+Tests the full agent loop with mocked LLM and MCP endpoints, verifying:
+- Multi-turn conversation flow with tool calls
+- Error handling for LLM API failures
+- Token limit / max iteration handling
+- Message history accumulation
+- Tool call argument parsing and dispatch
+"""
+
+import json
+from unittest import mock
+
+import pytest
+
+from services.strategy_proposer_agent import agent
+
+
+def _make_llm_tool_call(tc_id, fn_name, fn_args=None):
+    """Create a mock tool call from the LLM."""
+    tc = mock.Mock()
+    tc.id = tc_id
+    tc.function.name = fn_name
+    tc.function.arguments = json.dumps(fn_args or {})
+    return tc
+
+
+def _make_llm_response(message, finish_reason="tool_calls"):
+    """Create a mock LLM completion response."""
+    choice = mock.Mock()
+    choice.finish_reason = finish_reason
+    choice.message = message
+    resp = mock.Mock()
+    resp.choices = [choice]
+    return resp
+
+
+def _make_tool_call_message(tool_calls):
+    """Create a mock assistant message with tool calls."""
+    msg = mock.Mock()
+    msg.tool_calls = tool_calls
+    msg.content = None
+    msg.model_dump.return_value = {
+        "role": "assistant",
+        "tool_calls": [
+            {
+                "id": tc.id,
+                "function": {
+                    "name": tc.function.name,
+                    "arguments": tc.function.arguments,
+                },
+                "type": "function",
+            }
+            for tc in tool_calls
+        ],
+    }
+    return msg
+
+
+def _make_final_message(content):
+    """Create a mock final assistant message (no tool calls)."""
+    msg = mock.Mock()
+    msg.tool_calls = None
+    msg.content = content
+    msg.model_dump.return_value = {"role": "assistant", "content": content}
+    return msg
+
+
+def _make_mcp_http_response(data):
+    """Create a mock successful MCP HTTP response."""
+    resp = mock.Mock()
+    resp.status_code = 200
+    resp.json.return_value = {
+        "content": [{"type": "text", "text": json.dumps(data)}]
+    }
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+_VALID_SPEC = {
+    "name": "adx_cci_momentum",
+    "indicators": {
+        "ADX": {"period": 14},
+        "CCI": {"period": 20},
+        "EMA": {"period": 50},
+    },
+    "entry_conditions": {
+        "long": "ADX > 25 AND CCI crosses above 0 AND price > EMA(50)"
+    },
+    "exit_conditions": {
+        "stop_loss": "price < EMA(50) - 1.5 * ATR(14)",
+        "take_profit": "CCI > 200 OR ADX < 20",
+    },
+    "parameters": {"adx_period": 14, "cci_period": 20, "ema_period": 50},
+    "description": "Momentum strategy using ADX for trend strength and CCI for entry timing",
+}
+
+_MCP_URLS = {"strategy": "http://strategy-mcp:8080"}
+
+
+class TestMultiTurnConversation:
+    """Tests for multi-turn LLM conversation with tool calls."""
+
+    @mock.patch("requests.post")
+    @mock.patch("services.strategy_proposer_agent.agent.OpenAI")
+    def test_three_turn_workflow(self, mock_openai_cls, mock_post):
+        """Agent: list_strategy_types -> get_top_strategies -> final spec."""
+        mock_client = mock.Mock()
+        mock_openai_cls.return_value = mock_client
+
+        # Turn 1: LLM calls list_strategy_types
+        tc1 = _make_llm_tool_call("tc_1", "list_strategy_types")
+        msg1 = _make_tool_call_message([tc1])
+        resp1 = _make_llm_response(msg1)
+
+        # Turn 2: LLM calls get_top_strategies
+        tc2 = _make_llm_tool_call(
+            "tc_2", "get_top_strategies", {"symbol": "BTC-USD", "limit": 5}
+        )
+        msg2 = _make_tool_call_message([tc2])
+        resp2 = _make_llm_response(msg2)
+
+        # Turn 3: LLM finishes with spec
+        msg3 = _make_final_message(json.dumps(_VALID_SPEC))
+        resp3 = _make_llm_response(msg3, finish_reason="stop")
+
+        mock_client.chat.completions.create.side_effect = [resp1, resp2, resp3]
+
+        # MCP responses
+        mock_post.return_value = _make_mcp_http_response(
+            ["momentum", "mean_reversion", "breakout"]
+        )
+
+        result = agent.run_proposer_agent("test-key", _MCP_URLS)
+
+        assert result is not None
+        parsed = json.loads(result)
+        assert parsed["name"] == "adx_cci_momentum"
+        assert mock_client.chat.completions.create.call_count == 3
+
+    @mock.patch("requests.post")
+    @mock.patch("services.strategy_proposer_agent.agent.OpenAI")
+    def test_parallel_tool_calls_in_single_turn(self, mock_openai_cls, mock_post):
+        """LLM issues multiple tool calls in a single turn."""
+        mock_client = mock.Mock()
+        mock_openai_cls.return_value = mock_client
+
+        # Turn 1: LLM calls two tools at once
+        tc1 = _make_llm_tool_call("tc_1", "list_strategy_types")
+        tc2 = _make_llm_tool_call(
+            "tc_2", "get_top_strategies", {"symbol": "BTC-USD"}
+        )
+        msg1 = _make_tool_call_message([tc1, tc2])
+        resp1 = _make_llm_response(msg1)
+
+        # Turn 2: final
+        msg2 = _make_final_message(json.dumps(_VALID_SPEC))
+        resp2 = _make_llm_response(msg2, finish_reason="stop")
+
+        mock_client.chat.completions.create.side_effect = [resp1, resp2]
+        mock_post.return_value = _make_mcp_http_response(["momentum"])
+
+        result = agent.run_proposer_agent("test-key", _MCP_URLS)
+
+        assert result is not None
+        # Both tool results should be appended to messages
+        assert mock_post.call_count == 2
+
+    @mock.patch("requests.post")
+    @mock.patch("services.strategy_proposer_agent.agent.OpenAI")
+    def test_message_history_accumulates(self, mock_openai_cls, mock_post):
+        """Verify messages grow with each turn (system + user + assistant + tool)."""
+        mock_client = mock.Mock()
+        mock_openai_cls.return_value = mock_client
+
+        tc1 = _make_llm_tool_call("tc_1", "list_strategy_types")
+        msg1 = _make_tool_call_message([tc1])
+        resp1 = _make_llm_response(msg1)
+
+        msg2 = _make_final_message(json.dumps(_VALID_SPEC))
+        resp2 = _make_llm_response(msg2, finish_reason="stop")
+
+        mock_client.chat.completions.create.side_effect = [resp1, resp2]
+        mock_post.return_value = _make_mcp_http_response([])
+
+        agent.run_proposer_agent("test-key", _MCP_URLS)
+
+        calls = mock_client.chat.completions.create.call_args_list
+        # First call: system + user = 2 messages
+        assert len(calls[0].kwargs["messages"]) == 2
+        # Second call: system + user + assistant(tool_call) + tool_result = 4
+        assert len(calls[1].kwargs["messages"]) == 4
+
+
+class TestLlmErrorHandling:
+    """Tests for LLM API error handling."""
+
+    @mock.patch("services.strategy_proposer_agent.agent.OpenAI")
+    def test_openai_api_error_propagates(self, mock_openai_cls):
+        """An unhandled OpenAI API error should propagate up."""
+        from openai import APIError
+
+        mock_client = mock.Mock()
+        mock_openai_cls.return_value = mock_client
+        mock_client.chat.completions.create.side_effect = APIError(
+            message="Rate limit exceeded",
+            request=mock.Mock(),
+            body=None,
+        )
+
+        with pytest.raises(APIError):
+            agent.run_proposer_agent("test-key", _MCP_URLS)
+
+    @mock.patch("requests.post")
+    @mock.patch("services.strategy_proposer_agent.agent.OpenAI")
+    def test_malformed_tool_args_handled(self, mock_openai_cls, mock_post):
+        """LLM returns invalid JSON in tool call arguments."""
+        mock_client = mock.Mock()
+        mock_openai_cls.return_value = mock_client
+
+        tc1 = mock.Mock()
+        tc1.id = "tc_bad"
+        tc1.function.name = "list_strategy_types"
+        tc1.function.arguments = "not valid json{{"
+
+        msg1 = mock.Mock()
+        msg1.tool_calls = [tc1]
+        msg1.content = None
+        msg1.model_dump.return_value = {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "tc_bad",
+                    "function": {
+                        "name": "list_strategy_types",
+                        "arguments": "not valid json{{",
+                    },
+                    "type": "function",
+                }
+            ],
+        }
+        resp1 = _make_llm_response(msg1)
+
+        msg2 = _make_final_message(json.dumps(_VALID_SPEC))
+        resp2 = _make_llm_response(msg2, finish_reason="stop")
+
+        mock_client.chat.completions.create.side_effect = [resp1, resp2]
+        mock_post.return_value = _make_mcp_http_response([])
+
+        # Should not crash - malformed args fallback to {}
+        result = agent.run_proposer_agent("test-key", _MCP_URLS)
+        assert result is not None
+
+    @mock.patch("requests.post")
+    @mock.patch("services.strategy_proposer_agent.agent.OpenAI")
+    def test_mcp_failure_doesnt_crash_loop(self, mock_openai_cls, mock_post):
+        """MCP tool returning an error doesn't stop the agent loop."""
+        import requests as req_lib
+
+        mock_client = mock.Mock()
+        mock_openai_cls.return_value = mock_client
+
+        tc1 = _make_llm_tool_call("tc_1", "list_strategy_types")
+        msg1 = _make_tool_call_message([tc1])
+        resp1 = _make_llm_response(msg1)
+
+        msg2 = _make_final_message(json.dumps(_VALID_SPEC))
+        resp2 = _make_llm_response(msg2, finish_reason="stop")
+
+        mock_client.chat.completions.create.side_effect = [resp1, resp2]
+
+        # MCP call fails
+        mock_post.side_effect = req_lib.ConnectionError("connection refused")
+
+        result = agent.run_proposer_agent("test-key", _MCP_URLS)
+        # Agent should still complete (error is returned as tool result)
+        assert result is not None
+
+
+class TestMaxIterations:
+    """Tests for iteration limit behavior."""
+
+    @mock.patch("requests.post")
+    @mock.patch("services.strategy_proposer_agent.agent.OpenAI")
+    def test_returns_none_at_max_iterations(self, mock_openai_cls, mock_post):
+        """Agent returns None when max iterations reached without finishing."""
+        mock_client = mock.Mock()
+        mock_openai_cls.return_value = mock_client
+
+        tc = _make_llm_tool_call("tc_loop", "list_strategy_types")
+        msg = _make_tool_call_message([tc])
+        resp = _make_llm_response(msg)
+
+        mock_client.chat.completions.create.return_value = resp
+        mock_post.return_value = _make_mcp_http_response([])
+
+        result = agent.run_proposer_agent("test-key", _MCP_URLS)
+
+        assert result is None
+        assert mock_client.chat.completions.create.call_count == 20
+
+    @mock.patch("requests.post")
+    @mock.patch("services.strategy_proposer_agent.agent.OpenAI")
+    def test_finishes_early_on_stop(self, mock_openai_cls, mock_post):
+        """Agent exits loop immediately when finish_reason is 'stop'."""
+        mock_client = mock.Mock()
+        mock_openai_cls.return_value = mock_client
+
+        msg = _make_final_message(json.dumps(_VALID_SPEC))
+        resp = _make_llm_response(msg, finish_reason="stop")
+
+        mock_client.chat.completions.create.return_value = resp
+
+        result = agent.run_proposer_agent("test-key", _MCP_URLS)
+
+        assert result is not None
+        assert mock_client.chat.completions.create.call_count == 1
+
+    @mock.patch("requests.post")
+    @mock.patch("services.strategy_proposer_agent.agent.OpenAI")
+    def test_finishes_when_no_tool_calls(self, mock_openai_cls, mock_post):
+        """Agent exits when LLM returns no tool_calls (even if finish_reason != stop)."""
+        mock_client = mock.Mock()
+        mock_openai_cls.return_value = mock_client
+
+        msg = _make_final_message(json.dumps(_VALID_SPEC))
+        # finish_reason is not "stop" but no tool_calls
+        resp = _make_llm_response(msg, finish_reason="length")
+
+        mock_client.chat.completions.create.return_value = resp
+
+        result = agent.run_proposer_agent("test-key", _MCP_URLS)
+        assert result is not None
+        assert mock_client.chat.completions.create.call_count == 1
+
+
+class TestOpenAIClientConfiguration:
+    """Tests for OpenAI client setup."""
+
+    @mock.patch("requests.post")
+    @mock.patch("services.strategy_proposer_agent.agent.OpenAI")
+    def test_uses_openrouter_base_url(self, mock_openai_cls, mock_post):
+        """Client is configured with OpenRouter base URL."""
+        mock_client = mock.Mock()
+        mock_openai_cls.return_value = mock_client
+
+        msg = _make_final_message("{}")
+        resp = _make_llm_response(msg, finish_reason="stop")
+        mock_client.chat.completions.create.return_value = resp
+
+        agent.run_proposer_agent("my-api-key", _MCP_URLS)
+
+        mock_openai_cls.assert_called_once_with(
+            api_key="my-api-key",
+            base_url="https://openrouter.ai/api/v1",
+        )
+
+    @mock.patch("requests.post")
+    @mock.patch("services.strategy_proposer_agent.agent.OpenAI")
+    def test_uses_correct_model(self, mock_openai_cls, mock_post):
+        """LLM calls use anthropic/claude-3-5-sonnet model."""
+        mock_client = mock.Mock()
+        mock_openai_cls.return_value = mock_client
+
+        msg = _make_final_message("{}")
+        resp = _make_llm_response(msg, finish_reason="stop")
+        mock_client.chat.completions.create.return_value = resp
+
+        agent.run_proposer_agent("key", _MCP_URLS)
+
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert call_kwargs["model"] == "anthropic/claude-3-5-sonnet"
+
+    @mock.patch("requests.post")
+    @mock.patch("services.strategy_proposer_agent.agent.OpenAI")
+    def test_sends_tools_and_system_prompt(self, mock_openai_cls, mock_post):
+        """LLM calls include MCP tools and system prompt."""
+        mock_client = mock.Mock()
+        mock_openai_cls.return_value = mock_client
+
+        msg = _make_final_message("{}")
+        resp = _make_llm_response(msg, finish_reason="stop")
+        mock_client.chat.completions.create.return_value = resp
+
+        agent.run_proposer_agent("key", _MCP_URLS)
+
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert call_kwargs["tools"] == agent.MCP_TOOLS
+        assert call_kwargs["messages"][0]["role"] == "system"
+        assert call_kwargs["messages"][0]["content"] == agent.SYSTEM_PROMPT

--- a/services/strategy_proposer_agent/llm_integration_test.py
+++ b/services/strategy_proposer_agent/llm_integration_test.py
@@ -70,9 +70,7 @@ def _make_mcp_http_response(data):
     """Create a mock successful MCP HTTP response."""
     resp = mock.Mock()
     resp.status_code = 200
-    resp.json.return_value = {
-        "content": [{"type": "text", "text": json.dumps(data)}]
-    }
+    resp.json.return_value = {"content": [{"type": "text", "text": json.dumps(data)}]}
     resp.raise_for_status.return_value = None
     return resp
 
@@ -147,9 +145,7 @@ class TestMultiTurnConversation:
 
         # Turn 1: LLM calls two tools at once
         tc1 = _make_llm_tool_call("tc_1", "list_strategy_types")
-        tc2 = _make_llm_tool_call(
-            "tc_2", "get_top_strategies", {"symbol": "BTC-USD"}
-        )
+        tc2 = _make_llm_tool_call("tc_2", "get_top_strategies", {"symbol": "BTC-USD"})
         msg1 = _make_tool_call_message([tc1, tc2])
         resp1 = _make_llm_response(msg1)
 


### PR DESCRIPTION
## Summary
- Add integration tests for the **strategy proposer agent** LLM loop: multi-turn conversation flow, parallel tool calls, message history accumulation, LLM API error propagation, malformed tool argument handling, MCP failure resilience, max iteration limits, and OpenAI client configuration verification
- Add integration tests for the **agent gateway** event streaming: LLM decision event classification (reasoning/tool_call/signal/decision), metadata serialization (tokens, latency, model), recent events endpoint filtering, Redis pub/sub event publishing, and SSE stream filtering by agent name

## Test plan
- [x] `bazel test //services/strategy_proposer_agent:llm_integration_test` passes
- [x] `bazel test //services/agent_gateway:llm_integration_test` passes
- [x] Existing tests still pass (`agent_test`, `main_test`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)