### PR TITLE
fix(backtesting): replace hardcoded risk metrics with real calculations

### DIFF
--- a/services/backtesting/tests/test_vectorbt_runner.py
+++ b/services/backtesting/tests/test_vectorbt_runner.py
@@ -166,6 +166,101 @@ class TestVectorBTRunner:
         assert 0 <= result.strategy_score <= 1
 
 
+class TestRiskMetricCalculations:
+    """Tests for alpha, beta, and other risk metric calculations."""
+
+    def test_beta_calculation(self, runner):
+        """Test beta calculation with known correlated returns."""
+        np.random.seed(42)
+        n = 1000
+        benchmark = pd.Series(np.random.randn(n) * 0.01)
+        # Strategy returns = 1.5 * benchmark + noise (beta ~1.5)
+        strategy = 1.5 * benchmark + pd.Series(np.random.randn(n) * 0.002)
+
+        beta = runner._calc_beta(strategy, benchmark)
+        assert 1.3 < beta < 1.7, f"Expected beta near 1.5, got {beta}"
+
+    def test_beta_zero_variance_benchmark(self, runner):
+        """Test beta returns 0 when benchmark has zero variance."""
+        strategy = pd.Series([0.01, -0.02, 0.03])
+        benchmark = pd.Series([0.0, 0.0, 0.0])
+
+        beta = runner._calc_beta(strategy, benchmark)
+        assert beta == 0.0
+
+    def test_beta_identical_returns(self, runner):
+        """Test beta is 1.0 when strategy equals benchmark."""
+        returns = pd.Series([0.01, -0.02, 0.03, -0.01, 0.02])
+        beta = runner._calc_beta(returns, returns)
+        assert abs(beta - 1.0) < 0.01
+
+    def test_alpha_outperforming_strategy(self, runner):
+        """Test alpha is positive when strategy outperforms."""
+        np.random.seed(42)
+        n = 1000
+        benchmark = pd.Series(np.random.randn(n) * 0.001)
+        # Strategy has consistent positive excess returns
+        strategy = benchmark + 0.001
+
+        beta = runner._calc_beta(strategy, benchmark)
+        alpha = runner._calc_alpha(strategy, benchmark, beta, n)
+        assert alpha > 0, f"Expected positive alpha, got {alpha}"
+
+    def test_alpha_underperforming_strategy(self, runner):
+        """Test alpha is negative when strategy underperforms."""
+        np.random.seed(42)
+        n = 1000
+        benchmark = pd.Series(np.random.randn(n) * 0.001 + 0.001)
+        # Strategy consistently underperforms
+        strategy = benchmark - 0.002
+
+        beta = runner._calc_beta(strategy, benchmark)
+        alpha = runner._calc_alpha(strategy, benchmark, beta, n)
+        assert alpha < 0, f"Expected negative alpha, got {alpha}"
+
+    def test_alpha_zero_bars(self, runner):
+        """Test alpha returns 0 with zero-length data."""
+        strategy = pd.Series([], dtype=float)
+        benchmark = pd.Series([], dtype=float)
+        alpha = runner._calc_alpha(strategy, benchmark, 1.0, 0)
+        assert alpha == 0.0
+
+    def test_backtest_computes_alpha_beta(self, runner, sample_ohlcv):
+        """Test that run_backtest returns computed (non-placeholder) alpha and beta."""
+        n = len(sample_ohlcv)
+        entries = pd.Series([False] * n, index=sample_ohlcv.index)
+        exits = pd.Series([False] * n, index=sample_ohlcv.index)
+        entries.iloc[10] = True
+        exits.iloc[20] = True
+
+        result = runner.run_backtest(sample_ohlcv, entries, exits)
+
+        # Alpha and beta should be real numbers, not the old placeholders
+        assert isinstance(result.alpha, float)
+        assert isinstance(result.beta, float)
+        # Beta should not be exactly 1.0 (the old placeholder) for a strategy
+        # that only trades once vs buy-and-hold
+        assert result.beta != 1.0 or result.alpha != 0.0
+
+    def test_backtest_with_custom_benchmark(self, runner, sample_ohlcv):
+        """Test run_backtest accepts custom benchmark returns."""
+        n = len(sample_ohlcv)
+        entries = pd.Series([False] * n, index=sample_ohlcv.index)
+        exits = pd.Series([False] * n, index=sample_ohlcv.index)
+        entries.iloc[10] = True
+        exits.iloc[20] = True
+
+        # Use flat benchmark (zero returns)
+        flat_benchmark = pd.Series(0.0, index=sample_ohlcv.index)
+        result = runner.run_backtest(
+            sample_ohlcv, entries, exits, benchmark_returns=flat_benchmark
+        )
+
+        assert isinstance(result.alpha, float)
+        # With zero-variance benchmark, beta should be 0
+        assert result.beta == 0.0
+
+
 class TestPerformanceBenchmark:
     """Performance benchmark tests."""
 

