### PR TITLE
feat: migrate 5 strategies to YAML configs

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/configurable/StrategyConfigLoader.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/configurable/StrategyConfigLoader.java
@@ -46,7 +46,12 @@ public final class StrategyConfigLoader {
     RSI_EMA_CROSSOVER("strategies/rsi_ema_crossover.yaml"),
     SMA_EMA_CROSSOVER("strategies/sma_ema_crossover.yaml"),
     STOCHASTIC_RSI("strategies/stochastic_rsi.yaml"),
-    TRIPLE_EMA_CROSSOVER("strategies/triple_ema_crossover.yaml");
+    TRIPLE_EMA_CROSSOVER("strategies/triple_ema_crossover.yaml"),
+    VARIABLE_PERIOD_EMA("strategies/variable_period_ema.yaml"),
+    VOLUME_WEIGHTED_MACD("strategies/volume_weighted_macd.yaml"),
+    VPT("strategies/vpt.yaml"),
+    VWAP_CROSSOVER("strategies/vwap_crossover.yaml"),
+    VWAP_MEAN_REVERSION("strategies/vwap_mean_reversion.yaml");
 
     private final String resourcePath;
 

--- a/src/main/java/com/verlumen/tradestream/strategies/variableperiodema/VariablePeriodEmaParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/variableperiodema/VariablePeriodEmaParamConfig.java
@@ -8,6 +8,7 @@ import com.verlumen.tradestream.strategies.VariablePeriodEmaParameters;
 import io.jenetics.IntegerChromosome;
 import io.jenetics.NumericChromosome;
 
+@Deprecated
 public final class VariablePeriodEmaParamConfig implements ParamConfig {
   private static final ImmutableList<ChromosomeSpec<?>> SPECS =
       ImmutableList.of(

--- a/src/main/java/com/verlumen/tradestream/strategies/variableperiodema/VariablePeriodEmaStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/variableperiodema/VariablePeriodEmaStrategyFactory.java
@@ -14,6 +14,7 @@ import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.rules.CrossedDownIndicatorRule;
 import org.ta4j.core.rules.CrossedUpIndicatorRule;
 
+@Deprecated
 public final class VariablePeriodEmaStrategyFactory
     implements StrategyFactory<VariablePeriodEmaParameters> {
   @Override

--- a/src/main/java/com/verlumen/tradestream/strategies/volumeweightedmacd/VolumeWeightedMacdParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/volumeweightedmacd/VolumeWeightedMacdParamConfig.java
@@ -17,6 +17,7 @@ import java.util.logging.Logger;
  * create a more volume-sensitive MACD indicator. It enters when the MACD line crosses above the
  * signal line, and exits when the MACD line crosses below the signal line.
  */
+@Deprecated
 public class VolumeWeightedMacdParamConfig implements ParamConfig {
 
   private static final int DEFAULT_SHORT_PERIOD = 12;

--- a/src/main/java/com/verlumen/tradestream/strategies/volumeweightedmacd/VolumeWeightedMacdStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/volumeweightedmacd/VolumeWeightedMacdStrategyFactory.java
@@ -17,6 +17,7 @@ import org.ta4j.core.rules.CrossedUpIndicatorRule;
  * more volume-sensitive MACD indicator. The MACD line is calculated as the difference between short
  * and long EMAs, and the signal line is an EMA of the MACD line.
  */
+@Deprecated
 public class VolumeWeightedMacdStrategyFactory
     implements StrategyFactory<VolumeWeightedMacdParameters> {
 

--- a/src/main/java/com/verlumen/tradestream/strategies/vpt/VptParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/vpt/VptParamConfig.java
@@ -9,6 +9,7 @@ import io.jenetics.IntegerChromosome;
 import io.jenetics.NumericChromosome;
 import java.util.logging.Logger;
 
+@Deprecated
 public final class VptParamConfig implements ParamConfig {
   private static final Logger logger = Logger.getLogger(VptParamConfig.class.getName());
 

--- a/src/main/java/com/verlumen/tradestream/strategies/vpt/VptStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/vpt/VptStrategyFactory.java
@@ -12,6 +12,7 @@ import org.ta4j.core.num.Num;
 import org.ta4j.core.rules.CrossedDownIndicatorRule;
 import org.ta4j.core.rules.CrossedUpIndicatorRule;
 
+@Deprecated
 public final class VptStrategyFactory implements StrategyFactory<VptParameters> {
 
   @Override

--- a/src/main/java/com/verlumen/tradestream/strategies/vwapcrossover/VwapCrossoverParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/vwapcrossover/VwapCrossoverParamConfig.java
@@ -8,6 +8,7 @@ import com.verlumen.tradestream.strategies.VwapCrossoverParameters;
 import io.jenetics.IntegerChromosome;
 import io.jenetics.NumericChromosome;
 
+@Deprecated
 public final class VwapCrossoverParamConfig implements ParamConfig {
   private static final ImmutableList<ChromosomeSpec<?>> SPECS =
       ImmutableList.of(

--- a/src/main/java/com/verlumen/tradestream/strategies/vwapcrossover/VwapCrossoverStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/vwapcrossover/VwapCrossoverStrategyFactory.java
@@ -14,6 +14,7 @@ import org.ta4j.core.indicators.volume.VWAPIndicator;
 import org.ta4j.core.rules.CrossedDownIndicatorRule;
 import org.ta4j.core.rules.CrossedUpIndicatorRule;
 
+@Deprecated
 public final class VwapCrossoverStrategyFactory
     implements StrategyFactory<VwapCrossoverParameters> {
   @Override

--- a/src/main/java/com/verlumen/tradestream/strategies/vwapmeanreversion/VwapMeanReversionParamConfig.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/vwapmeanreversion/VwapMeanReversionParamConfig.java
@@ -10,6 +10,7 @@ import io.jenetics.IntegerChromosome;
 import io.jenetics.NumericChromosome;
 import java.util.logging.Logger;
 
+@Deprecated
 public final class VwapMeanReversionParamConfig implements ParamConfig {
   private static final Logger logger =
       Logger.getLogger(VwapMeanReversionParamConfig.class.getName());

--- a/src/main/java/com/verlumen/tradestream/strategies/vwapmeanreversion/VwapMeanReversionStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/vwapmeanreversion/VwapMeanReversionStrategyFactory.java
@@ -13,6 +13,7 @@ import org.ta4j.core.num.Num;
 import org.ta4j.core.rules.CrossedDownIndicatorRule;
 import org.ta4j.core.rules.CrossedUpIndicatorRule;
 
+@Deprecated
 public final class VwapMeanReversionStrategyFactory
     implements StrategyFactory<VwapMeanReversionParameters> {
 

--- a/src/main/resources/strategies/volume_weighted_macd.yaml
+++ b/src/main/resources/strategies/volume_weighted_macd.yaml
@@ -1,0 +1,45 @@
+name: VOLUME_WEIGHTED_MACD
+description: Volume Weighted MACD strategy using volume-sensitive MACD with signal line crossover
+complexity: SIMPLE
+parameterMessageType: com.verlumen.tradestream.strategies.VolumeWeightedMacdParameters
+
+indicators:
+  - id: macd
+    type: MACD
+    params:
+      shortPeriod: "${shortPeriod}"
+      longPeriod: "${longPeriod}"
+  - id: signalLine
+    type: EMA
+    input: macd
+    params:
+      period: "${signalPeriod}"
+
+entryConditions:
+  - type: CROSSED_UP
+    indicator: macd
+    params:
+      crosses: signalLine
+
+exitConditions:
+  - type: CROSSED_DOWN
+    indicator: macd
+    params:
+      crosses: signalLine
+
+parameters:
+  - name: shortPeriod
+    type: INTEGER
+    min: 8
+    max: 16
+    defaultValue: 12
+  - name: longPeriod
+    type: INTEGER
+    min: 20
+    max: 32
+    defaultValue: 26
+  - name: signalPeriod
+    type: INTEGER
+    min: 6
+    max: 12
+    defaultValue: 9


### PR DESCRIPTION
## Summary
- Create YAML config for VOLUME_WEIGHTED_MACD strategy (the only one missing)
- Register all 5 strategies (VWAP_MEAN_REVERSION, VWAP_CROSSOVER, VPT, VOLUME_WEIGHTED_MACD, VARIABLE_PERIOD_EMA) in the `ConfigStrategy` enum
- Deprecate Java `StrategyFactory` and `ParamConfig` implementations for all 5 strategies

Closes #1624, closes #1623, closes #1622, closes #1621, closes #1615

## Test plan
- [ ] Verify YAML configs load correctly via `ConfigStrategy` enum
- [ ] Verify build passes with deprecated annotations
- [ ] Verify no regressions in existing strategy tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)