### PR TITLE
fix(security): bind HTTP services to 127.0.0.1 by default (S5)

### DIFF
--- a/charts/tradestream/templates/market-mcp.yaml
+++ b/charts/tradestream/templates/market-mcp.yaml
@@ -27,6 +27,8 @@ spec:
               containerPort: {{ .Values.marketMcp.service.port | default 8080 }}
               protocol: TCP
           env:
+            - name: HOST
+              value: "0.0.0.0"
             - name: INFLUXDB_URL
               value: {{ tpl .Values.marketMcp.influxdb.url . | quote }}
             - name: INFLUXDB_TOKEN

--- a/charts/tradestream/templates/paper-trading.yaml
+++ b/charts/tradestream/templates/paper-trading.yaml
@@ -27,6 +27,8 @@ spec:
               containerPort: {{ .Values.paperTrading.config.port }}
               protocol: TCP
           env:
+            - name: HOST
+              value: "0.0.0.0"
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/tradestream/templates/signal-mcp.yaml
+++ b/charts/tradestream/templates/signal-mcp.yaml
@@ -27,6 +27,8 @@ spec:
               containerPort: {{ .Values.signalMcp.service.port | default 8080 }}
               protocol: TCP
           env:
+            - name: HOST
+              value: "0.0.0.0"
             - name: POSTGRES_HOST
               value: {{ tpl .Values.signalMcp.database.host . | quote }}
             - name: POSTGRES_PORT

--- a/charts/tradestream/templates/strategy-mcp.yaml
+++ b/charts/tradestream/templates/strategy-mcp.yaml
@@ -27,6 +27,8 @@ spec:
               containerPort: {{ .Values.strategyMcp.service.port | default 8080 }}
               protocol: TCP
           env:
+            - name: HOST
+              value: "0.0.0.0"
             - name: POSTGRES_HOST
               value: {{ tpl .Values.strategyMcp.database.host . | quote }}
             - name: POSTGRES_PORT

--- a/charts/tradestream/templates/strategy-rotation.yaml
+++ b/charts/tradestream/templates/strategy-rotation.yaml
@@ -42,6 +42,8 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
           env:
+            - name: HOST
+              value: "0.0.0.0"
             - name: POSTGRES_HOST
               value: {{ tpl .Values.strategyRotation.config.postgresHost . | quote }}
             - name: POSTGRES_PORT

--- a/services/agent_gateway/main.py
+++ b/services/agent_gateway/main.py
@@ -309,7 +309,7 @@ async def publish_event(event: dict):
 
 
 def main():
-    host = os.environ.get("API_HOST", "0.0.0.0")
+    host = os.environ.get("API_HOST", "127.0.0.1")
     port = int(os.environ.get("API_PORT", "8080"))
     uvicorn.run(app, host=host, port=port, log_level="info")
 

--- a/services/market_mcp/main.py
+++ b/services/market_mcp/main.py
@@ -4,6 +4,7 @@ Connects to InfluxDB and Redis, then serves MCP tools via stdio or SSE.
 """
 
 import asyncio
+import os
 import sys
 
 from absl import app
@@ -96,7 +97,7 @@ async def main_async() -> None:
 
             config = uvicorn.Config(
                 starlette_app,
-                host="0.0.0.0",
+                host=os.environ.get("HOST", "127.0.0.1"),
                 port=FLAGS.mcp_port,
             )
             server = uvicorn.Server(config)

--- a/services/paper_trading/main.py
+++ b/services/paper_trading/main.py
@@ -1,6 +1,7 @@
 """Entry point for the Paper Trading evaluation service."""
 
 import asyncio
+import os
 import signal
 import sys
 
@@ -58,7 +59,8 @@ def main(argv):
     signal.signal(signal.SIGTERM, shutdown_handler)
 
     logging.info("Paper Trading service starting on port %d", FLAGS.port)
-    flask_app.run(host="0.0.0.0", port=FLAGS.port)
+    host = os.environ.get("HOST", "127.0.0.1")
+    flask_app.run(host=host, port=FLAGS.port)
 
 
 if __name__ == "__main__":

--- a/services/signal_mcp/main.py
+++ b/services/signal_mcp/main.py
@@ -4,6 +4,7 @@ Connects to Redis and PostgreSQL, then serves MCP tools via stdio or SSE.
 """
 
 import asyncio
+import os
 import signal
 import sys
 
@@ -99,7 +100,7 @@ async def main_async() -> None:
 
             config = uvicorn.Config(
                 starlette_app,
-                host="0.0.0.0",
+                host=os.environ.get("HOST", "127.0.0.1"),
                 port=FLAGS.mcp_port,
             )
             server = uvicorn.Server(config)

--- a/services/strategy_mcp/main.py
+++ b/services/strategy_mcp/main.py
@@ -4,6 +4,7 @@ Configurable via absl flags for PostgreSQL and MCP transport settings.
 """
 
 import asyncio
+import os
 import sys
 
 from absl import app
@@ -115,7 +116,7 @@ async def main_async() -> None:
 
             config = uvicorn.Config(
                 starlette_app,
-                host="0.0.0.0",
+                host=os.environ.get("HOST", "127.0.0.1"),
                 port=FLAGS.mcp_port,
             )
             uvicorn_server = uvicorn.Server(config)

--- a/services/strategy_monitor_api/main.py
+++ b/services/strategy_monitor_api/main.py
@@ -861,7 +861,7 @@ flags.DEFINE_string("postgres_database", "tradestream", "PostgreSQL database")
 flags.DEFINE_string("postgres_username", "postgres", "PostgreSQL username")
 flags.DEFINE_string("postgres_password", "", "PostgreSQL password")
 flags.DEFINE_integer("api_port", 8080, "API server port")
-flags.DEFINE_string("api_host", "0.0.0.0", "API server host")
+flags.DEFINE_string("api_host", "127.0.0.1", "API server host")
 
 # Global database connection parameters
 DB_CONFIG = {}

--- a/services/strategy_rotation/main.py
+++ b/services/strategy_rotation/main.py
@@ -13,6 +13,7 @@ Long-running service that continuously evaluates strategy rotation:
 """
 
 import asyncio
+import os
 import signal
 import sys
 import threading
@@ -140,7 +141,8 @@ class HealthHandler(BaseHTTPRequestHandler):
 
 def _start_health_server(port: int) -> HTTPServer:
     """Start HTTP health check server in a background thread."""
-    server = HTTPServer(("0.0.0.0", port), HealthHandler)
+    host = os.environ.get("HOST", "127.0.0.1")
+    server = HTTPServer((host, port), HealthHandler)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     logging.info("Health endpoint listening on port %d", port)


### PR DESCRIPTION
## Summary
- Change all 7 Python HTTP services to default to `127.0.0.1` instead of `0.0.0.0`, addressing audit finding S5 (P2)
- Add `HOST` env var support to 5 services that previously had hardcoded bind addresses (paper_trading, strategy_rotation, market_mcp, signal_mcp, strategy_mcp)
- Add `HOST=0.0.0.0` to Kubernetes Helm templates so containerized deployments continue binding to all interfaces for pod networking

## Test plan
- [ ] Verify local dev services bind to 127.0.0.1 by default
- [ ] Verify Kubernetes deployments still accept traffic via `HOST=0.0.0.0` env var
- [ ] Confirm health checks pass in deployed environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)