### PR TITLE
feat(strategies): YAML migration batch 24 — deprecate 5 strategies

### DIFF
--- a/src/main/resources/strategies/heiken_ashi.yaml
+++ b/src/main/resources/strategies/heiken_ashi.yaml
@@ -1,29 +1,29 @@
 name: HEIKEN_ASHI
-description: Heiken Ashi - enters when HA close crosses above HA open, exits when HA close crosses below HA open
-complexity: MODERATE
+description: Heiken Ashi candle pattern - enters when HA close crosses above HA open
+complexity: SIMPLE
 parameterMessageType: com.verlumen.tradestream.strategies.HeikenAshiParameters
 
 indicators:
-  - id: heikenAshiClose
+  - id: haClose
     type: HEIKEN_ASHI_CLOSE
     params:
       period: "${period}"
-  - id: heikenAshiOpen
+  - id: haOpen
     type: HEIKEN_ASHI_OPEN
     params:
       period: "${period}"
 
 entryConditions:
   - type: CROSSED_UP
-    indicator: heikenAshiClose
+    indicator: haClose
     params:
-      crosses: heikenAshiOpen
+      crosses: haOpen
 
 exitConditions:
   - type: CROSSED_DOWN
-    indicator: heikenAshiClose
+    indicator: haClose
     params:
-      crosses: heikenAshiOpen
+      crosses: haOpen
 
 parameters:
   - name: period

--- a/src/main/resources/strategies/linear_regression_channels.yaml
+++ b/src/main/resources/strategies/linear_regression_channels.yaml
@@ -1,31 +1,33 @@
 name: LINEAR_REGRESSION_CHANNELS
-description: Linear Regression Channels - enters when price breaks above upper channel, exits when price breaks below lower channel
-complexity: MODERATE
+description: Linear Regression Channels - enters on upper channel breakout, exits on lower channel breakdown
+complexity: MEDIUM
 parameterMessageType: com.verlumen.tradestream.strategies.LinearRegressionChannelsParameters
 
 indicators:
-  - id: lrcUpper
-    type: LINEAR_REGRESSION_UPPER_CHANNEL
+  - id: closePrice
+    type: CLOSE
+  - id: upperChannel
+    type: LINEAR_REGRESSION_UPPER
     params:
       period: "${period}"
       multiplier: "${multiplier}"
-  - id: lrcLower
-    type: LINEAR_REGRESSION_LOWER_CHANNEL
+  - id: lowerChannel
+    type: LINEAR_REGRESSION_LOWER
     params:
       period: "${period}"
       multiplier: "${multiplier}"
 
 entryConditions:
   - type: CROSSED_UP
-    indicator: close
+    indicator: closePrice
     params:
-      crosses: lrcUpper
+      crosses: upperChannel
 
 exitConditions:
   - type: CROSSED_DOWN
-    indicator: close
+    indicator: closePrice
     params:
-      crosses: lrcLower
+      crosses: lowerChannel
 
 parameters:
   - name: period


### PR DESCRIPTION
## Summary
- Add YAML configs for HEIKEN_ASHI and LINEAR_REGRESSION_CHANNELS strategies
- Deprecate Java StrategyFactory and ParamConfig for 5 strategies: CMO_MFI, DEMA_TEMA_CROSSOVER, ELDER_RAY_MA, HEIKEN_ASHI, LINEAR_REGRESSION_CHANNELS
- Continues the ongoing YAML strategy migration effort

## Test plan
- [ ] CI passes (format checks, helm validation, unit tests)
- [ ] YAML configs follow established patterns
- [ ] @Deprecated annotations added to all 10 Java files (5 factories + 5 param configs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)