--- a/services/backtesting/vectorbt_runner.py
+++ b/services/backtesting/vectorbt_runner.py
@@ -469,9 +469,7 @@ class VectorBTRunner:
         except Exception:
             return 0.0
 
-    def _calc_beta(
-        self, returns: pd.Series, benchmark_returns: pd.Series
-    ) -> float:
+    def _calc_beta(self, returns: pd.Series, benchmark_returns: pd.Series) -> float:
         """Calculate beta (systematic risk) relative to benchmark.
 
         Beta = Cov(strategy, benchmark) / Var(benchmark)

--- a/services/backtesting/vectorbt_runner.py
+++ b/services/backtesting/vectorbt_runner.py
@@ -48,6 +48,7 @@ class VectorBTRunner:
         ohlcv: pd.DataFrame,
         entry_signal: pd.Series,
         exit_signal: pd.Series,
+        benchmark_returns: Optional[pd.Series] = None,
     ) -> BacktestMetrics:
         """
         Run a backtest with given entry/exit signals.
@@ -56,6 +57,8 @@ class VectorBTRunner:
             ohlcv: DataFrame with columns [open, high, low, close, volume]
             entry_signal: Boolean series for entry signals
             exit_signal: Boolean series for exit signals
+            benchmark_returns: Optional benchmark return series for alpha/beta.
+                If None, uses buy-and-hold of the same asset as benchmark.
 
         Returns:
             BacktestMetrics with performance results
@@ -73,6 +76,13 @@ class VectorBTRunner:
         # Extract metrics
         returns = portfolio.returns()
 
+        # Use buy-and-hold returns as benchmark if none provided
+        if benchmark_returns is None:
+            benchmark_returns = ohlcv["close"].pct_change().fillna(0.0)
+
+        beta = self._calc_beta(returns, benchmark_returns)
+        alpha = self._calc_alpha(returns, benchmark_returns, beta, len(ohlcv))
+
         return BacktestMetrics(
             cumulative_return=self._calc_cumulative_return(portfolio),
             annualized_return=self._calc_annualized_return(portfolio, len(ohlcv)),
@@ -84,8 +94,8 @@ class VectorBTRunner:
             profit_factor=self._calc_profit_factor(portfolio),
             number_of_trades=self._calc_num_trades(portfolio),
             average_trade_duration=self._calc_avg_trade_duration(portfolio),
-            alpha=0.0,  # Placeholder - requires benchmark
-            beta=1.0,  # Placeholder - requires benchmark
+            alpha=alpha,
+            beta=beta,
             strategy_score=0.0,  # Calculated after other metrics
         )
 
@@ -456,6 +466,56 @@ class VectorBTRunner:
                 return 0.0
             durations = trades["Exit Index"] - trades["Entry Index"]
             return float(durations.mean())
+        except Exception:
+            return 0.0
+
+    def _calc_beta(
+        self, returns: pd.Series, benchmark_returns: pd.Series
+    ) -> float:
+        """Calculate beta (systematic risk) relative to benchmark.
+
+        Beta = Cov(strategy, benchmark) / Var(benchmark)
+        """
+        try:
+            # Align series by index
+            aligned = pd.concat(
+                [returns.rename("strategy"), benchmark_returns.rename("benchmark")],
+                axis=1,
+            ).dropna()
+            if len(aligned) < 2:
+                return 0.0
+            benchmark_var = aligned["benchmark"].var()
+            if benchmark_var == 0:
+                return 0.0
+            covariance = aligned["strategy"].cov(aligned["benchmark"])
+            return float(covariance / benchmark_var)
+        except Exception:
+            return 0.0
+
+    def _calc_alpha(
+        self,
+        returns: pd.Series,
+        benchmark_returns: pd.Series,
+        beta: float,
+        num_bars: int,
+    ) -> float:
+        """Calculate Jensen's alpha (annualized).
+
+        Alpha = annualized(strategy return) - [Rf + beta * (annualized(benchmark return) - Rf)]
+        """
+        try:
+            years = num_bars / self._bars_per_year
+            if years <= 0:
+                return 0.0
+
+            strategy_total = (1 + returns).prod() - 1
+            benchmark_total = (1 + benchmark_returns).prod() - 1
+
+            strategy_ann = (1 + strategy_total) ** (1 / years) - 1
+            benchmark_ann = (1 + benchmark_total) ** (1 / years) - 1
+
+            rf = self._risk_free_rate
+            return float(strategy_ann - (rf + beta * (benchmark_ann - rf)))
         except Exception:
             return 0.0
 

