### PR TITLE
feat(market-mcp): add pyproject.toml, Dockerfile, README, and client unit tests

### DIFF
--- a/services/market_mcp/BUILD
+++ b/services/market_mcp/BUILD
@@ -72,6 +72,25 @@ py_test(
     ],
 )
 
+py_test(
+    name = "influxdb_client_test",
+    srcs = ["influxdb_client_test.py"],
+    deps = [
+        ":influxdb_client_lib",
+        "//third_party/python:pytest",
+    ],
+)
+
+py_test(
+    name = "redis_client_test",
+    srcs = ["redis_client_test.py"],
+    deps = [
+        ":redis_client_lib",
+        "//third_party/python:pytest",
+        "//third_party/python:redis",
+    ],
+)
+
 # --- OCI Image Rules ---
 py_image_layer(
     name = "layers",

--- a/services/market_mcp/Dockerfile
+++ b/services/market_mcp/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.13-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY *.py ./
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')" || exit 1
+
+ENTRYPOINT ["python", "main.py"]
+CMD ["--mcp_transport", "stdio"]

--- a/services/market_mcp/README.md
+++ b/services/market_mcp/README.md
@@ -1,0 +1,73 @@
+# Market MCP Server
+
+MCP server for market data. Connects to InfluxDB for candle/OHLCV data and Redis for active cryptocurrency symbols.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `get_candles` | Query OHLCV candle data for a symbol. Params: `symbol`, `timeframe` (1m/5m/15m/1h/4h/1d), `start?`, `end?`, `limit` (default 100). |
+| `get_latest_price` | Get most recent candle close price for a symbol. Returns price, volume_24h, change_24h. |
+| `get_volatility` | Compute volatility metrics (stddev of returns, ATR) for a symbol over `period_minutes` (default 60). |
+| `get_symbols` | Get active cryptocurrency symbol list from Redis (`top_cryptocurrencies` key). |
+| `get_market_summary` | Aggregated summary: price, change_1h, change_24h, volume_24h, volatility, high_24h, low_24h, vwap. |
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `INFLUXDB_URL` | Yes | InfluxDB server URL (e.g., `http://localhost:8086`) |
+| `INFLUXDB_TOKEN` | Yes | InfluxDB authentication token |
+| `INFLUXDB_ORG` | Yes | InfluxDB organization |
+| `INFLUXDB_BUCKET` | Yes | InfluxDB bucket name |
+| `REDIS_URL` | No | Redis URL (default: `localhost:6379`) |
+
+### Flags
+
+```bash
+--influxdb_url       InfluxDB URL (default: http://localhost:8086)
+--influxdb_token     InfluxDB authentication token
+--influxdb_org       InfluxDB organization
+--influxdb_bucket    InfluxDB bucket name
+--redis_host         Redis host (default: localhost)
+--redis_port         Redis port (default: 6379)
+--mcp_transport      Transport type: stdio or sse (default: stdio)
+--mcp_port           SSE server port (default: 8080)
+```
+
+## Running
+
+### With Bazel
+
+```bash
+bazel run //services/market_mcp:app -- \
+  --influxdb_token=$INFLUXDB_TOKEN \
+  --influxdb_org=$INFLUXDB_ORG \
+  --influxdb_bucket=$INFLUXDB_BUCKET
+```
+
+### With Docker
+
+```bash
+docker build -t market-mcp services/market_mcp/
+docker run -e INFLUXDB_TOKEN=$INFLUXDB_TOKEN \
+           -e INFLUXDB_ORG=$INFLUXDB_ORG \
+           -e INFLUXDB_BUCKET=$INFLUXDB_BUCKET \
+           market-mcp
+```
+
+## Testing
+
+```bash
+bazel test //services/market_mcp:server_test
+bazel test //services/market_mcp:influxdb_client_test
+bazel test //services/market_mcp:redis_client_test
+```
+
+## Architecture
+
+- **InfluxDB**: Stores time-series candle data (measurement: `candles`, tag: `currency_pair`, fields: open/high/low/close/volume)
+- **Redis**: Stores active symbol list under `top_cryptocurrencies` key (JSON array of tiingo-format symbols)
+- **MCP Protocol**: Exposes tools via stdio or SSE transport

--- a/services/market_mcp/influxdb_client_test.py
+++ b/services/market_mcp/influxdb_client_test.py
@@ -1,0 +1,236 @@
+"""
+Tests for the InfluxDB market client with mocked InfluxDB.
+"""
+
+import datetime
+import pytest
+from unittest.mock import MagicMock, patch
+
+from services.market_mcp.influxdb_client import InfluxDBMarketClient
+
+
+class TestInfluxDBMarketClient:
+    """Test cases for InfluxDBMarketClient."""
+
+    @pytest.fixture
+    def client(self):
+        """Create an InfluxDBMarketClient with a mocked connection."""
+        c = InfluxDBMarketClient(
+            url="http://localhost:8086",
+            token="test-token",
+            org="test-org",
+            bucket="test-bucket",
+        )
+        c.client = MagicMock()
+        return c
+
+    def _make_record(self, values):
+        """Create a mock record with given values."""
+        record = MagicMock()
+        record.values = values
+        return record
+
+    def _make_table(self, records):
+        """Create a mock table with records."""
+        table = MagicMock()
+        table.records = [self._make_record(r) for r in records]
+        return table
+
+    def _mock_query(self, client, tables_data):
+        """Set up the query_api mock to return tables."""
+        tables = [self._make_table(records) for records in tables_data]
+        client.client.query_api.return_value.query.return_value = tables
+
+    def test_connect_success(self):
+        """Test successful connection."""
+        with patch("services.market_mcp.influxdb_client.InfluxDBClient") as mock_cls:
+            mock_instance = MagicMock()
+            mock_instance.ping.return_value = True
+            mock_cls.return_value = mock_instance
+
+            c = InfluxDBMarketClient(
+                url="http://localhost:8086",
+                token="tok",
+                org="org",
+                bucket="bucket",
+            )
+            c.connect()
+            assert c.client is mock_instance
+
+    def test_connect_failure(self):
+        """Test connection failure raises."""
+        with patch("services.market_mcp.influxdb_client.InfluxDBClient") as mock_cls:
+            mock_instance = MagicMock()
+            mock_instance.ping.return_value = False
+            mock_cls.return_value = mock_instance
+
+            c = InfluxDBMarketClient(
+                url="http://localhost:8086",
+                token="tok",
+                org="org",
+                bucket="bucket",
+            )
+            with pytest.raises(ConnectionError):
+                c.connect()
+
+    def test_query_without_connection(self):
+        """Test querying without connecting raises RuntimeError."""
+        c = InfluxDBMarketClient(
+            url="http://localhost:8086",
+            token="tok",
+            org="org",
+            bucket="bucket",
+        )
+        with pytest.raises(RuntimeError, match="not established"):
+            c._query("from(bucket: \"test\")")
+
+    def test_get_candles(self, client):
+        """Test get_candles returns formatted OHLCV data."""
+        ts = datetime.datetime(2026, 3, 8, 12, 0, 0)
+        self._mock_query(client, [[
+            {
+                "_time": ts,
+                "open": 50000.0,
+                "high": 50100.0,
+                "low": 49900.0,
+                "close": 50050.0,
+                "volume": 1.5,
+            },
+            {
+                "_time": ts.replace(minute=1),
+                "open": 50050.0,
+                "high": 50200.0,
+                "low": 50000.0,
+                "close": 50150.0,
+                "volume": 2.0,
+            },
+        ]])
+
+        result = client.get_candles("BTC/USD", timeframe="1m", limit=100)
+
+        assert len(result) == 2
+        assert result[0]["open"] == 50000.0
+        assert result[0]["close"] == 50050.0
+        assert result[0]["volume"] == 1.5
+        assert "timestamp" in result[0]
+        assert result[1]["close"] == 50150.0
+
+    def test_get_candles_empty(self, client):
+        """Test get_candles with no data."""
+        self._mock_query(client, [[]])
+        result = client.get_candles("UNKNOWN/USD")
+        assert result == []
+
+    def test_get_candles_with_time_range(self, client):
+        """Test get_candles with start and end parameters."""
+        self._mock_query(client, [[]])
+        client.get_candles("BTC/USD", start="-24h", end="-1h")
+        query_call = client.client.query_api.return_value.query
+        query_call.assert_called_once()
+        flux = query_call.call_args[0][0]
+        assert "-24h" in flux
+        assert "-1h" in flux
+
+    def test_get_latest_price(self, client):
+        """Test get_latest_price returns correct structure."""
+        ts = datetime.datetime(2026, 3, 8, 12, 0, 0)
+        # First call: latest candle
+        # Second call: 24h records
+        call_count = [0]
+        original_query = client.client.query_api.return_value.query
+
+        def side_effect(flux, org=None):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                # Latest candle
+                return [self._make_table([{
+                    "_time": ts,
+                    "close": 50050.0,
+                    "volume": 1.5,
+                }])]
+            else:
+                # 24h records
+                return [self._make_table([
+                    {"_time": ts.replace(hour=0), "close": 49000.0, "volume": 10.0},
+                    {"_time": ts, "close": 50050.0, "volume": 1.5},
+                ])]
+
+        client.client.query_api.return_value.query.side_effect = side_effect
+
+        result = client.get_latest_price("BTC/USD")
+
+        assert result["symbol"] == "BTC/USD"
+        assert result["price"] == 50050.0
+        assert result["volume_24h"] == 11.5
+        assert result["change_24h"] is not None
+        assert result["timestamp"] is not None
+
+    def test_get_latest_price_no_data(self, client):
+        """Test get_latest_price with no candle data."""
+        self._mock_query(client, [[]])
+        result = client.get_latest_price("UNKNOWN/USD")
+        assert result["symbol"] == "UNKNOWN/USD"
+        assert result["price"] is None
+
+    def test_get_volatility(self, client):
+        """Test get_volatility computes stddev and ATR."""
+        records = [
+            {"_time": "t0", "open": 100, "high": 105, "low": 95, "close": 100},
+            {"_time": "t1", "open": 100, "high": 110, "low": 90, "close": 105},
+            {"_time": "t2", "open": 105, "high": 115, "low": 100, "close": 110},
+            {"_time": "t3", "open": 110, "high": 112, "low": 98, "close": 102},
+        ]
+        self._mock_query(client, [records])
+
+        result = client.get_volatility("BTC/USD", period_minutes=60)
+
+        assert result["symbol"] == "BTC/USD"
+        assert result["period"] == 60
+        assert result["volatility"] is not None
+        assert result["volatility"] > 0
+        assert result["atr"] is not None
+        assert result["atr"] > 0
+
+    def test_get_volatility_insufficient_data(self, client):
+        """Test get_volatility with too few records."""
+        self._mock_query(client, [[{"_time": "t0", "close": 100}]])
+        result = client.get_volatility("BTC/USD")
+        assert result["volatility"] is None
+        assert result["atr"] is None
+
+    def test_get_market_summary(self, client):
+        """Test get_market_summary returns all expected fields."""
+        records = []
+        for i in range(100):
+            records.append({
+                "_time": f"t{i}",
+                "open": 50000 + i,
+                "high": 50100 + i,
+                "low": 49900 + i,
+                "close": 50000 + i * 10,
+                "volume": 1.0 + i * 0.1,
+            })
+        self._mock_query(client, [records])
+
+        result = client.get_market_summary("BTC/USD")
+
+        assert result["symbol"] == "BTC/USD"
+        assert result["price"] is not None
+        assert result["high_24h"] is not None
+        assert result["low_24h"] is not None
+        assert result["volume_24h"] is not None
+        assert result["vwap"] is not None
+        assert result["change_24h"] is not None
+        assert result["volatility"] is not None
+
+    def test_get_market_summary_no_data(self, client):
+        """Test get_market_summary with no data."""
+        self._mock_query(client, [[]])
+        result = client.get_market_summary("UNKNOWN/USD")
+        assert result["price"] is None
+        assert result["vwap"] is None
+
+    def test_close(self, client):
+        """Test close calls client.close()."""
+        client.close()
+        client.client.close.assert_called_once()

--- a/services/market_mcp/influxdb_client_test.py
+++ b/services/market_mcp/influxdb_client_test.py
@@ -3,8 +3,9 @@ Tests for the InfluxDB market client with mocked InfluxDB.
 """
 
 import datetime
-import pytest
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from services.market_mcp.influxdb_client import InfluxDBMarketClient
 

--- a/services/market_mcp/influxdb_client_test.py
+++ b/services/market_mcp/influxdb_client_test.py
@@ -82,29 +82,34 @@ class TestInfluxDBMarketClient:
             bucket="bucket",
         )
         with pytest.raises(RuntimeError, match="not established"):
-            c._query("from(bucket: \"test\")")
+            c._query('from(bucket: "test")')
 
     def test_get_candles(self, client):
         """Test get_candles returns formatted OHLCV data."""
         ts = datetime.datetime(2026, 3, 8, 12, 0, 0)
-        self._mock_query(client, [[
-            {
-                "_time": ts,
-                "open": 50000.0,
-                "high": 50100.0,
-                "low": 49900.0,
-                "close": 50050.0,
-                "volume": 1.5,
-            },
-            {
-                "_time": ts.replace(minute=1),
-                "open": 50050.0,
-                "high": 50200.0,
-                "low": 50000.0,
-                "close": 50150.0,
-                "volume": 2.0,
-            },
-        ]])
+        self._mock_query(
+            client,
+            [
+                [
+                    {
+                        "_time": ts,
+                        "open": 50000.0,
+                        "high": 50100.0,
+                        "low": 49900.0,
+                        "close": 50050.0,
+                        "volume": 1.5,
+                    },
+                    {
+                        "_time": ts.replace(minute=1),
+                        "open": 50050.0,
+                        "high": 50200.0,
+                        "low": 50000.0,
+                        "close": 50150.0,
+                        "volume": 2.0,
+                    },
+                ]
+            ],
+        )
 
         result = client.get_candles("BTC/USD", timeframe="1m", limit=100)
 
@@ -137,23 +142,36 @@ class TestInfluxDBMarketClient:
         # First call: latest candle
         # Second call: 24h records
         call_count = [0]
-        original_query = client.client.query_api.return_value.query
 
         def side_effect(flux, org=None):
             call_count[0] += 1
             if call_count[0] == 1:
                 # Latest candle
-                return [self._make_table([{
-                    "_time": ts,
-                    "close": 50050.0,
-                    "volume": 1.5,
-                }])]
+                return [
+                    self._make_table(
+                        [
+                            {
+                                "_time": ts,
+                                "close": 50050.0,
+                                "volume": 1.5,
+                            }
+                        ]
+                    )
+                ]
             else:
                 # 24h records
-                return [self._make_table([
-                    {"_time": ts.replace(hour=0), "close": 49000.0, "volume": 10.0},
-                    {"_time": ts, "close": 50050.0, "volume": 1.5},
-                ])]
+                return [
+                    self._make_table(
+                        [
+                            {
+                                "_time": ts.replace(hour=0),
+                                "close": 49000.0,
+                                "volume": 10.0,
+                            },
+                            {"_time": ts, "close": 50050.0, "volume": 1.5},
+                        ]
+                    )
+                ]
 
         client.client.query_api.return_value.query.side_effect = side_effect
 
@@ -202,14 +220,16 @@ class TestInfluxDBMarketClient:
         """Test get_market_summary returns all expected fields."""
         records = []
         for i in range(100):
-            records.append({
-                "_time": f"t{i}",
-                "open": 50000 + i,
-                "high": 50100 + i,
-                "low": 49900 + i,
-                "close": 50000 + i * 10,
-                "volume": 1.0 + i * 0.1,
-            })
+            records.append(
+                {
+                    "_time": f"t{i}",
+                    "open": 50000 + i,
+                    "high": 50100 + i,
+                    "low": 49900 + i,
+                    "close": 50000 + i * 10,
+                    "volume": 1.0 + i * 0.1,
+                }
+            )
         self._mock_query(client, [records])
 
         result = client.get_market_summary("BTC/USD")

--- a/services/market_mcp/pyproject.toml
+++ b/services/market_mcp/pyproject.toml
@@ -1,0 +1,29 @@
+[project]
+name = "market-mcp"
+version = "0.1.0"
+description = "MCP server for market data — candles, prices, volatility, and market summaries from InfluxDB and Redis"
+requires-python = ">=3.11"
+dependencies = [
+    "mcp>=1.0.0",
+    "influxdb-client>=1.36.0",
+    "redis>=5.0.0",
+    "absl-py>=2.0.0",
+    "uvicorn>=0.24.0",
+    "starlette>=0.27.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "pytest-asyncio>=0.21",
+    "black>=23.0",
+    "mypy>=1.0",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+python_files = ["*_test.py"]
+
+[tool.black]
+line-length = 88
+target-version = ["py311"]

--- a/services/market_mcp/redis_client_test.py
+++ b/services/market_mcp/redis_client_test.py
@@ -1,0 +1,90 @@
+"""
+Tests for the Redis market client with mocked Redis.
+"""
+
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+
+from services.market_mcp.redis_client import RedisMarketClient
+
+
+class TestRedisMarketClient:
+    """Test cases for RedisMarketClient."""
+
+    @pytest.fixture
+    def client(self):
+        """Create a RedisMarketClient with a mocked connection."""
+        c = RedisMarketClient(host="localhost", port=6379)
+        c.client = MagicMock()
+        return c
+
+    def test_connect_success(self):
+        """Test successful Redis connection."""
+        with patch("services.market_mcp.redis_client.redis.Redis") as mock_cls:
+            mock_instance = MagicMock()
+            mock_cls.return_value = mock_instance
+
+            c = RedisMarketClient(host="localhost", port=6379)
+            c.connect()
+
+            mock_cls.assert_called_once_with(
+                host="localhost", port=6379, decode_responses=True
+            )
+            mock_instance.ping.assert_called_once()
+
+    def test_get_symbols(self, client):
+        """Test get_symbols parses tiingo-format symbols."""
+        client.client.get.return_value = json.dumps(["btcusd", "ethusd", "solusd"])
+
+        result = client.get_symbols()
+
+        assert len(result) == 3
+        assert result[0]["id"] == "btcusd"
+        assert result[0]["base"] == "BTC"
+        assert result[0]["quote"] == "USD"
+        assert result[0]["asset_class"] == "crypto"
+        assert result[1]["base"] == "ETH"
+        assert result[2]["base"] == "SOL"
+
+    def test_get_symbols_empty(self, client):
+        """Test get_symbols when Redis key is missing."""
+        client.client.get.return_value = None
+        result = client.get_symbols()
+        assert result == []
+
+    def test_get_symbols_non_usd_pair(self, client):
+        """Test get_symbols with non-USD pair falls back to full string as base."""
+        client.client.get.return_value = json.dumps(["btceur"])
+        result = client.get_symbols()
+        assert result[0]["base"] == "BTCEUR"
+        assert result[0]["quote"] == "USD"
+
+    def test_get_symbols_custom_key(self, client):
+        """Test get_symbols with a custom Redis key."""
+        client.client.get.return_value = json.dumps(["btcusd"])
+        result = client.get_symbols(key="custom_key")
+        client.client.get.assert_called_once_with("custom_key")
+        assert len(result) == 1
+
+    def test_get_symbols_default_key(self, client):
+        """Test get_symbols uses top_cryptocurrencies key by default."""
+        client.client.get.return_value = json.dumps([])
+        client.get_symbols()
+        client.client.get.assert_called_once_with("top_cryptocurrencies")
+
+    def test_get_symbols_without_connection(self):
+        """Test get_symbols without connecting raises RuntimeError."""
+        c = RedisMarketClient(host="localhost", port=6379)
+        with pytest.raises(RuntimeError, match="not established"):
+            c.get_symbols()
+
+    def test_close(self, client):
+        """Test close calls client.close()."""
+        client.close()
+        client.client.close.assert_called_once()
+
+    def test_close_no_connection(self):
+        """Test close without connection doesn't raise."""
+        c = RedisMarketClient(host="localhost", port=6379)
+        c.close()  # Should not raise

--- a/services/market_mcp/redis_client_test.py
+++ b/services/market_mcp/redis_client_test.py
@@ -3,8 +3,9 @@ Tests for the Redis market client with mocked Redis.
 """
 
 import json
-import pytest
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from services.market_mcp.redis_client import RedisMarketClient
 


### PR DESCRIPTION
## Summary
- Adds `pyproject.toml` with project metadata and dependencies for the market-mcp MCP server
- Adds `Dockerfile` for containerized deployment
- Adds `README.md` documenting all 5 MCP tools, configuration, and usage
- Adds `influxdb_client_test.py` with 11 unit tests covering all InfluxDB client methods (mocked)
- Adds `redis_client_test.py` with 9 unit tests covering all Redis client methods (mocked)
- Updates `BUILD` with new `influxdb_client_test` and `redis_client_test` Bazel targets

## Test plan
- [x] `bazel test //services/market_mcp:server_test` — PASSED
- [x] `bazel test //services/market_mcp:influxdb_client_test` — PASSED
- [x] `bazel test //services/market_mcp:redis_client_test` — PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)