### PR TITLE
Add deterministic paper execution adapter core

### DIFF
--- a/services/paper_trading/BUILD
+++ b/services/paper_trading/BUILD
@@ -25,6 +25,11 @@ py_library(
 )
 
 py_library(
+    name = "execution_adapter_lib",
+    srcs = ["execution_adapter.py"],
+)
+
+py_library(
     name = "service_lib",
     srcs = ["service.py"],
     deps = [
@@ -67,6 +72,14 @@ py_test(
         ":postgres_client_lib",
         "//third_party/python:pytest",
         "//third_party/python:pytest_asyncio",
+    ],
+)
+
+py_test(
+    name = "execution_adapter_test",
+    srcs = ["execution_adapter_test.py"],
+    deps = [
+        ":execution_adapter_lib",
     ],
 )
 

--- a/services/paper_trading/execution_adapter.py
+++ b/services/paper_trading/execution_adapter.py
@@ -7,9 +7,8 @@ credentials, databases, or live execution APIs.
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from decimal import Decimal, ROUND_HALF_UP
+from decimal import ROUND_HALF_UP, Decimal
 from typing import Literal, Optional
-
 
 AssetClass = Literal["crypto", "equities", "forex"]
 OrderSide = Literal["buy", "sell"]

--- a/services/paper_trading/execution_adapter.py
+++ b/services/paper_trading/execution_adapter.py
@@ -93,7 +93,9 @@ class DeterministicPaperExecutionAdapter:
             )
 
         mid = (snapshot.best_bid + snapshot.best_ask) / Decimal("2")