--- a/services/risk_adjusted_sizing/main.py
+++ b/services/risk_adjusted_sizing/main.py
@@ -97,23 +97,39 @@ class RiskAdjustedSizer:
             logging.info("Database connection closed")
 
     async def get_strategies_with_risk_metrics(self) -> List[RiskMetrics]:
-        """Get strategies with calculated risk metrics."""
+        """Get strategies with risk metrics from latest performance records."""
         query = """
-        SELECT 
-            strategy_id,
-            symbol,
-            strategy_type,
-            current_score,
-            -- Placeholder risk metrics (would come from actual calculations)
-            0.15 as volatility,
-            1.2 as sharpe_ratio,
-            0.05 as max_drawdown,
-            0.65 as win_rate,
-            1.8 as profit_factor
-        FROM strategies 
-        WHERE is_active = TRUE
-        AND current_score >= 0.6
-        ORDER BY current_score DESC
+        SELECT
+            s.strategy_id,
+            s.symbol,
+            s.strategy_type,
+            s.current_score,
+            COALESCE(perf.volatility, 0) as volatility,
+            COALESCE(perf.sharpe_ratio, 0) as sharpe_ratio,
+            COALESCE(perf.max_drawdown, 0) as max_drawdown,
+            COALESCE(perf.win_rate, 0) as win_rate,
+            COALESCE(perf.profit_factor, 0) as profit_factor
+        FROM strategies s
+        LEFT JOIN strategy_specs spec ON spec.name = s.strategy_type AND spec.is_active = TRUE
+        LEFT JOIN strategy_implementations impl ON impl.spec_id = spec.id
+            AND impl.status IN ('VALIDATED', 'DEPLOYED')
+        LEFT JOIN LATERAL (
+            SELECT
+                sp.volatility,
+                sp.sharpe_ratio,
+                sp.max_drawdown,
+                sp.win_rate,
+                sp.profit_factor
+            FROM strategy_performance sp
+            WHERE sp.implementation_id = impl.id
+            AND sp.environment IN ('BACKTEST', 'PAPER', 'LIVE')
+            ORDER BY sp.created_at DESC
+            LIMIT 1
+        ) perf ON TRUE
+        WHERE s.is_active = TRUE
+        AND s.current_score >= 0.6
+        AND perf.sharpe_ratio IS NOT NULL
+        ORDER BY s.current_score DESC
         """
 
         async with self.pool.acquire() as conn:
@@ -126,12 +142,12 @@ class RiskAdjustedSizer:
                         strategy_id=row["strategy_id"],
                         symbol=row["symbol"],
                         strategy_type=row["strategy_type"],
-                        current_score=row["current_score"],
-                        volatility=row["volatility"],
-                        sharpe_ratio=row["sharpe_ratio"],
-                        max_drawdown=row["max_drawdown"],
-                        win_rate=row["win_rate"],
-                        profit_factor=row["profit_factor"],
+                        current_score=float(row["current_score"]),
+                        volatility=float(row["volatility"]),
+                        sharpe_ratio=float(row["sharpe_ratio"]),
+                        max_drawdown=float(row["max_drawdown"]),
+                        win_rate=float(row["win_rate"]),
+                        profit_factor=float(row["profit_factor"]),
                     )
                 )
 


### PR DESCRIPTION
## Summary
- **vectorbt_runner.py**: Replaced hardcoded `alpha=0.0` and `beta=1.0` placeholders with real calculations using covariance-based beta and Jensen's alpha against buy-and-hold benchmark (or custom benchmark)
- **risk_adjusted_sizing/main.py**: Replaced hardcoded SQL constants (`sharpe_ratio=1.2`, `max_drawdown=0.05`, etc.) with a JOIN to `strategy_performance` table to pull real metrics from the latest backtest/paper/live performance records
- Added 8 new tests covering alpha/beta computation edge cases and integration with `run_backtest`

Addresses audit finding Q3: hardcoded backtest risk metrics.

## Test plan
- [x] All 21 tests pass (13 existing + 8 new) via `bazel test //services/backtesting:test_vectorbt_runner`
- [ ] Verify risk_adjusted_sizing queries work against staging DB with populated strategy_performance data
- [ ] Confirm position sizing output changes are reasonable with real metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)