### PR TITLE
feat(strategy-mcp): Add pyproject.toml, Dockerfile, and README

### DIFF
--- a/services/strategy_mcp/Dockerfile
+++ b/services/strategy_mcp/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.13-slim
+
+WORKDIR /app
+
+COPY pyproject.toml .
+RUN pip install --no-cache-dir .
+
+COPY *.py ./
+
+ENV DB_HOST=localhost \
+    DB_PORT=5432 \
+    DB_NAME="" \
+    DB_USER=postgres \
+    DB_PASSWORD=""
+
+EXPOSE 8080
+
+ENTRYPOINT ["python", "main.py"]
+CMD ["--mcp_transport", "stdio"]

--- a/services/strategy_mcp/README.md
+++ b/services/strategy_mcp/README.md
@@ -1,0 +1,49 @@
+# Strategy MCP Server
+
+MCP server for querying and managing trading strategy data from PostgreSQL.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `get_top_strategies` | Top strategies by Sharpe ratio for a symbol (VALIDATED/DEPLOYED only) |
+| `get_spec` | Full strategy_spec row by name |
+| `get_performance` | Performance metrics (backtest/paper/live) for an implementation |
+| `get_performance_batch` | Batch performance lookup for multiple implementations |
+| `list_strategy_types` | Distinct strategy types with at least one validated implementation |
+| `create_spec` | Insert a new strategy spec with `source=LLM_GENERATED` |
+| `get_walk_forward` | Walk-forward validation results for an implementation |
+| `get_strategy_signal` | Current signal from a specific strategy for a symbol |
+| `get_strategy_consensus` | Aggregated consensus across all active strategies for a symbol |
+
+## Configuration
+
+Database credentials via environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DB_HOST` | `localhost` | PostgreSQL host |
+| `DB_PORT` | `5432` | PostgreSQL port |
+| `DB_NAME` | — | Database name |
+| `DB_USER` | `postgres` | Database user |
+| `DB_PASSWORD` | — | Database password |
+
+## Development
+
+```bash
+# Run with Bazel
+bazel run //services/strategy_mcp:app -- --postgres_password=secret
+
+# Run tests
+bazel test //services/strategy_mcp:server_test //services/strategy_mcp:postgres_client_test
+
+# Or with pytest directly
+python -m pytest services/strategy_mcp/server_test.py services/strategy_mcp/postgres_client_test.py -v
+```
+
+## Docker
+
+```bash
+docker build -t strategy-mcp services/strategy_mcp/
+docker run -e DB_HOST=db -e DB_NAME=tradestream -e DB_PASSWORD=secret strategy-mcp
+```

--- a/services/strategy_mcp/pyproject.toml
+++ b/services/strategy_mcp/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "strategy-mcp"
+version = "0.1.0"
+description = "MCP server for strategy queries — exposes tools over PostgreSQL for strategy specs, implementations, performance, and walk-forward results."
+requires-python = ">=3.11"
+dependencies = [
+    "asyncpg>=0.29.0",
+    "mcp>=1.0.0",
+    "tenacity>=8.2.0",
+    "absl-py>=2.0.0",
+    "uvicorn>=0.24.0",
+    "starlette>=0.27.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.4.0",
+    "pytest-asyncio>=0.21.0",
+]
+
+[build-system]
+requires = ["setuptools>=68.0"]
+build-backend = "setuptools.backends._legacy:_Backend"


### PR DESCRIPTION
## Summary
- Add `pyproject.toml` with all required dependencies (asyncpg, mcp, tenacity, absl-py, uvicorn, starlette)
- Add `Dockerfile` based on `python:3.13-slim` with env-based DB configuration
- Add `README.md` documenting all 9 MCP tools, configuration variables, and development/Docker usage

The strategy-mcp service already had full server, postgres_client, and test implementations. This PR adds the missing packaging, containerization, and documentation files.

## Test plan
- [x] `bazel test //services/strategy_mcp:server_test` — PASSED
- [x] `bazel test //services/strategy_mcp:postgres_client_test` — PASSED
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)