### PR TITLE
feat(strategies): YAML migration batch 20 — FRAMA, HEIKEN_ASHI, LINEAR_REGRESSION_CHANNELS, MOMENTUM_PINBALL, PRICE_OSCILLATOR_SIGNAL

### DIFF
--- a/src/test/java/com/verlumen/tradestream/strategies/heikenashi/BUILD
+++ b/src/test/java/com/verlumen/tradestream/strategies/heikenashi/BUILD
@@ -1,27 +1,15 @@
 load("@rules_java//java:defs.bzl", "java_test")
 
 java_test(
-    name = "HeikenAshiParamConfigTest",
-    srcs = ["HeikenAshiParamConfigTest.java"],
+    name = "HeikenAshiConfigTest",
+    srcs = ["HeikenAshiConfigTest.java"],
+    resources = ["//src/main/resources:strategies"],
     deps = [
         "//protos:strategies_java_proto",
         "//src/main/java/com/verlumen/tradestream/discovery:chromosome_spec",
-        "//src/main/java/com/verlumen/tradestream/strategies/heikenashi:param_config",
+        "//src/main/java/com/verlumen/tradestream/strategies/configurable",
         "//third_party/java:guava",
         "//third_party/java:jenetics",
-        "//third_party/java:junit",
-        "//third_party/java:protobuf_java",
-        "//third_party/java:truth",
-    ],
-)
-
-java_test(
-    name = "HeikenAshiStrategyFactoryTest",
-    srcs = ["HeikenAshiStrategyFactoryTest.java"],
-    deps = [
-        "//protos:strategies_java_proto",
-        "//src/main/java/com/verlumen/tradestream/strategies/heikenashi:strategy_factory",
-        "//third_party/java:guava",
         "//third_party/java:junit",
         "//third_party/java:protobuf_java",
         "//third_party/java:ta4j_core",

--- a/src/test/java/com/verlumen/tradestream/strategies/heikenashi/HeikenAshiConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/heikenashi/HeikenAshiConfigTest.java
@@ -1,0 +1,83 @@
+package com.verlumen.tradestream.strategies.heikenashi;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.verlumen.tradestream.discovery.ChromosomeSpec;
+import com.verlumen.tradestream.strategies.ConfigurableStrategyParameters;
+import com.verlumen.tradestream.strategies.configurable.ConfigurableParamConfig;
+import com.verlumen.tradestream.strategies.configurable.ConfigurableStrategyFactory;
+import com.verlumen.tradestream.strategies.configurable.StrategyConfig;
+import com.verlumen.tradestream.strategies.configurable.StrategyConfigLoader;
+import io.jenetics.IntegerChromosome;
+import io.jenetics.NumericChromosome;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.ta4j.core.BaseBar;
+import org.ta4j.core.BaseBarSeries;
+import org.ta4j.core.Strategy;
+
+@RunWith(JUnit4.class)
+public class HeikenAshiConfigTest {
+  private StrategyConfig config;
+  private ConfigurableStrategyFactory factory;
+  private ConfigurableParamConfig paramConfig;
+  private BaseBarSeries series;
+
+  @Before
+  public void setUp() throws Exception {
+    config = StrategyConfigLoader.loadResource("strategies/heiken_ashi.yaml");
+    factory = new ConfigurableStrategyFactory(config);
+    paramConfig = new ConfigurableParamConfig(config);
+
+    series = new BaseBarSeries();
+    ZonedDateTime now = ZonedDateTime.now();
+    for (int i = 0; i < 100; i++) {
+      double price = 100 + Math.sin(i * 0.1) * 20;
+      series.addBar(
+          new BaseBar(
+              Duration.ofMinutes(1),
+              now.plusMinutes(i),
+              price,
+              price + 2,
+              price - 2,
+              price,
+              1000.0));
+    }
+  }
+
+  @Test
+  public void createStrategy_returnsValidStrategy() throws Exception {
+    Strategy strategy = factory.createStrategy(series, factory.getDefaultParameters());
+    assertThat(strategy).isNotNull();
+    assertThat(strategy.getName()).isEqualTo("HEIKEN_ASHI");
+  }
+
+  @Test
+  public void strategy_canEvaluateSignals() throws Exception {
+    Strategy strategy = factory.createStrategy(series, factory.getDefaultParameters());
+    for (int i = 50; i < series.getBarCount(); i++) {
+      strategy.shouldEnter(i);
+      strategy.shouldExit(i);
+    }
+  }
+
+  @Test
+  public void chromosomeSpecs_matchParameterCount() {
+    ImmutableList<ChromosomeSpec<?>> specs = paramConfig.getChromosomeSpecs();
+    assertThat(specs).hasSize(1);
+  }
+
+  @Test
+  public void createParameters_fromChromosomes_succeeds() throws Exception {
+    ImmutableList<NumericChromosome<?, ?>> chromosomes =
+        ImmutableList.of(IntegerChromosome.of(2, 30));
+    Any packed = paramConfig.createParameters(chromosomes);
+    assertThat(packed.is(ConfigurableStrategyParameters.class)).isTrue();
+  }
+}

--- a/src/test/java/com/verlumen/tradestream/strategies/linearregressionchannels/BUILD
+++ b/src/test/java/com/verlumen/tradestream/strategies/linearregressionchannels/BUILD
@@ -1,27 +1,15 @@
 load("@rules_java//java:defs.bzl", "java_test")
 
 java_test(
-    name = "param_config_test",
-    srcs = ["LinearRegressionChannelsParamConfigTest.java"],
-    test_class = "com.verlumen.tradestream.strategies.linearregressionchannels.LinearRegressionChannelsParamConfigTest",
+    name = "LinearRegressionChannelsConfigTest",
+    srcs = ["LinearRegressionChannelsConfigTest.java"],
+    resources = ["//src/main/resources:strategies"],
     deps = [
         "//protos:strategies_java_proto",
-        "//src/main/java/com/verlumen/tradestream/strategies/linearregressionchannels:param_config",
+        "//src/main/java/com/verlumen/tradestream/discovery:chromosome_spec",
+        "//src/main/java/com/verlumen/tradestream/strategies/configurable",
         "//third_party/java:guava",
         "//third_party/java:jenetics",
-        "//third_party/java:junit",
-        "//third_party/java:protobuf_java",
-        "//third_party/java:truth",
-    ],
-)
-
-java_test(
-    name = "strategy_factory_test",
-    srcs = ["LinearRegressionChannelsStrategyFactoryTest.java"],
-    test_class = "com.verlumen.tradestream.strategies.linearregressionchannels.LinearRegressionChannelsStrategyFactoryTest",
-    deps = [
-        "//protos:strategies_java_proto",
-        "//src/main/java/com/verlumen/tradestream/strategies/linearregressionchannels:strategy_factory",
         "//third_party/java:junit",
         "//third_party/java:protobuf_java",
         "//third_party/java:ta4j_core",

--- a/src/test/java/com/verlumen/tradestream/strategies/linearregressionchannels/LinearRegressionChannelsConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/linearregressionchannels/LinearRegressionChannelsConfigTest.java
@@ -77,9 +77,7 @@ public class LinearRegressionChannelsConfigTest {
   @Test
   public void createParameters_fromChromosomes_succeeds() throws Exception {
     ImmutableList<NumericChromosome<?, ?>> chromosomes =
-        ImmutableList.of(
-            IntegerChromosome.of(10, 50),
-            DoubleChromosome.of(1.0, 3.0));
+        ImmutableList.of(IntegerChromosome.of(10, 50), DoubleChromosome.of(1.0, 3.0));
     Any packed = paramConfig.createParameters(chromosomes);
     assertThat(packed.is(ConfigurableStrategyParameters.class)).isTrue();
   }

--- a/src/test/java/com/verlumen/tradestream/strategies/linearregressionchannels/LinearRegressionChannelsConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/linearregressionchannels/LinearRegressionChannelsConfigTest.java
@@ -1,0 +1,86 @@
+package com.verlumen.tradestream.strategies.linearregressionchannels;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.verlumen.tradestream.discovery.ChromosomeSpec;
+import com.verlumen.tradestream.strategies.ConfigurableStrategyParameters;
+import com.verlumen.tradestream.strategies.configurable.ConfigurableParamConfig;
+import com.verlumen.tradestream.strategies.configurable.ConfigurableStrategyFactory;
+import com.verlumen.tradestream.strategies.configurable.StrategyConfig;
+import com.verlumen.tradestream.strategies.configurable.StrategyConfigLoader;
+import io.jenetics.DoubleChromosome;
+import io.jenetics.IntegerChromosome;
+import io.jenetics.NumericChromosome;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.ta4j.core.BaseBar;
+import org.ta4j.core.BaseBarSeries;
+import org.ta4j.core.Strategy;
+
+@RunWith(JUnit4.class)
+public class LinearRegressionChannelsConfigTest {
+  private StrategyConfig config;
+  private ConfigurableStrategyFactory factory;
+  private ConfigurableParamConfig paramConfig;
+  private BaseBarSeries series;
+
+  @Before
+  public void setUp() throws Exception {
+    config = StrategyConfigLoader.loadResource("strategies/linear_regression_channels.yaml");
+    factory = new ConfigurableStrategyFactory(config);
+    paramConfig = new ConfigurableParamConfig(config);
+
+    series = new BaseBarSeries();
+    ZonedDateTime now = ZonedDateTime.now();
+    for (int i = 0; i < 100; i++) {
+      double price = 100 + Math.sin(i * 0.1) * 20;
+      series.addBar(
+          new BaseBar(
+              Duration.ofMinutes(1),
+              now.plusMinutes(i),
+              price,
+              price + 2,
+              price - 2,
+              price,
+              1000.0));
+    }
+  }
+
+  @Test
+  public void createStrategy_returnsValidStrategy() throws Exception {
+    Strategy strategy = factory.createStrategy(series, factory.getDefaultParameters());
+    assertThat(strategy).isNotNull();
+    assertThat(strategy.getName()).isEqualTo("LINEAR_REGRESSION_CHANNELS");
+  }
+
+  @Test
+  public void strategy_canEvaluateSignals() throws Exception {
+    Strategy strategy = factory.createStrategy(series, factory.getDefaultParameters());
+    for (int i = 50; i < series.getBarCount(); i++) {
+      strategy.shouldEnter(i);
+      strategy.shouldExit(i);
+    }
+  }
+
+  @Test
+  public void chromosomeSpecs_matchParameterCount() {
+    ImmutableList<ChromosomeSpec<?>> specs = paramConfig.getChromosomeSpecs();
+    assertThat(specs).hasSize(2);
+  }
+
+  @Test
+  public void createParameters_fromChromosomes_succeeds() throws Exception {
+    ImmutableList<NumericChromosome<?, ?>> chromosomes =
+        ImmutableList.of(
+            IntegerChromosome.of(10, 50),
+            DoubleChromosome.of(1.0, 3.0));
+    Any packed = paramConfig.createParameters(chromosomes);
+    assertThat(packed.is(ConfigurableStrategyParameters.class)).isTrue();
+  }
+}

--- a/src/test/java/com/verlumen/tradestream/strategies/priceoscillatorsignal/BUILD
+++ b/src/test/java/com/verlumen/tradestream/strategies/priceoscillatorsignal/BUILD
@@ -1,29 +1,17 @@
 load("@rules_java//java:defs.bzl", "java_test")
 
 java_test(
-    name = "param_config_test",
-    srcs = ["PriceOscillatorSignalParamConfigTest.java"],
-    test_class = "com.verlumen.tradestream.strategies.priceoscillatorsignal.PriceOscillatorSignalParamConfigTest",
+    name = "PriceOscillatorSignalConfigTest",
+    srcs = ["PriceOscillatorSignalConfigTest.java"],
+    resources = ["//src/main/resources:strategies"],
     deps = [
         "//protos:strategies_java_proto",
-        "//src/main/java/com/verlumen/tradestream/strategies/priceoscillatorsignal:param_config",
+        "//src/main/java/com/verlumen/tradestream/discovery:chromosome_spec",
+        "//src/main/java/com/verlumen/tradestream/strategies/configurable",
         "//third_party/java:guava",
         "//third_party/java:jenetics",
         "//third_party/java:junit",
         "//third_party/java:protobuf_java",
-        "//third_party/java:truth",
-    ],
-)
-
-java_test(
-    name = "strategy_factory_test",
-    srcs = ["PriceOscillatorSignalStrategyFactoryTest.java"],
-    test_class = "com.verlumen.tradestream.strategies.priceoscillatorsignal.PriceOscillatorSignalStrategyFactoryTest",
-    deps = [
-        "//protos:strategies_java_proto",
-        "//src/main/java/com/verlumen/tradestream/strategies/priceoscillatorsignal:strategy_factory",
-        "//third_party/java:guava",
-        "//third_party/java:junit",
         "//third_party/java:ta4j_core",
         "//third_party/java:truth",
     ],

--- a/src/test/java/com/verlumen/tradestream/strategies/priceoscillatorsignal/PriceOscillatorSignalConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/priceoscillatorsignal/PriceOscillatorSignalConfigTest.java
@@ -1,0 +1,86 @@
+package com.verlumen.tradestream.strategies.priceoscillatorsignal;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.verlumen.tradestream.discovery.ChromosomeSpec;
+import com.verlumen.tradestream.strategies.ConfigurableStrategyParameters;
+import com.verlumen.tradestream.strategies.configurable.ConfigurableParamConfig;
+import com.verlumen.tradestream.strategies.configurable.ConfigurableStrategyFactory;
+import com.verlumen.tradestream.strategies.configurable.StrategyConfig;
+import com.verlumen.tradestream.strategies.configurable.StrategyConfigLoader;
+import io.jenetics.IntegerChromosome;
+import io.jenetics.NumericChromosome;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.ta4j.core.BaseBar;
+import org.ta4j.core.BaseBarSeries;
+import org.ta4j.core.Strategy;
+
+@RunWith(JUnit4.class)
+public class PriceOscillatorSignalConfigTest {
+  private StrategyConfig config;
+  private ConfigurableStrategyFactory factory;
+  private ConfigurableParamConfig paramConfig;
+  private BaseBarSeries series;
+
+  @Before
+  public void setUp() throws Exception {
+    config = StrategyConfigLoader.loadResource("strategies/price_oscillator_signal.yaml");
+    factory = new ConfigurableStrategyFactory(config);
+    paramConfig = new ConfigurableParamConfig(config);
+
+    series = new BaseBarSeries();
+    ZonedDateTime now = ZonedDateTime.now();
+    for (int i = 0; i < 100; i++) {
+      double price = 100 + Math.sin(i * 0.1) * 20;
+      series.addBar(
+          new BaseBar(
+              Duration.ofMinutes(1),
+              now.plusMinutes(i),
+              price,
+              price + 2,
+              price - 2,
+              price,
+              1000.0));
+    }
+  }
+
+  @Test
+  public void createStrategy_returnsValidStrategy() throws Exception {
+    Strategy strategy = factory.createStrategy(series, factory.getDefaultParameters());
+    assertThat(strategy).isNotNull();
+    assertThat(strategy.getName()).isEqualTo("PRICE_OSCILLATOR_SIGNAL");
+  }
+
+  @Test
+  public void strategy_canEvaluateSignals() throws Exception {
+    Strategy strategy = factory.createStrategy(series, factory.getDefaultParameters());
+    for (int i = 50; i < series.getBarCount(); i++) {
+      strategy.shouldEnter(i);
+      strategy.shouldExit(i);
+    }
+  }
+
+  @Test
+  public void chromosomeSpecs_matchParameterCount() {
+    ImmutableList<ChromosomeSpec<?>> specs = paramConfig.getChromosomeSpecs();
+    assertThat(specs).hasSize(3);
+  }
+
+  @Test
+  public void createParameters_fromChromosomes_succeeds() throws Exception {
+    ImmutableList<NumericChromosome<?, ?>> chromosomes =
+        ImmutableList.of(
+            IntegerChromosome.of(5, 20),
+            IntegerChromosome.of(10, 50),
+            IntegerChromosome.of(5, 20));
+    Any packed = paramConfig.createParameters(chromosomes);
+    assertThat(packed.is(ConfigurableStrategyParameters.class)).isTrue();
+  }
+}

--- a/src/test/java/com/verlumen/tradestream/strategies/priceoscillatorsignal/PriceOscillatorSignalConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/priceoscillatorsignal/PriceOscillatorSignalConfigTest.java
@@ -77,9 +77,7 @@ public class PriceOscillatorSignalConfigTest {
   public void createParameters_fromChromosomes_succeeds() throws Exception {
     ImmutableList<NumericChromosome<?, ?>> chromosomes =
         ImmutableList.of(
-            IntegerChromosome.of(5, 20),
-            IntegerChromosome.of(10, 50),
-            IntegerChromosome.of(5, 20));
+            IntegerChromosome.of(5, 20), IntegerChromosome.of(10, 50), IntegerChromosome.of(5, 20));
     Any packed = paramConfig.createParameters(chromosomes);
     assertThat(packed.is(ConfigurableStrategyParameters.class)).isTrue();
   }


### PR DESCRIPTION
## Summary
- Create YAML configs for 5 strategies that previously only had hardcoded Java implementations
- Register all 5 in the `ConfigStrategy` enum
- Add config tests for each strategy
- Deprecate Java `StrategyFactory` and `ParamConfig` implementations (10 files)

### Strategies migrated
- **FRAMA** (#1594) — Fractal Adaptive MA, approximated via KAMA crossover
- **HEIKEN_ASHI** (#1596) — smoothed candle crossover via typical price / open EMA
- **LINEAR_REGRESSION_CHANNELS** (#1599) — channel breakout via Bollinger Bands approximation
- **MOMENTUM_PINBALL** (#1600) — dual momentum zero-line crossover
- **PRICE_OSCILLATOR_SIGNAL** (#1603) — MACD-based oscillator with signal line crossover

Closes #1594, closes #1596, closes #1599, closes #1600, closes #1603

## Test plan
- [ ] CI builds successfully with @Deprecated annotations
- [ ] New YAML configs load correctly via ConfigStrategy enum
- [ ] Config tests pass for all 5 strategies

🤖 Generated with [Claude Code](https://claude.com/claude-code)