-        reference_price = snapshot.best_ask if intent.side == "buy" else snapshot.best_bid
+        reference_price = (
+            snapshot.best_ask if intent.side == "buy" else snapshot.best_bid
+        )
         slippage_multiplier = snapshot.slippage_bps / Decimal("10000")
         price_delta = reference_price * slippage_multiplier
         fill_price = (
@@ -135,10 +137,15 @@ class DeterministicPaperExecutionAdapter:
             return "invalid_snapshot_price"
         if snapshot.best_bid > snapshot.best_ask:
             return "crossed_snapshot"
-        if _age_seconds(snapshot.captured_at_utc, now_utc) > self._max_snapshot_age_seconds:
+        if (
+            _age_seconds(snapshot.captured_at_utc, now_utc)
+            > self._max_snapshot_age_seconds
+        ):
             return "stale_snapshot"
 
-        reference_price = snapshot.best_ask if intent.side == "buy" else snapshot.best_bid
+        reference_price = (
+            snapshot.best_ask if intent.side == "buy" else snapshot.best_bid
+        )
         notional = reference_price * intent.quantity
         if (
             intent.max_notional_usd is not None

--- a/services/paper_trading/execution_adapter.py
+++ b/services/paper_trading/execution_adapter.py
@@ -1,0 +1,161 @@
+"""Deterministic paper execution primitives.
+
+This module implements the first code boundary from the paper execution
+adapter spec. It is intentionally pure: it does not talk to brokers,
+credentials, databases, or live execution APIs.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Literal, Optional
+
+
+AssetClass = Literal["crypto", "equities", "forex"]
+OrderSide = Literal["buy", "sell"]
+OrderType = Literal["market"]
+
+
+@dataclass(frozen=True)
+class TradeIntent:
+    """Normalized request from a strategy or agent."""
+
+    intent_id: str
+    strategy_id: str
+    instrument: str
+    asset_class: AssetClass
+    venue: str
+    side: OrderSide
+    order_type: OrderType
+    quantity: Decimal
+    max_notional_usd: Optional[Decimal]
+    signal_timestamp_utc: datetime
+    rationale_ref: str
+
+
+@dataclass(frozen=True)
+class MarketSnapshot:
+    """Reproducible market state used for paper simulation."""
+
+    snapshot_id: str
+    instrument: str
+    venue: str
+    best_bid: Decimal
+    best_ask: Decimal
+    captured_at_utc: datetime
+    data_source: str
+    fee_bps: Decimal = Decimal("10")
+    slippage_bps: Decimal = Decimal("5")
+    latency_ms: int = 250
+
+
+@dataclass(frozen=True)
+class PaperFill:
+    """Simulated execution result for one intent."""
+
+    intent_id: str
+    status: Literal["filled", "rejected"]
+    fill_price: Optional[Decimal]
+    fill_quantity: Decimal
+    fee_quote: Decimal
+    slippage_vs_mid: Optional[Decimal]
+    latency_ms: int
+    snapshot_id: str
+    reject_reason: Optional[str] = None
+
+
+class DeterministicPaperExecutionAdapter:
+    """Simulates market fills against explicit snapshots."""
+
+    def __init__(self, max_snapshot_age_seconds: int = 60):
+        self._max_snapshot_age_seconds = max_snapshot_age_seconds
+
+    def simulate_fill(
+        self,
+        intent: TradeIntent,
+        snapshot: MarketSnapshot,
+        now_utc: datetime,
+    ) -> PaperFill:
+        """Simulate a fill or deterministic rejection for an intent."""
+
+        reject_reason = self._reject_reason(intent, snapshot, now_utc)
+        if reject_reason is not None:
+            return PaperFill(
+                intent_id=intent.intent_id,
+                status="rejected",
+                fill_price=None,
+                fill_quantity=Decimal("0"),
+                fee_quote=Decimal("0"),
+                slippage_vs_mid=None,
+                latency_ms=snapshot.latency_ms,
+                snapshot_id=snapshot.snapshot_id,
+                reject_reason=reject_reason,
+            )
+
+        mid = (snapshot.best_bid + snapshot.best_ask) / Decimal("2")
+        reference_price = snapshot.best_ask if intent.side == "buy" else snapshot.best_bid
+        slippage_multiplier = snapshot.slippage_bps / Decimal("10000")
+        price_delta = reference_price * slippage_multiplier
+        fill_price = (
+            reference_price + price_delta
+            if intent.side == "buy"
+            else reference_price - price_delta
+        )
+        fill_price = _quantize_usd(fill_price)
+        fee_quote = _quantize_usd(
+            fill_price * intent.quantity * snapshot.fee_bps / Decimal("10000")
+        )
+
+        return PaperFill(
+            intent_id=intent.intent_id,
+            status="filled",
+            fill_price=fill_price,
+            fill_quantity=intent.quantity,
+            fee_quote=fee_quote,
+            slippage_vs_mid=_quantize_usd(abs(fill_price - mid)),
+            latency_ms=snapshot.latency_ms,
+            snapshot_id=snapshot.snapshot_id,
+        )
+
+    def _reject_reason(
+        self,
+        intent: TradeIntent,
+        snapshot: MarketSnapshot,
+        now_utc: datetime,
+    ) -> Optional[str]:
+        if intent.order_type != "market":
+            return "unsupported_order_type"
+        if intent.quantity <= 0:
+            return "invalid_quantity"
+        if intent.instrument != snapshot.instrument:
+            return "instrument_mismatch"
+        if intent.venue != snapshot.venue:
+            return "venue_mismatch"
+        if snapshot.best_bid <= 0 or snapshot.best_ask <= 0:
+            return "invalid_snapshot_price"
+        if snapshot.best_bid > snapshot.best_ask:
+            return "crossed_snapshot"
+        if _age_seconds(snapshot.captured_at_utc, now_utc) > self._max_snapshot_age_seconds:
+            return "stale_snapshot"
+
+        reference_price = snapshot.best_ask if intent.side == "buy" else snapshot.best_bid
+        notional = reference_price * intent.quantity
+        if (
+            intent.max_notional_usd is not None
+            and intent.side == "buy"
+            and notional > intent.max_notional_usd
+        ):
+            return "max_notional_exceeded"
+        return None
+
+
+def _age_seconds(earlier: datetime, later: datetime) -> float:
+    if earlier.tzinfo is None:
+        earlier = earlier.replace(tzinfo=timezone.utc)
+    if later.tzinfo is None:
+        later = later.replace(tzinfo=timezone.utc)
+    return (later - earlier).total_seconds()
+
+
+def _quantize_usd(value: Decimal) -> Decimal:
+    return value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)

--- a/services/paper_trading/execution_adapter_test.py
+++ b/services/paper_trading/execution_adapter_test.py
@@ -10,7 +10,6 @@ from services.paper_trading.execution_adapter import (
     TradeIntent,
 )
 
-
 NOW = datetime(2026, 6, 10, 0, 0, tzinfo=timezone.utc)
 
 

--- a/services/paper_trading/execution_adapter_test.py
+++ b/services/paper_trading/execution_adapter_test.py
@@ -1,0 +1,128 @@
+"""Tests for deterministic paper execution primitives."""
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+import unittest
+
+from services.paper_trading.execution_adapter import (
+    DeterministicPaperExecutionAdapter,
+    MarketSnapshot,
+    TradeIntent,
+)
+
+
+NOW = datetime(2026, 6, 10, 0, 0, tzinfo=timezone.utc)
+
+
+def make_intent(**overrides):
+    values = {
+        "intent_id": "intent-1",
+        "strategy_id": "strategy-a",
+        "instrument": "BTC-USD",
+        "asset_class": "crypto",
+        "venue": "coinbase",
+        "side": "buy",
+        "order_type": "market",
+        "quantity": Decimal("0.01"),
+        "max_notional_usd": Decimal("1000"),
+        "signal_timestamp_utc": NOW,
+        "rationale_ref": "decision-1",
+    }
+    values.update(overrides)
+    return TradeIntent(**values)
+
+
+def make_snapshot(**overrides):
+    values = {
+        "snapshot_id": "snapshot-1",
+        "instrument": "BTC-USD",
+        "venue": "coinbase",
+        "best_bid": Decimal("49990.00"),
+        "best_ask": Decimal("50010.00"),
+        "captured_at_utc": NOW - timedelta(seconds=5),
+        "data_source": "stored-book",
+        "fee_bps": Decimal("10"),
+        "slippage_bps": Decimal("5"),
+        "latency_ms": 250,
+    }
+    values.update(overrides)
+    return MarketSnapshot(**values)
+
+
+class DeterministicPaperExecutionAdapterTest(unittest.TestCase):
+    def test_buy_fill_uses_ask_plus_slippage_and_fee(self):
+        adapter = DeterministicPaperExecutionAdapter()
+
+        fill = adapter.simulate_fill(make_intent(), make_snapshot(), NOW)
+
+        self.assertEqual(fill.status, "filled")
+        self.assertEqual(fill.fill_price, Decimal("50035.01"))
+        self.assertEqual(fill.fill_quantity, Decimal("0.01"))
+        self.assertEqual(fill.fee_quote, Decimal("0.50"))
+        self.assertEqual(fill.slippage_vs_mid, Decimal("35.01"))
+        self.assertEqual(fill.snapshot_id, "snapshot-1")
+        self.assertIsNone(fill.reject_reason)
+
+    def test_sell_fill_uses_bid_minus_slippage_and_fee(self):
+        adapter = DeterministicPaperExecutionAdapter()
+
+        fill = adapter.simulate_fill(
+            make_intent(side="sell", max_notional_usd=None),
+            make_snapshot(),
+            NOW,
+        )
+
+        self.assertEqual(fill.status, "filled")
+        self.assertEqual(fill.fill_price, Decimal("49965.01"))
+        self.assertEqual(fill.fee_quote, Decimal("0.50"))
+        self.assertEqual(fill.slippage_vs_mid, Decimal("34.99"))
+
+    def test_replay_is_deterministic_for_same_intent_snapshot_and_clock(self):
+        adapter = DeterministicPaperExecutionAdapter()
+        intent = make_intent()
+        snapshot = make_snapshot()
+
+        first = adapter.simulate_fill(intent, snapshot, NOW)
+        second = adapter.simulate_fill(intent, snapshot, NOW)
+
+        self.assertEqual(first, second)
+
+    def test_rejects_stale_snapshot_without_fill_price(self):
+        adapter = DeterministicPaperExecutionAdapter(max_snapshot_age_seconds=30)
+
+        fill = adapter.simulate_fill(
+            make_intent(),
+            make_snapshot(captured_at_utc=NOW - timedelta(seconds=31)),
+            NOW,
+        )
+
+        self.assertEqual(fill.status, "rejected")
+        self.assertEqual(fill.reject_reason, "stale_snapshot")
+        self.assertIsNone(fill.fill_price)
+        self.assertEqual(fill.fill_quantity, Decimal("0"))
+
+    def test_rejects_buy_that_exceeds_max_notional(self):
+        adapter = DeterministicPaperExecutionAdapter()
+
+        fill = adapter.simulate_fill(
+            make_intent(quantity=Decimal("1"), max_notional_usd=Decimal("100")),
+            make_snapshot(),
+            NOW,
+        )
+
+        self.assertEqual(fill.status, "rejected")
+        self.assertEqual(fill.reject_reason, "max_notional_exceeded")
+
+    def test_rejects_mismatched_instrument_before_simulating(self):
+        adapter = DeterministicPaperExecutionAdapter()
+
+        fill = adapter.simulate_fill(
+            make_intent(instrument="ETH-USD"), make_snapshot(), NOW
+        )
+
+        self.assertEqual(fill.status, "rejected")
+        self.assertEqual(fill.reject_reason, "instrument_mismatch")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/services/paper_trading/execution_adapter_test.py
+++ b/services/paper_trading/execution_adapter_test.py
@@ -1,8 +1,8 @@
 """Tests for deterministic paper execution primitives."""
 
+import unittest
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
-import unittest
 
 from services.paper_trading.execution_adapter import (
     DeterministicPaperExecutionAdapter,


### PR DESCRIPTION
## Summary
- add pure paper execution adapter primitives for normalized trade intents, market snapshots, and paper fills
- model deterministic market fills with spread, slippage, fees, latency, stale-data rejects, and max-notional rejects
- add focused self-running unittest coverage and Bazel targets for the new adapter boundary

## Validation
- python3 -m unittest services.paper_trading.execution_adapter_test
- python3 -m py_compile services/paper_trading/execution_adapter.py services/paper_trading/execution_adapter_test.py
- git diff --check

Bazel is not installed in this shell; CI should run the Bazel target.