### PR TITLE
Batch YAML migration: GANN_SWING, HEIKEN_ASHI, ICHIMOKU_CLOUD, KST_OSCILLATOR, LINEAR_REGRESSION_CHANNELS

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudStrategyFactory.kt
+++ b/src/main/java/com/verlumen/tradestream/strategies/ichimokucloud/IchimokuCloudStrategyFactory.kt
@@ -16,6 +16,7 @@ import org.ta4j.core.num.Num
 import org.ta4j.core.rules.OverIndicatorRule
 import org.ta4j.core.rules.UnderIndicatorRule
 
+@Deprecated("Migrated to YAML configuration. See ichimoku_cloud.yaml.")
 class IchimokuCloudStrategyFactory : StrategyFactory<IchimokuCloudParameters> {
     override fun createStrategy(
         series: BarSeries,

--- a/src/main/java/com/verlumen/tradestream/strategies/kstoscillator/KstOscillatorStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/kstoscillator/KstOscillatorStrategyFactory.java
@@ -19,9 +19,9 @@ import org.ta4j.core.rules.CrossedUpIndicatorRule;
  *
  * @deprecated Migrated to YAML configuration. See kst_oscillator.yaml.
  *
- * <p>The KST Oscillator combines four Rate of Change (ROC) indicators with different periods and
- * smoothing to create a comprehensive momentum indicator. The strategy generates buy signals when
- * the KST crosses above its signal line and sell signals when it crosses below.
+ *     <p>The KST Oscillator combines four Rate of Change (ROC) indicators with different periods
+ *     and smoothing to create a comprehensive momentum indicator. The strategy generates buy
+ *     signals when the KST crosses above its signal line and sell signals when it crosses below.
  */
 @Deprecated
 public final class KstOscillatorStrategyFactory

--- a/src/main/java/com/verlumen/tradestream/strategies/kstoscillator/KstOscillatorStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/kstoscillator/KstOscillatorStrategyFactory.java
@@ -18,7 +18,6 @@ import org.ta4j.core.rules.CrossedUpIndicatorRule;
  * Factory for creating KST Oscillator strategies.
  *
  * @deprecated Migrated to YAML configuration. See kst_oscillator.yaml.
- *
  *     <p>The KST Oscillator combines four Rate of Change (ROC) indicators with different periods
  *     and smoothing to create a comprehensive momentum indicator. The strategy generates buy
  *     signals when the KST crosses above its signal line and sell signals when it crosses below.

--- a/src/main/java/com/verlumen/tradestream/strategies/kstoscillator/KstOscillatorStrategyFactory.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/kstoscillator/KstOscillatorStrategyFactory.java
@@ -17,6 +17,8 @@ import org.ta4j.core.rules.CrossedUpIndicatorRule;
 /**
  * Factory for creating KST Oscillator strategies.
  *
+ * @deprecated Migrated to YAML configuration. See kst_oscillator.yaml.
+ *
  * <p>The KST Oscillator combines four Rate of Change (ROC) indicators with different periods and
  * smoothing to create a comprehensive momentum indicator. The strategy generates buy signals when
  * the KST crosses above its signal line and sell signals when it crosses below.


### PR DESCRIPTION
## Summary
- Create YAML configs for HEIKEN_ASHI and LINEAR_REGRESSION_CHANNELS strategies (3 others already existed)
- Deprecate Java implementations (StrategyFactory + ParamConfig) for all 5 strategies
- HEIKEN_ASHI uses EMA crossovers to approximate smoothed candlestick signals
- LINEAR_REGRESSION_CHANNELS uses Bollinger Bands as channel proxy for regression channels

Closes #1595, closes #1596, closes #1597, closes #1598, closes #1599

## Test plan
- [ ] Verify YAML configs load correctly via strategy registry
- [ ] Verify deprecated Java classes still compile (backwards compatible)
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)