### PR TITLE
feat(strategies): YAML migration batch 8 — deprecate 5 strategies

### DIFF
--- a/src/main/java/com/verlumen/tradestream/strategies/configurable/StrategyConfigLoader.java
+++ b/src/main/java/com/verlumen/tradestream/strategies/configurable/StrategyConfigLoader.java
@@ -37,6 +37,7 @@ public final class StrategyConfigLoader {
     DOUBLE_TOP_BOTTOM("strategies/double_top_bottom.yaml"),
     DPO_CROSSOVER("strategies/dpo_crossover.yaml"),
     DOUBLE_EMA_CROSSOVER("strategies/double_ema_crossover.yaml"),
+    DOUBLE_TOP_BOTTOM("strategies/double_top_bottom.yaml"),
     ELDER_RAY_MA("strategies/elder_ray_ma.yaml"),
     EMA_MACD("strategies/ema_macd.yaml"),
     FIBONACCI_RETRACEMENTS("strategies/fibonacci_retracements.yaml"),


### PR DESCRIPTION
## Summary
- Register ATR_TRAILING_STOP and DOUBLE_TOP_BOTTOM in the `ConfigStrategy` enum (YAML configs already exist)
- Deprecate Java `StrategyFactory` and `ParamConfig` implementations for all 5 strategies (10 files total)

### Strategies migrated
- **ATR_TRAILING_STOP** (#1590) — added to ConfigStrategy enum + deprecated Java classes
- **DOUBLE_TOP_BOTTOM** (#1591) — added to ConfigStrategy enum + deprecated Java classes
- **SMA_EMA_CROSSOVER** (#1587) — deprecated Java classes (already in ConfigStrategy enum)
- **RSI_EMA_CROSSOVER** (#1586) — deprecated Java classes (already in ConfigStrategy enum)
- **ROC_MA_CROSSOVER** (#1585) — deprecated Java classes (already in ConfigStrategy enum)

Closes #1585, closes #1586, closes #1587, closes #1590, closes #1591

## Test plan
- [ ] CI builds successfully with @Deprecated annotations
- [ ] Existing YAML ConfigTest targets pass for all 5 strategies
- [ ] New ConfigStrategy enum entries load YAML configs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)