### PR TITLE
feat(strategies): validate DOUBLE_EMA_CROSSOVER YAML migration

### DIFF
--- a/src/test/java/com/verlumen/tradestream/strategies/doubleemacrossover/DoubleEmaCrossoverConfigTest.java
+++ b/src/test/java/com/verlumen/tradestream/strategies/doubleemacrossover/DoubleEmaCrossoverConfigTest.java
@@ -39,8 +39,8 @@ public class DoubleEmaCrossoverConfigTest {
     paramConfig = new ConfigurableParamConfig(config);
     series = new BaseBarSeriesBuilder().build();
     ZonedDateTime now = ZonedDateTime.now();
-    for (int i = 0; i < 100; i++) {
-      double price = 100 + Math.sin(i * 0.1) * 20;
+    for (int i = 0; i < 1200; i++) {
+      double price = 100 + Math.sin(i * 0.1) * 20 + Math.cos(i * 0.03) * 10;
       series.addBar(
           new BaseBar(
               Duration.ofMinutes(1),
@@ -64,12 +64,37 @@ public class DoubleEmaCrossoverConfigTest {
   }
 
   @Test
-  public void strategy_canEvaluateSignals() throws Exception {
+  public void strategy_canEvaluateSignals_over1000Candles() throws Exception {
     Strategy strategy = factory.createStrategy(series, factory.getDefaultParameters());
+    int entrySignals = 0;
+    int exitSignals = 0;
     for (int i = 50; i < series.getBarCount(); i++) {
-      strategy.shouldEnter(i);
-      strategy.shouldExit(i);
+      if (strategy.shouldEnter(i)) {
+        entrySignals++;
+      }
+      if (strategy.shouldExit(i)) {
+        exitSignals++;
+      }
     }
+    assertThat(entrySignals).isGreaterThan(0);
+    assertThat(exitSignals).isGreaterThan(0);
+  }
+
+  @Test
+  public void config_hasCorrectIndicators() {
+    assertThat(config.getIndicators()).hasSize(2);
+    assertThat(config.getIndicators().get(0).getId()).isEqualTo("shortEma");
+    assertThat(config.getIndicators().get(0).getType()).isEqualTo("EMA");
+    assertThat(config.getIndicators().get(1).getId()).isEqualTo("longEma");
+    assertThat(config.getIndicators().get(1).getType()).isEqualTo("EMA");
+  }
+
+  @Test
+  public void config_hasCorrectEntryExitConditions() {
+    assertThat(config.getEntryConditions()).hasSize(1);
+    assertThat(config.getEntryConditions().get(0).getType()).isEqualTo("CROSSED_UP");
+    assertThat(config.getExitConditions()).hasSize(1);
+    assertThat(config.getExitConditions().get(0).getType()).isEqualTo("CROSSED_DOWN");
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Validates DOUBLE_EMA_CROSSOVER YAML config matches Java implementation
- Enhances migration test to verify indicators (shortEma/longEma as EMA), entry/exit conditions (CROSSED_UP/CROSSED_DOWN), and signal generation over 1200 candles
- All migration acceptance criteria verified: YAML config, @Deprecated annotations, StrategyConfigLoader enum entry, and config test

## Validation Checklist
- [x] YAML config has correct indicators (fast EMA, slow EMA on close price)
- [x] Entry condition: CROSSED_UP shortEma vs longEma (matches Java CrossedUpIndicatorRule)
- [x] Exit condition: CROSSED_DOWN shortEma vs longEma (matches Java CrossedDownIndicatorRule)
- [x] Parameter definitions: shortEmaPeriod (INTEGER), longEmaPeriod (INTEGER)
- [x] Java DoubleEmaCrossoverStrategyFactory has @Deprecated
- [x] Java DoubleEmaCrossoverParamConfig has @Deprecated
- [x] StrategyConfigLoader has DOUBLE_EMA_CROSSOVER enum entry
- [x] Config test validates strategy creation, signal evaluation, and parameter chromosome specs

## Test plan
- [ ] DoubleEmaCrossoverConfigTest passes in CI

Closes #1576

🤖 Generated with [Claude Code](https://claude.com/claude-code)